### PR TITLE
Code cleanup - remove `useNQT()` method

### DIFF
--- a/src/brs/Constants.java
+++ b/src/brs/Constants.java
@@ -61,7 +61,6 @@ public final class Constants {
   public static final int MAX_DGS_LISTING_TAGS_LENGTH = 100;
   public static final int MAX_DGS_GOODS_LENGTH = 10240;
 
-  public static final int NQT_BLOCK = 0;
 
   public static final int MAX_AUTOMATED_TRANSACTION_NAME_LENGTH = 30;
   public static final int MAX_AUTOMATED_TRANSACTION_DESCRIPTION_LENGTH = 1000;

--- a/src/brs/TransactionProcessorImpl.java
+++ b/src/brs/TransactionProcessorImpl.java
@@ -293,9 +293,7 @@ public class TransactionProcessorImpl implements TransactionProcessor {
 	  if (blockchain.getLastBlock().getTimestamp() < timeService.getEpochTime() - 60 * 1440 && ! testUnconfirmedTransactions) {
       return new ArrayList<>();
     }
-    if (blockchain.getHeight() <= Constants.NQT_BLOCK) {
-      return new ArrayList<>();
-    }
+
     List<Transaction> transactions = new ArrayList<>();
     for (JsonElement transactionData : transactionsData) {
       try {
@@ -335,9 +333,6 @@ public class TransactionProcessorImpl implements TransactionProcessor {
 
           try {
             stores.beginTransaction();
-            if (blockchain.getHeight() < Constants.NQT_BLOCK) {
-              break; // not ready to process transactions
-            }
 
             if (dbs.getTransactionDb().hasTransaction(transaction.getId()) || unconfirmedTransactionStore.exists(transaction.getId())) {
               stores.commitTransaction();


### PR DESCRIPTION
This PR removes the `useNQT()` method from Transaction.java, the `NQT_BLOCK` constant from Constants.java, and all references to them.

Justification for removal:
This is legacy code that is not used in Signum because the Signum node started after this change was made, so the NQT_BLOCK becomes the genesis block.

Also the contents of the `useNQT()` method are very confusing to have sitting around.