### PR TITLE
Update Dockerfile.h2

### DIFF
--- a/Dockerfile.h2
+++ b/Dockerfile.h2
@@ -27,7 +27,7 @@ RUN apk update && apk upgrade && apk add --no-cache bash curl wget unzip
 WORKDIR /app
 COPY --from=builder /app/dist/tmp/signum-node.jar .
 COPY --from=docbuilder /app/html html
-VOLUME ["/conf", "/db"]
+VOLUME ["/conf", "/burst_db"]
 RUN ln -s /conf /app/conf
 COPY conf/brs.properties.h2 /app/conf/brs.properties
 COPY conf/brs-default.properties /app/conf/brs-default.properties

--- a/Dockerfile.h2
+++ b/Dockerfile.h2
@@ -29,6 +29,7 @@ COPY --from=builder /app/dist/tmp/signum-node.jar .
 COPY --from=docbuilder /app/html html
 VOLUME ["/conf", "/burst_db"]
 RUN ln -s /conf /app/conf
+RUN ln -s /burst_db /app/burst_db
 COPY conf/brs.properties.h2 /app/conf/brs.properties
 COPY conf/brs-default.properties /app/conf/brs-default.properties
 COPY conf/logging-default.properties /app/conf/logging-default.properties

--- a/Dockerfile.h2
+++ b/Dockerfile.h2
@@ -27,9 +27,9 @@ RUN apk update && apk upgrade && apk add --no-cache bash curl wget unzip
 WORKDIR /app
 COPY --from=builder /app/dist/tmp/signum-node.jar .
 COPY --from=docbuilder /app/html html
-VOLUME ["/conf", "/burst_db"]
+VOLUME ["/conf", "/db"]
 RUN ln -s /conf /app/conf
-RUN ln -s /burst_db /app/burst_db
+RUN ln -s /db /app/burst_db
 COPY conf/brs.properties.h2 /app/conf/brs.properties
 COPY conf/brs-default.properties /app/conf/brs-default.properties
 COPY conf/logging-default.properties /app/conf/logging-default.properties

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,5 @@ services:
       - "8125:8125"
     volumes:
       - "./conf:/conf"
+      - "./db:/db"
 


### PR DESCRIPTION
change VOLUME ["/conf", "/db"] to VOLUME ["/conf", "/burst_db"] so that the docker container folder ./burst_db will be able to connect to the host folder.
Then a new build on DockerHub needs to be run on signumnetwork/node:latest-h2