### PR TITLE
API request getBlocks documentation correction

### DIFF
--- a/openapi/paths/getters/getBlocks.json
+++ b/openapi/paths/getters/getBlocks.json
@@ -1,7 +1,7 @@
 {
   "get": {
     "summary": "Get Block Range",
-    "description": "Gets a range of blocks. Return the most recent 500 blocks if no argument is given",
+    "description": "Gets a range of blocks. Return the most recent 100 blocks if no argument is given",
     "tags": [
       "network"
     ],


### PR DESCRIPTION
By default getBlocks API request returns only most recent 100 blocks. Not most recent 500 blocks.
