### PR TITLE
Update node-default.properties to support easier maria use

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Modify these settings in the `node-default.properties` file in the node director
 
 after you install MariaDB and use a root passowrd of your choice, go to the windows icon and find the "MariaDB XX.XX" folder and within that open the "MySQL Client" option. You should see a command prompt asking for your root password, type the password you created when installing maria and hit enter. You should now see something like MariaDB [(none)]>  if so copy the below including the blank lines and paste it into that command prompt window.  
 
-**TIP: _use the copy icon in github when you mouse over the text, then use the LEFT mouse button and click in the command prompt window_**
+**TIP: _use the copy icon in github when you mouse over the text, then use the RIGHT mouse button and click in the command prompt window to paste_**
 ```
 create database if not exists signum;
 create user if not exists 'signum_user'@'localhost' identified by 'S!gnumP@$S';

--- a/README.md
+++ b/README.md
@@ -66,14 +66,29 @@ The important part is that the Java version starts with `11.` (Java 11)
 
 [Download and install MariaDB](https://mariadb.com/downloads/mariadb-tx)
 
-The MariaDb installation will ask to setup a password for the root user. 
-Add this password to the `node.properties` file you will create when installing BRS:
+The MariaDb installation will ask to setup a password for the root user.
+This password can be anything you like. 
+Modify these settings in the `node-default.properties` created after installing the Signum node:
 
+**TIP: _remove # from first character of each line so it looks like the below_**
 ```properties
-DB.Url=jdbc:mariadb://localhost:3306/signum
-DB.Username=root
-DB.Password=YOUR_PASSWORD
+ DB.Url=jdbc:mariadb://localhost:3306/signum
+ DB.Username=signum_user
+ DB.Password=S!gnumP@$S
 ```
+**Windows Setup**
+after you install MariaDB and use a root passowrd of your choice, go to the windows icon and find the "MariaDB XX.XX" folder and within that open the "MySQL Client" option. You should see a command prompt asking for your root password, type the password you created when installing maria and hit enter. You should now see something like MariaDB [(none)]>  if so copy the below including the blank lines and paste it into that command prompt window.  
+
+**TIP: _use the copy icon in github when you mouse over the text, then use the LEFT mouse button and click in the command prompt window_**
+```
+create database if not exists signum;
+create user if not exists 'signum_user'@'localhost' identified by 'S!gnumP@$S';
+grant all privileges on signum.* to 'signum_user'@'localhost';
+flush privileges;
+
+```
+You should see 4 "Query OK" responses after pasting, maria is now setup!   If you have already updated your node-default.properties file as shown above you should be able to start your node and begin to syncronize it to the network.
+
 
 ## Set Up
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ The important part is that the Java version starts with `11.` (Java 11)
 
 The MariaDb installation will ask to setup a password for the root user.
 This password can be anything you like. 
-Modify these settings in the `node-default.properties` created after installing the Signum node:
+
+Modify these settings in the `node-default.properties` file in the node directory after installing the Signum node:
 
 **TIP: _remove # from first character of each line so it looks like the below_**
 ```properties
@@ -77,6 +78,7 @@ Modify these settings in the `node-default.properties` created after installing 
  DB.Password=S!gnumP@$S
 ```
 **Windows Setup**
+
 after you install MariaDB and use a root passowrd of your choice, go to the windows icon and find the "MariaDB XX.XX" folder and within that open the "MySQL Client" option. You should see a command prompt asking for your root password, type the password you created when installing maria and hit enter. You should now see something like MariaDB [(none)]>  if so copy the below including the blank lines and paste it into that command prompt window.  
 
 **TIP: _use the copy icon in github when you mouse over the text, then use the LEFT mouse button and click in the command prompt window_**

--- a/conf/node-default.properties
+++ b/conf/node-default.properties
@@ -38,8 +38,8 @@
 ## If you want to use MariaDB:
 
 # DB.Url=jdbc:mariadb://localhost:3306/signum
-# DB.Username=root
-# DB.Password=YOUR_PASSWORD
+# DB.Username=signum_user
+# DB.Password=S!gnumP@$S
 
 #### PEER 2 PEER NETWORKING ####
 


### PR DESCRIPTION
I am requesting changing the MariaDB default user and password to what is above..   so when users convert from h2 to maria it will be easy for us to script the maria install to be painless for end users.      the maria scripts/directions can then focus on these signum specific database, user, password without a lot of confusion, and security issues with using root.. 

install maria, set root password of your choice, run signum setup script, the start node would be the directions.   hopefully we can build into the node the ability to ask user for root password, connect to default database and perform these functions below on their behalf, then we do not even need a startup script.

`create database if not exists signum;
create user if not exists 'signum_user'@'localhost' identified by 'S!gnumP@$S'; 
grant all privileges on signum.* to 'signum_user'@'localhost'; 
flush privileges;
`