### PR TITLE
Add graceful shutdown options to example docker-compose file

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -32,6 +32,8 @@ version: "3.8"
 services:
   signum:
     image: signumnetwork/node:latest-h2
+    init: true
+    stop_grace_period: 2m
     deploy:
       replicas: 1
     restart: always


### PR DESCRIPTION
Makes a minor change to the example docker-compose file to allow for graceful shutdowns even with defrag enabled. This will make the docker engine wait for up to 2 minutes before killing the container, allowing some time for the h2 defrag to happen.