### PR TITLE
Fix issue on creationBytes validation

### DIFF
--- a/src/brs/at/AtController.java
+++ b/src/brs/at/AtController.java
@@ -160,6 +160,9 @@ public abstract class AtController {
             b.getLong();
 
             int codeLen = getLength(codePages, b);
+            if (codeLen == 0 && codePages == 1 && version > 2) {
+                codeLen = 256;
+            }
             if (codeLen < minCodePages || codeLen > codePages * 256) {
                 throw new AtException(AtError.INCORRECT_CODE_LENGTH.getDescription());
             }
@@ -167,6 +170,9 @@ public abstract class AtController {
             b.get(code, 0, codeLen);
 
             int dataLen = getLength(dataPages, b);
+            if (dataLen == 0 && dataPages == 1 && b.capacity() - b.position() == 256 && version > 2) {
+                dataLen = 256;
+            }
             if (dataLen < 0 || dataLen > dataPages * 256) {
                 throw new AtException(AtError.INCORRECT_DATA_LENGTH.getDescription());
             }


### PR DESCRIPTION
Fixes issue #610 

Below is a valid creationBytes that triggers both cases, byteCode and byteData to be 256 bytes.

--------------

03000000010001000000000080f0fa0200000000000403000000010300000005000000000000000103000000050000000000000001030000000500000000000000010300000005000000000000000103000000050000000000000001030000000500000000000000010300000005000000000000000103000000050000000000000001030000000500000000000000010300000005000000000000000103000000050000000000000001030000000500000000000000010300000005000000000000000103000000050000000000000001030000000500000000000000010300000005000000000000000103000000050000000000000001030000000500000000000000010300000005000000000000007f7f7f280011121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff11121314151617ff21222324252627ff