### PR TITLE
feat API getTransactionsAtBlock

### DIFF
--- a/src/brs/Blockchain.java
+++ b/src/brs/Blockchain.java
@@ -34,6 +34,8 @@ public interface Blockchain {
 
   Transaction getTransaction(long transactionId);
 
+  Collection<Transaction> getAllTransactionsAtBlock(long blockId);
+
   Transaction getTransactionByFullHash(String fullHash); // TODO add byte[] method
 
   boolean hasTransaction(long transactionId);

--- a/src/brs/BlockchainImpl.java
+++ b/src/brs/BlockchainImpl.java
@@ -206,7 +206,7 @@ public class BlockchainImpl implements Blockchain {
 
   @Override
   public Collection<Transaction> getAllTransactionsAtBlock(long blockId) {
-      return transactionDb.findBlockAllTransactions(blockId);
+      return transactionDb.findAllTransactionsByBlock(blockId);
   };
 
   @Override

--- a/src/brs/BlockchainImpl.java
+++ b/src/brs/BlockchainImpl.java
@@ -205,6 +205,11 @@ public class BlockchainImpl implements Blockchain {
   }
 
   @Override
+  public Collection<Transaction> getAllTransactionsAtBlock(long blockId) {
+      return transactionDb.findBlockAllTransactions(blockId);
+  };
+
+  @Override
   public Collection<Transaction> getTransactions(Account account, int numberOfConfirmations, byte type, byte subtype,
                                                  int blockTimestamp, int from, int to, boolean includeIndirectIncoming) {
     return blockchainStore.getTransactions(account, numberOfConfirmations, type, subtype, blockTimestamp, from, to, includeIndirectIncoming);

--- a/src/brs/BlockchainImpl.java
+++ b/src/brs/BlockchainImpl.java
@@ -206,7 +206,7 @@ public class BlockchainImpl implements Blockchain {
 
   @Override
   public Collection<Transaction> getAllTransactionsAtBlock(long blockId) {
-      return transactionDb.findAllTransactionsByBlock(blockId);
+      return transactionDb.findAllTransactionsAtBlock(blockId);
   };
 
   @Override

--- a/src/brs/db/TransactionDb.java
+++ b/src/brs/db/TransactionDb.java
@@ -19,7 +19,7 @@ public interface TransactionDb extends Table {
 
   List<Transaction> findBlockTransactions(long blockId);
 
-  List<Transaction> findAllTransactionsByBlock(long blockId);
+  List<Transaction> findAllTransactionsAtBlock(long blockId);
 
   void saveTransactions(List<Transaction> transactions);
 }

--- a/src/brs/db/TransactionDb.java
+++ b/src/brs/db/TransactionDb.java
@@ -19,7 +19,7 @@ public interface TransactionDb extends Table {
 
   List<Transaction> findBlockTransactions(long blockId);
 
-  List<Transaction> findBlockAllTransactions(long blockId);
+  List<Transaction> findAllTransactionsByBlock(long blockId);
 
   void saveTransactions(List<Transaction> transactions);
 }

--- a/src/brs/db/TransactionDb.java
+++ b/src/brs/db/TransactionDb.java
@@ -19,5 +19,7 @@ public interface TransactionDb extends Table {
 
   List<Transaction> findBlockTransactions(long blockId);
 
+  List<Transaction> findBlockAllTransactions(long blockId);
+
   void saveTransactions(List<Transaction> transactions);
 }

--- a/src/brs/db/sql/SqlTransactionDb.java
+++ b/src/brs/db/sql/SqlTransactionDb.java
@@ -104,7 +104,7 @@ public class SqlTransactionDb implements TransactionDb {
   }
 
   @Override
-  public List<Transaction> findBlockAllTransactions(long blockId) {
+  public List<Transaction> findAllTransactionsByBlock(long blockId) {
     return Db.useDSLContext(ctx -> {
       return ctx.selectFrom(TRANSACTION)
               .where(TRANSACTION.BLOCK_ID.eq(blockId))

--- a/src/brs/db/sql/SqlTransactionDb.java
+++ b/src/brs/db/sql/SqlTransactionDb.java
@@ -104,6 +104,21 @@ public class SqlTransactionDb implements TransactionDb {
   }
 
   @Override
+  public List<Transaction> findBlockAllTransactions(long blockId) {
+    return Db.useDSLContext(ctx -> {
+      return ctx.selectFrom(TRANSACTION)
+              .where(TRANSACTION.BLOCK_ID.eq(blockId))
+              .fetch(record -> {
+                try {
+                  return loadTransaction(record);
+                } catch (BurstException.ValidationException e) {
+                  throw new RuntimeException("Transaction already in database for block_id = " + Convert.toUnsignedLong(blockId) + " does not pass validation!", e);
+                }
+              });
+    });
+  }
+
+  @Override
   public List<Transaction> findBlockTransactions(long blockId) {
     return Db.useDSLContext(ctx -> {
       return ctx.selectFrom(TRANSACTION)

--- a/src/brs/db/sql/SqlTransactionDb.java
+++ b/src/brs/db/sql/SqlTransactionDb.java
@@ -104,7 +104,7 @@ public class SqlTransactionDb implements TransactionDb {
   }
 
   @Override
-  public List<Transaction> findAllTransactionsByBlock(long blockId) {
+  public List<Transaction> findAllTransactionsAtBlock(long blockId) {
     return Db.useDSLContext(ctx -> {
       return ctx.selectFrom(TRANSACTION)
               .where(TRANSACTION.BLOCK_ID.eq(blockId))

--- a/src/brs/http/APIServlet.java
+++ b/src/brs/http/APIServlet.java
@@ -105,7 +105,7 @@ public final class APIServlet extends HttpServlet {
     map.put("getTransaction", new GetTransaction(transactionProcessor, blockchain));
     map.put("getTransactionBytes", new GetTransactionBytes(blockchain, transactionProcessor));
     map.put("getTransactionIds", new GetTransactionIds(parameterService, blockchain));
-    map.put("getTransactionsByBlock", new GetTransactionsByBlock(blockchain));
+    map.put("getTransactionsAtBlock", new GetTransactionsAtBlock(blockchain));
     map.put("getUnconfirmedTransactionIds", new GetUnconfirmedTransactionIds(transactionProcessor, indirectIncomingService, parameterService));
     map.put("getUnconfirmedTransactions", new GetUnconfirmedTransactions(transactionProcessor, indirectIncomingService, parameterService));
     map.put("getAccountCurrentAskOrderIds", new GetAccountCurrentAskOrderIds(parameterService, assetExchange));

--- a/src/brs/http/APIServlet.java
+++ b/src/brs/http/APIServlet.java
@@ -105,6 +105,7 @@ public final class APIServlet extends HttpServlet {
     map.put("getTransaction", new GetTransaction(transactionProcessor, blockchain));
     map.put("getTransactionBytes", new GetTransactionBytes(blockchain, transactionProcessor));
     map.put("getTransactionIds", new GetTransactionIds(parameterService, blockchain));
+    map.put("getTransactionsByBlock", new GetTransactionsByBlock(blockchain));
     map.put("getUnconfirmedTransactionIds", new GetUnconfirmedTransactionIds(transactionProcessor, indirectIncomingService, parameterService));
     map.put("getUnconfirmedTransactions", new GetUnconfirmedTransactions(transactionProcessor, indirectIncomingService, parameterService));
     map.put("getAccountCurrentAskOrderIds", new GetAccountCurrentAskOrderIds(parameterService, assetExchange));

--- a/src/brs/http/GetTransactionsAtBlock.java
+++ b/src/brs/http/GetTransactionsAtBlock.java
@@ -17,11 +17,11 @@ import static brs.http.common.ResultFields.TRANSACTIONS_RESPONSE;
 import static brs.http.common.Parameters.*;
 import javax.servlet.http.HttpServletRequest;
 
-final class GetTransactionsByBlock extends APIServlet.JsonRequestHandler {
+final class GetTransactionsAtBlock extends APIServlet.JsonRequestHandler {
 
   private final Blockchain blockchain;
 
-  GetTransactionsByBlock(Blockchain blockchain) {
+  GetTransactionsAtBlock(Blockchain blockchain) {
     super(new APITag[] {APITag.TRANSACTIONS}, BLOCK_PARAMETER, HEIGHT_PARAMETER, TIMESTAMP_PARAMETER);
     this.blockchain = blockchain;
   }

--- a/src/brs/http/GetTransactionsByBlock.java
+++ b/src/brs/http/GetTransactionsByBlock.java
@@ -1,0 +1,77 @@
+package brs.http;
+
+import brs.Block;
+import brs.Blockchain;
+import brs.BurstException;
+import brs.Transaction;
+import brs.util.Convert;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonArray;
+
+import java.util.Collection;
+
+import static brs.http.JSONResponses.*;
+import static brs.http.common.ResultFields.TRANSACTIONS_RESPONSE;
+import static brs.http.common.Parameters.*;
+import javax.servlet.http.HttpServletRequest;
+
+final class GetTransactionsByBlock extends APIServlet.JsonRequestHandler {
+
+  private final Blockchain blockchain;
+
+  GetTransactionsByBlock(Blockchain blockchain) {
+    super(new APITag[] {APITag.TRANSACTIONS}, BLOCK_PARAMETER, HEIGHT_PARAMETER, TIMESTAMP_PARAMETER);
+    this.blockchain = blockchain;
+  }
+
+  @Override
+  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+    String blockValue = Convert.emptyToNull(req.getParameter(BLOCK_PARAMETER));
+    String heightValue = Convert.emptyToNull(req.getParameter(HEIGHT_PARAMETER));
+    String timestampValue = Convert.emptyToNull(req.getParameter(TIMESTAMP_PARAMETER));
+
+    Block blockData;
+    if (blockValue != null) {
+      try {
+        blockData = blockchain.getBlock(Convert.parseUnsignedLong(blockValue));
+      } catch (RuntimeException e) {
+        return INCORRECT_BLOCK;
+      }
+    } else if (heightValue != null) {
+      try {
+        int height = Integer.parseInt(heightValue);
+        if (height < 0 || height > blockchain.getHeight()) {
+          return INCORRECT_HEIGHT;
+        }
+        blockData = blockchain.getBlockAtHeight(height);
+      } catch (RuntimeException e) {
+        return INCORRECT_HEIGHT;
+      }
+    } else if (timestampValue != null) {
+      try {
+        int timestamp = Integer.parseInt(timestampValue);
+        if (timestamp < 0) {
+          return INCORRECT_TIMESTAMP;
+        }
+        blockData = blockchain.getLastBlock(timestamp);
+      } catch (RuntimeException e) {
+        return INCORRECT_TIMESTAMP;
+      }
+    } else {
+      blockData = blockchain.getLastBlock();
+    }
+
+    final Collection<Transaction> transactionsFound = blockchain.getAllTransactionsAtBlock(blockData.getId());
+
+    JsonArray transactions = new JsonArray();
+    for (Transaction transaction : transactionsFound) {
+      transactions.add(JSONData.transaction(transaction, blockData.getHeight()));
+    }
+
+    JsonObject response = new JsonObject();
+    response.add(TRANSACTIONS_RESPONSE, transactions);
+    return response;
+  }
+}


### PR DESCRIPTION
Users can check all transactions from a given block in block explorer, including _AT Payments_, but there is no automated way to get same information using current API's.

Adding this API will make possible to create monitors to watch AT payments in general.

How it was done:
Using the same structure from api GetBlock, user can choose to search block by blockId, blockHeight or Timestamp. Once the block data is fetch, a query to get block transactions is done. It is very fast. I choose API Tag to Transactions, so it will be grouped there. Another alternative is to add a field in GetBlock API to return also automated transactions. Currently it deliberated filters out transactions without signature, that's why I'm proposing another API.