### PR TITLE
More on re-brand fixes and improvements #508

### DIFF
--- a/html/ui/css/ui/sidebar.css
+++ b/html/ui/css/ui/sidebar.css
@@ -193,16 +193,3 @@
   border-bottom-left-radius: 0;
 }
 
-.open>.sbdropdown-menu {
-  display: block;
-}
-
-.sbdropdown-menu {
-  position: static;
-  background-color: #2c3b41;
-  display: none;
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  padding-left: 5px;
-}

--- a/html/ui/html/sidebar.html
+++ b/html/ui/html/sidebar.html
@@ -3,12 +3,15 @@
     <div class="pull-left info">
       <div class="pull-left info">
         <div style="margin-bottom:5px;margin-top:5px;"><a href="#" id="account_name" data-toggle="modal" data-target="#account_info_modal" data-i18n="no_name_set">No Name Set</a></div>
-            <div role="presentation"><a class="copy_link" role="menuitem" tabindex="-1" href="#" data-type="account_rs" data-i18n="copy_account_rs">Copy Your Account Address</a></div>
-            <div role="presentation"><a class="copy_link" role="menuitem" tabindex="-1" href="#" data-type="account_id" data-i18n="copy_account_id">Copy Numeric Account ID</a></div>
-            <!-- disabled
+        <div id="account_id_dropdown" class="dropdown">
+          <span id="account_id" class="dropdown-toggle" data-toggle="dropdown" data-type="account_id"></span>
+          <ul class="sbdropdown-menu" role="menu" aria-labelledby="dropdownMenu1">
+            <li role="presentation"><a class="copy_link" role="menuitem" tabindex="-1" href="#" data-type="account_rs" data-i18n="copy_account_id">Copy Account ID</a></li>
+            <li role="presentation"><a class="copy_link" role="menuitem" tabindex="-1" href="#" data-type="account_id">Copy Numeric Account     ID</a></li>
             <li role="presentation"><a class="copy_link" role="menuitem" tabindex="-1" href="#" data-type="message_link" data-i18n="copy_send_message_link">Copy "Send Message" Link</a></li>
-            <li role="presentation"><a class="copy_link" role="menuitem" tabindex="-1" href="#" data-type="send_link" data-i18n="copy_send_burst_link">Copy "Send SIGNA" Link</a></li>
-            -->
+            <li role="presentation"><a class="copy_link" role="menuitem" tabindex="-1" href="#" data-type="send_link" data-i18n="copy_send_burst_link">Copy "Send BURST" Link</a></li>
+          </ul>
+        </div>
       </div>
     </div>
   </div>

--- a/html/ui/html/sidebar.html
+++ b/html/ui/html/sidebar.html
@@ -3,11 +3,10 @@
     <div class="pull-left info">
       <div class="pull-left info">
         <div style="margin-bottom:5px;margin-top:5px;"><a href="#" id="account_name" data-toggle="modal" data-target="#account_info_modal" data-i18n="no_name_set">No Name Set</a></div>
-        <div id="account_id_dropdown" class="dropdown">
-          <span id="account_id" class="dropdown-toggle" data-toggle="dropdown" data-type="account_id"></span>
-          <ul class="sbdropdown-menu" role="menu" aria-labelledby="dropdownMenu1">
-            <li role="presentation"><a class="copy_link" role="menuitem" tabindex="-1" href="#" data-type="account_rs" data-i18n="copy_account_id">Copy Account ID</a></li>
-            <li role="presentation"><a class="copy_link" role="menuitem" tabindex="-1" href="#" data-type="account_id">Copy Numeric Account     ID</a></li>
+        <a id="account_id" class="copy_link" role="menuitem" tabindex="-1" href="#" data-type="account_rs" title="Copy"></a>
+        <div id="account_id_sidebar">
+          <ul class="nav nav-pills nav-stacked" role="menu">
+            <li role="presentation"><a class="copy_link" role="menuitem" tabindex="-1" href="#" data-type="account_id"  data-i18n="copy_account_id">Copy Numeric Account ID</a></li>
             <li role="presentation"><a class="copy_link" role="menuitem" tabindex="-1" href="#" data-type="message_link" data-i18n="copy_send_message_link">Copy "Send Message" Link</a></li>
             <li role="presentation"><a class="copy_link" role="menuitem" tabindex="-1" href="#" data-type="send_link" data-i18n="copy_send_burst_link">Copy "Send BURST" Link</a></li>
           </ul>

