### PR TITLE
Explicitly import org.jooq.Record to avoid ambiquity

### DIFF
--- a/src/brs/db/EntityTable.java
+++ b/src/brs/db/EntityTable.java
@@ -1,6 +1,7 @@
 package brs.db;
 
 import org.jooq.*;
+import org.jooq.Record;
 
 import java.util.Collection;
 import java.util.List;

--- a/src/brs/db/VersionedBatchEntityTable.java
+++ b/src/brs/db/VersionedBatchEntityTable.java
@@ -2,6 +2,7 @@ package brs.db;
 
 import org.ehcache.Cache;
 import org.jooq.*;
+import org.jooq.Record;
 
 import java.util.Collection;
 import java.util.List;

--- a/src/brs/db/sql/DbKey.java
+++ b/src/brs/db/sql/DbKey.java
@@ -3,6 +3,7 @@ package brs.db.sql;
 import brs.db.BurstKey;
 import brs.util.StringUtils;
 import org.jooq.*;
+import org.jooq.Record;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/brs/db/sql/EntitySqlTable.java
+++ b/src/brs/db/sql/EntitySqlTable.java
@@ -5,6 +5,7 @@ import brs.db.BurstKey;
 import brs.db.EntityTable;
 import brs.db.store.DerivedTableManager;
 import org.jooq.*;
+import org.jooq.Record;
 import org.jooq.impl.DSL;
 import org.jooq.impl.TableImpl;
 

--- a/src/brs/db/sql/SqlATStore.java
+++ b/src/brs/db/sql/SqlATStore.java
@@ -17,6 +17,7 @@ import brs.schema.tables.records.AtStateRecord;
 
 import brs.util.CollectionWithIndex;
 import org.jooq.*;
+import org.jooq.Record;
 import org.jooq.exception.DataAccessException;
 
 import java.util.ArrayList;

--- a/src/brs/db/sql/SqlAccountStore.java
+++ b/src/brs/db/sql/SqlAccountStore.java
@@ -17,6 +17,7 @@ import brs.util.Convert;
 import signumj.crypto.SignumCrypto;
 
 import org.jooq.*;
+import org.jooq.Record;
 import org.jooq.impl.DSL;
 import org.slf4j.LoggerFactory;
 

--- a/src/brs/db/sql/SqlBlockDb.java
+++ b/src/brs/db/sql/SqlBlockDb.java
@@ -7,6 +7,7 @@ import brs.db.BlockDb;
 import brs.schema.tables.records.BlockRecord;
 import io.reactivex.Maybe;
 import org.jooq.*;
+import org.jooq.Record;
 import org.jooq.impl.DSL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/brs/db/sql/SqlSubscriptionStore.java
+++ b/src/brs/db/sql/SqlSubscriptionStore.java
@@ -8,6 +8,7 @@ import brs.db.store.DerivedTableManager;
 import brs.db.store.SubscriptionStore;
 
 import org.jooq.*;
+import org.jooq.Record;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/brs/db/sql/VersionedBatchEntitySqlTable.java
+++ b/src/brs/db/sql/VersionedBatchEntitySqlTable.java
@@ -6,6 +6,7 @@ import brs.db.cache.DBCacheManagerImpl;
 import brs.db.store.DerivedTableManager;
 import org.ehcache.Cache;
 import org.jooq.*;
+import org.jooq.Record;
 import org.jooq.impl.TableImpl;
 
 import java.util.*;

--- a/src/brs/db/sql/VersionedEntitySqlTable.java
+++ b/src/brs/db/sql/VersionedEntitySqlTable.java
@@ -5,6 +5,7 @@ import brs.db.BurstKey;
 import brs.db.VersionedEntityTable;
 import brs.db.store.DerivedTableManager;
 import org.jooq.*;
+import org.jooq.Record;
 import org.jooq.impl.DSL;
 import org.jooq.impl.TableImpl;
 import org.slf4j.Logger;


### PR DESCRIPTION
VS Code's java extension was complaining that the Record in each of these files was ambiguous, which makes sense because there are several available libraries that offer Record all in use in the project, but only one is valid for this case. I assume it is the jooq version since all Record instances are found in what appears to be jooq code, so I explicitly imported it, which now removes all ambiguity Errors in the java compiler.