### PR TITLE
fix: Version on wallet selection screen

### DIFF
--- a/html/ui/js/selector/index.js
+++ b/html/ui/js/selector/index.js
@@ -22,7 +22,9 @@ function selectedWallet(name){
 
 (async () => {
     const version = await getNodeVersion()
-    const walletName = localStorage.getItem(preferredWalletKey)
-    document.getElementById(`${walletName}-link`).click()
     document.getElementById('version').textContent = version
+    const walletName = localStorage.getItem(preferredWalletKey)
+    if(walletName){
+        document.getElementById(`${walletName}-link`).click()
+    }
 })()


### PR DESCRIPTION
Fixes an error when wallet selection was not stored. Due to exception thrown the version was not shown. This fixes it