--- a/html/ui/html/sidebar.html
+++ b/html/ui/html/sidebar.html
@@ -8,7 +8,7 @@
           <ul class="nav nav-pills nav-stacked" role="menu">
             <li role="presentation"><a class="copy_link" role="menuitem" tabindex="-1" href="#" data-type="account_id"  data-i18n="copy_account_id">Copy Numeric Account ID</a></li>
             <li role="presentation"><a class="copy_link" role="menuitem" tabindex="-1" href="#" data-type="message_link" data-i18n="copy_send_message_link">Copy "Send Message" Link</a></li>
-            <li role="presentation"><a class="copy_link" role="menuitem" tabindex="-1" href="#" data-type="send_link" data-i18n="copy_send_burst_link">Copy "Send BURST" Link</a></li>
+            <li role="presentation"><a class="copy_link" role="menuitem" tabindex="-1" href="#" data-type="send_link" data-i18n="copy_send_burst_link">Copy "Send SIGNA" Link</a></li>
           </ul>
         </div>
       </div>

--- a/html/ui/js/brs.login.js
+++ b/html/ui/js/brs.login.js
@@ -216,7 +216,7 @@ var BRS = (function(BRS, $, undefined) {
                         $(".hide_secret_phrase").show();
                     }
 
-                    $("#account_id").html(String(BRS.accountRS).escapeHTML()).css("font-size", "12px");
+                    $("#account_id").html(String(BRS.accountRS).escapeHTML());
 
                     var passwordNotice = "";
 

--- a/html/ui/js/brs.util.js
+++ b/html/ui/js/brs.util.js
@@ -805,9 +805,7 @@ var BRS = (function(BRS, $, undefined) {
     };
 
     BRS.setupClipboardFunctionality = function() {
-        var elements = "#asset_id_dropdown .dropdown-menu a, #account_id_dropdown .sbdropdown-menu a";
-
-        var $el = $(elements);
+        var $el = $("#asset_id_dropdown .dropdown-menu a, #account_id, #account_id_sidebar li a");
 
         if (BRS.inApp) {
             $el.on("click", function() {
@@ -847,8 +845,8 @@ var BRS = (function(BRS, $, undefined) {
             });
 
             clipboard.on('error', function(e) {
-                $("#account_id_dropdown .sbdropdown-menu, #asset_id_dropdown .dropdown-menu").remove();
-                $("#account_id_dropdown, #asset_id").data("toggle", "");
+                $("#asset_id_dropdown .dropdown-menu").remove();
+                $("#asset_id").data("toggle", "");
                 $.notify($.t("error_clipboard_copy"), {
                     type: 'danger',
                     offset: {


### PR DESCRIPTION
Account wasn't shown anymore in left sidebar of the classic wallet. Restored old code. Fixed.

**Important:**
1. There is still the wording BURST in copy_send_burst_link (locales). If you want i can fix that, too.
2. As i do not know the whole existing functionality i am not sure if the functionality for `copy_account_id` is correct. It uses the value of `account_rs` as i thought should lead to a copy of the RS address like S-59P9-XXXX-XXXX-XXXXX but if i click on the link to copy the data i get the RS address followed by another string like S-59P9-XXXX-XXXX-XXXXX-MANYCHARSANDNUMBERS

![image](https://user-images.githubusercontent.com/18901038/122825655-84f4a700-d2e2-11eb-8a78-8d1553593e7a.png)

Question about reference information in the commit: I used pull request #508 as a reference. I am not sure if this was correct. Normally i reference issue numbers. If there is something to improve here just give me feedback so i will take care of that in the future. Thanks.