### PR TITLE
Docker MariaDB fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,13 @@
+buildscript {
+    repositories {
+        mavenCentral()
+        maven { url 'https://jitpack.io' }
+    }
+    dependencies {
+        classpath("org.flywaydb:flyway-mysql:8.5.13")
+    }
+}
+
 plugins {
   id 'com.github.johnrengelman.shadow' version '7.1.2'
   id 'java'


### PR DESCRIPTION
Appears that adding a buildscript block resolves the issue and MariaDB is able to be connected to through docker again. 

```
[INFO] 2024-01-20 15:18:01 brs.db.sql.Db - Running flyway migration
[INFO] 2024-01-20 15:19:58 brs.db.sql.Db - Using SQL Backend with Dialect MariaDB - Version 11.1.3-MariaDB-1:11.1.3+maria~ubu2204
[INFO] 2024-01-20 15:19:59 brs.BlockchainProcessorImpl - Genesis block already in database
```