### PR TITLE
Fix issue when asking for blocks and indices are 0 or missing, fix #606

### DIFF
--- a/src/brs/db/sql/SqlBlockchainStore.java
+++ b/src/brs/db/sql/SqlBlockchainStore.java
@@ -38,7 +38,7 @@ public class SqlBlockchainStore implements BlockchainStore {
       int blockchainHeight = Burst.getBlockchain().getHeight();
       return
         getBlocks(ctx.selectFrom(BLOCK)
-                .where(BLOCK.HEIGHT.between(to > 0 ? blockchainHeight - to : 0).and(blockchainHeight - Math.max(from, 0)))
+                .where(BLOCK.HEIGHT.between(to > 0 ? blockchainHeight - to : blockchainHeight).and(blockchainHeight - Math.max(from, 0)))
                 .orderBy(BLOCK.HEIGHT.desc())
                 .fetch());
     });
@@ -293,7 +293,7 @@ public class SqlBlockchainStore implements BlockchainStore {
       }
 
       SelectConditionStep<TransactionRecord> select = ctx.selectFrom(TRANSACTION).where(conditions);
-      
+
       if (recipient != null) {
         select = select.and(TRANSACTION.RECIPIENT_ID.eq(recipient));
       }


### PR DESCRIPTION
The index for blocks is from the current height backwards, if the 'to' is missing or zero it should be assumed as the current height and not 0.