### PR TITLE
Formatter suggestion

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,382 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+    Checkstyle configuration that checks the Google coding conventions from Google Java Style
+    that can be found at https://google.github.io/styleguide/javaguide.html
+
+    Checkstyle is very configurable. Be sure to read the documentation at
+    http://checkstyle.org (or in your downloaded distribution).
+
+    To completely disable a check, just comment it out or delete it from the file.
+    To suppress certain violations please review suppression filters.
+
+    Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
+ -->
+
+<module name="Checker">
+  <module name="SuppressWarningsFilter"/>
+
+  <property name="charset" value="UTF-8"/>
+
+  <property name="severity" value="warning"/>
+
+  <property name="fileExtensions" value="java, properties, xml"/>
+  <!-- Excludes all 'module-info.java' files              -->
+  <!-- See https://checkstyle.org/filefilters/index.html -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$"/>
+  </module>
+  <!-- https://checkstyle.org/filters/suppressionfilter.html -->
+  <module name="SuppressionFilter">
+    <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
+           default="checkstyle-suppressions.xml" />
+    <property name="optional" value="true"/>
+  </module>
+
+  <!-- Checks for whitespace                               -->
+  <!-- See http://checkstyle.org/checks/whitespace/index.html -->
+  <module name="FileTabCharacter">
+    <property name="eachLine" value="true"/>
+  </module>
+
+  <module name="LineLength">
+    <property name="fileExtensions" value="java"/>
+    <property name="max" value="100"/>
+    <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+  </module>
+
+  <module name="TreeWalker">
+    <module name="OuterTypeFilename"/>
+    <module name="IllegalTokenText">
+      <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+      <property name="format"
+               value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+      <property name="message"
+               value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
+    </module>
+    <module name="AvoidEscapedUnicodeCharacters">
+      <property name="allowEscapesForControlCharacters" value="true"/>
+      <property name="allowByTailComment" value="true"/>
+      <property name="allowNonPrintableEscapes" value="true"/>
+    </module>
+    <module name="AvoidStarImport"/>
+    <module name="OneTopLevelClass"/>
+    <module name="NoLineWrap">
+      <property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT"/>
+    </module>
+    <module name="EmptyBlock">
+      <property name="option" value="TEXT"/>
+      <property name="tokens"
+               value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+    </module>
+    <module name="NeedBraces">
+      <property name="tokens"
+               value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE"/>
+    </module>
+    <module name="LeftCurly">
+      <property name="tokens"
+               value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
+                    INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, LITERAL_DEFAULT,
+                    LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF,
+                    OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="RightCurly">
+      <property name="id" value="RightCurlySame"/>
+      <property name="tokens"
+               value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE,
+                    LITERAL_DO"/>
+    </module>
+    <module name="RightCurly">
+      <property name="id" value="RightCurlyAlone"/>
+      <property name="option" value="alone"/>
+      <property name="tokens"
+               value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
+                    INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
+                    COMPACT_CTOR_DEF, LITERAL_SWITCH"/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <!-- suppresion is required till https://github.com/checkstyle/checkstyle/issues/7541 -->
+      <property name="id" value="RightCurlyAlone"/>
+      <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1]
+                                     or preceding-sibling::*[last()][self::LCURLY]]"/>
+    </module>
+    <module name="WhitespaceAfter">
+      <property name="tokens"
+               value="COMMA, SEMI, TYPECAST, LITERAL_IF, LITERAL_ELSE, LITERAL_RETURN,
+                    LITERAL_WHILE, LITERAL_DO, LITERAL_FOR, LITERAL_FINALLY, DO_WHILE, ELLIPSIS,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_CATCH, LAMBDA,
+                    LITERAL_YIELD, LITERAL_CASE"/>
+    </module>
+    <module name="WhitespaceAround">
+      <property name="allowEmptyConstructors" value="true"/>
+      <property name="allowEmptyLambdas" value="true"/>
+      <property name="allowEmptyMethods" value="true"/>
+      <property name="allowEmptyTypes" value="true"/>
+      <property name="allowEmptyLoops" value="true"/>
+      <property name="ignoreEnhancedForColon" value="false"/>
+      <property name="tokens"
+               value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR,
+                    BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND,
+                    LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY,
+                    LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH, LITERAL_SYNCHRONIZED,
+                    LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN,
+                    NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR,
+                    SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND"/>
+      <message key="ws.notFollowed"
+              value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks
+               may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+      <message key="ws.notPreceded"
+              value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+    </module>
+    <module name="OneStatementPerLine"/>
+    <module name="MultipleVariableDeclarations"/>
+    <module name="ArrayTypeStyle"/>
+    <module name="MissingSwitchDefault"/>
+    <module name="FallThrough"/>
+    <module name="UpperEll"/>
+    <module name="ModifierOrder"/>
+    <module name="EmptyLineSeparator">
+      <property name="tokens"
+               value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                    STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF,
+                    COMPACT_CTOR_DEF"/>
+      <property name="allowNoEmptyLineBetweenFields" value="true"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapDot"/>
+      <property name="tokens" value="DOT"/>
+      <property name="option" value="nl"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapComma"/>
+      <property name="tokens" value="COMMA"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <!-- ELLIPSIS is EOL until https://github.com/google/styleguide/issues/259 -->
+      <property name="id" value="SeparatorWrapEllipsis"/>
+      <property name="tokens" value="ELLIPSIS"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <!-- ARRAY_DECLARATOR is EOL until https://github.com/google/styleguide/issues/258 -->
+      <property name="id" value="SeparatorWrapArrayDeclarator"/>
+      <property name="tokens" value="ARRAY_DECLARATOR"/>
+      <property name="option" value="EOL"/>
+    </module>
+    <module name="SeparatorWrap">
+      <property name="id" value="SeparatorWrapMethodRef"/>
+      <property name="tokens" value="METHOD_REF"/>
+      <property name="option" value="nl"/>
+    </module>
+    <module name="PackageName">
+      <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+      <message key="name.invalidPattern"
+             value="Package name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="TypeName">
+      <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                    ANNOTATION_DEF, RECORD_DEF"/>
+      <message key="name.invalidPattern"
+             value="Type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="MemberName">
+      <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+      <message key="name.invalidPattern"
+             value="Member name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="ParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="LambdaParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="CatchParameterName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="LocalVariableName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="PatternVariableName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+             value="Pattern variable name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="ClassTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+             value="Class type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="RecordComponentName">
+      <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+      <message key="name.invalidPattern"
+               value="Record component name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="RecordTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+               value="Record type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="MethodTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+             value="Method type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="InterfaceTypeParameterName">
+      <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
+      <message key="name.invalidPattern"
+             value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="NoFinalizer"/>
+    <module name="GenericWhitespace">
+      <message key="ws.followed"
+             value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+      <message key="ws.preceded"
+             value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+      <message key="ws.illegalFollow"
+             value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+      <message key="ws.notPreceded"
+             value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+    </module>
+    <module name="Indentation">
+      <property name="basicOffset" value="4"/>
+      <property name="braceAdjustment" value="2"/>
+      <property name="caseIndent" value="2"/>
+      <property name="throwsIndent" value="4"/>
+      <property name="lineWrappingIndentation" value="4"/>
+      <property name="arrayInitIndent" value="2"/>
+    </module>
+    <module name="AbbreviationAsWordInName">
+      <property name="ignoreFinal" value="false"/>
+      <property name="allowedAbbreviationLength" value="0"/>
+      <property name="tokens"
+               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
+                    PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,
+                    RECORD_COMPONENT_DEF"/>
+    </module>
+    <module name="NoWhitespaceBeforeCaseDefaultColon"/>
+    <module name="OverloadMethodsDeclarationOrder"/>
+    <module name="VariableDeclarationUsageDistance"/>
+    <module name="CustomImportOrder">
+      <property name="sortImportsInGroupAlphabetically" value="true"/>
+      <property name="separateLineBetweenGroups" value="true"/>
+      <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+      <property name="tokens" value="IMPORT, STATIC_IMPORT, PACKAGE_DEF"/>
+    </module>
+    <module name="MethodParamPad">
+      <property name="tokens"
+               value="CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF,
+                    SUPER_CTOR_CALL, ENUM_CONSTANT_DEF, RECORD_DEF"/>
+    </module>
+    <module name="NoWhitespaceBefore">
+      <property name="tokens"
+               value="COMMA, SEMI, POST_INC, POST_DEC, DOT,
+                    LABELED_STAT, METHOD_REF"/>
+      <property name="allowLineBreaks" value="true"/>
+    </module>
+    <module name="ParenPad">
+      <property name="tokens"
+               value="ANNOTATION, ANNOTATION_FIELD_DEF, CTOR_CALL, CTOR_DEF, DOT, ENUM_CONSTANT_DEF,
+                    EXPR, LITERAL_CATCH, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_NEW,
+                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_WHILE, METHOD_CALL,
+                    METHOD_DEF, QUESTION, RESOURCE_SPECIFICATION, SUPER_CTOR_CALL, LAMBDA,
+                    RECORD_DEF"/>
+    </module>
+    <module name="OperatorWrap">
+      <property name="option" value="NL"/>
+      <property name="tokens"
+               value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR,
+                    LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF,
+                    TYPE_EXTENSION_AND "/>
+    </module>
+    <module name="AnnotationLocation">
+      <property name="id" value="AnnotationLocationMostCases"/>
+      <property name="tokens"
+               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF,
+                      RECORD_DEF, COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="AnnotationLocation">
+      <property name="id" value="AnnotationLocationVariables"/>
+      <property name="tokens" value="VARIABLE_DEF"/>
+      <property name="allowSamelineMultipleAnnotations" value="true"/>
+    </module>
+    <module name="NonEmptyAtclauseDescription"/>
+    <module name="InvalidJavadocPosition"/>
+    <module name="JavadocTagContinuationIndentation"/>
+    <module name="SummaryJavadoc">
+      <property name="forbiddenSummaryFragments"
+               value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+    </module>
+    <module name="JavadocParagraph"/>
+    <module name="RequireEmptyLineBeforeBlockTagGroup"/>
+    <module name="AtclauseOrder">
+      <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
+      <property name="target"
+               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+    </module>
+    <module name="JavadocMethod">
+      <property name="accessModifiers" value="public"/>
+      <property name="allowMissingParamTags" value="true"/>
+      <property name="allowMissingReturnTag" value="true"/>
+      <property name="allowedAnnotations" value="Override, Test"/>
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="MissingJavadocMethod">
+      <property name="scope" value="public"/>
+      <property name="minLineCount" value="2"/>
+      <property name="allowedAnnotations" value="Override, Test"/>
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,
+                                   COMPACT_CTOR_DEF"/>
+    </module>
+    <module name="MissingJavadocType">
+      <property name="scope" value="protected"/>
+      <property name="tokens"
+                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                      RECORD_DEF, ANNOTATION_DEF"/>
+      <property name="excludeScope" value="nothing"/>
+    </module>
+    <module name="MethodName">
+      <property name="format" value="^[a-z][a-z0-9]\w*$"/>
+      <message key="name.invalidPattern"
+             value="Method name ''{0}'' must match pattern ''{1}''."/>
+    </module>
+    <module name="SingleLineJavadoc"/>
+    <module name="EmptyCatchBlock">
+      <property name="exceptionVariableName" value="expected"/>
+    </module>
+    <module name="CommentsIndentation">
+      <property name="tokens" value="SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN"/>
+    </module>
+    <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
+    <module name="SuppressionXpathFilter">
+      <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
+             default="checkstyle-xpath-suppressions.xml" />
+      <property name="optional" value="true"/>
+    </module>
+    <module name="SuppressWarningsHolder" />
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)" />
+      <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)" />
+      <property name="checkFormat" value="$1" />
+    </module>
+    <module name="SuppressWithNearbyCommentFilter">
+      <property name="commentFormat" value="CHECKSTYLE.SUPPRESS\: ([\w\|]+)"/>
+      <!-- $1 refers to the first match group in the regex defined in commentFormat -->
+      <property name="checkFormat" value="$1"/>
+      <!-- The check is suppressed in the next line of code after the comment -->
+      <property name="influenceFormat" value="1"/>
+    </module>
+  </module>
+</module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -48,7 +48,9 @@
     <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
   </module>
 
+  <module name="SuppressWarningsFilter"/>
   <module name="TreeWalker">
+    <module name="SuppressWarningsHolder"/>
     <module name="OuterTypeFilename"/>
     <module name="IllegalTokenText">
       <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>

--- a/eclipse-java-style.xml
+++ b/eclipse-java-style.xml
@@ -1,0 +1,341 @@
+<!-- Based off of https://raw.githubusercontent.com/google/styleguide/gh-pages/eclipse-java-google-style.xml -->
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="13">
+<profile kind="CodeFormatterProfile" name="SignumStyle" version="13">
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_cascading_method_invocation_with_arguments.count_dependent" value="16|-1|16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_prefer_two_fragments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_comment_inline_tags" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_local_variable_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_parameter" value="1040"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_type.count_dependent" value="1585|-1|1585"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields.count_dependent" value="16|-1|16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression.count_dependent" value="16|4|80"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration.count_dependent" value="16|4|48"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration.count_dependent" value="16|4|49"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_cascading_method_invocation_with_arguments" value="16"/>
+<setting id="org.eclipse.jdt.core.compiler.source" value="1.7"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration.count_dependent" value="16|4|48"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_local_variable_annotation" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants.count_dependent" value="16|5|48"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="100"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation.count_dependent" value="16|4|48"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_package" value="1585"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="16"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_type_annotation" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_field_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_generic_type_arguments" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.comment_new_line_at_start_of_html_paragraph" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comment_prefix" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_parameter_annotation" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_method" value="1585"/>
+<setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation.count_dependent" value="16|5|80"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_parameter.count_dependent" value="1040|-1|1040"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_package.count_dependent" value="1585|-1|1585"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.force_if_else_statement_brace" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="3"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_package_annotation" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation.count_dependent" value="16|-1|16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_type" value="1585"/>
+<setting id="org.eclipse.jdt.core.compiler.compliance" value="1.7"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_new_anonymous_class" value="20"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_local_variable.count_dependent" value="1585|-1|1585"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_field.count_dependent" value="1585|-1|1585"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration.count_dependent" value="16|5|80"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="enabled"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant.count_dependent" value="16|-1|16"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="100"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_field" value="1585"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer.count_dependent" value="16|5|80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.7"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration.count_dependent" value="16|4|48"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_method.count_dependent" value="1585|-1|1585"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression.count_dependent" value="16|-1|16"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_member_annotation" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_local_variable" value="1585"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call.count_dependent" value="16|5|80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_generic_type_arguments.count_dependent" value="16|-1|16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression.count_dependent" value="16|5|80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration.count_dependent" value="16|5|80"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_for_statement" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.count_line_length_from_starting_position" value="true"/>
+</profile>
+</profiles>

--- a/src/brs/Signum.java
+++ b/src/brs/Signum.java
@@ -19,8 +19,28 @@ import brs.peer.Peers;
 import brs.props.PropertyService;
 import brs.props.PropertyServiceImpl;
 import brs.props.Props;
-import brs.services.*;
-import brs.services.impl.*;
+import brs.services.ATService;
+import brs.services.AccountService;
+import brs.services.AliasService;
+import brs.services.BlockService;
+import brs.services.DGSGoodsStoreService;
+import brs.services.EscrowService;
+import brs.services.IndirectIncomingService;
+import brs.services.ParameterService;
+import brs.services.SubscriptionService;
+import brs.services.TimeService;
+import brs.services.TransactionService;
+import brs.services.impl.ATServiceImpl;
+import brs.services.impl.AccountServiceImpl;
+import brs.services.impl.AliasServiceImpl;
+import brs.services.impl.BlockServiceImpl;
+import brs.services.impl.DGSGoodsStoreServiceImpl;
+import brs.services.impl.EscrowServiceImpl;
+import brs.services.impl.IndirectIncomingServiceImpl;
+import brs.services.impl.ParameterServiceImpl;
+import brs.services.impl.SubscriptionServiceImpl;
+import brs.services.impl.TimeServiceImpl;
+import brs.services.impl.TransactionServiceImpl;
 import brs.statistics.StatisticsManagerImpl;
 import brs.util.DownloadCacheImpl;
 import brs.util.LoggerConfigurator;
@@ -31,7 +51,12 @@ import brs.web.api.http.common.APITransactionManagerImpl;
 import brs.web.server.WebServer;
 import brs.web.server.WebServerContext;
 import brs.web.server.WebServerImpl;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
@@ -45,386 +70,516 @@ import org.slf4j.LoggerFactory;
 import signum.net.NetworkParameters;
 import signumj.util.SignumUtils;
 
+/**
+ * The main class of the Signum node.
+ */
 public final class Signum {
 
-  public static final Version VERSION = Version.parse("v3.8.0");
-  public static final String APPLICATION = "BRS";
-
-  public static final String CONF_FOLDER = "./conf";
-  public static final String DEFAULT_PROPERTIES_NAME = "node-default.properties";
-  public static final String PROPERTIES_NAME = "node.properties";
-
-  public static final Option CONF_FOLDER_OPTION = Option.builder("c")
-      .longOpt("config")
-      .argName("conf folder")
-      .numberOfArgs(1)
-      .desc("The configuration folder to use")
-      .build();
-
-  public static final Options CLI_OPTIONS = new Options()
-      .addOption(CONF_FOLDER_OPTION)
-      .addOption(Option.builder("l")
-          .longOpt("headless")
-          .desc("Run in headless mode")
-          .build())
-      .addOption(Option.builder("h")
-          .longOpt("help")
-          .build());
-
-  private static final Logger logger = LoggerFactory.getLogger(Signum.class);
-
-  private static Stores stores;
-  private static Dbs dbs;
-
-  private static ThreadPool threadPool;
-
-  private static BlockchainImpl blockchain;
-  private static BlockchainProcessorImpl blockchainProcessor;
-  private static TransactionProcessorImpl transactionProcessor;
-  private static TransactionService transactionService;
-  private static SubscriptionService subscriptionService;
-  private static AssetExchange assetExchange;
-
-  private static PropertyService propertyService;
-  private static FluxCapacitor fluxCapacitor;
-
-  private static DBCacheManagerImpl dbCacheManager;
-
-  private static WebServer webServer;
-
-  private static AtomicBoolean shuttingdown = new AtomicBoolean(false);
-
-  private static PropertyService loadProperties(String confFolder) {
-    logger.info("Initializing Signum Node version {}", VERSION);
-
-    logger.info("Configurations from folder {}", confFolder);
-    Properties defaultProperties = new Properties();
-    try (InputStream is = new FileInputStream(new File(confFolder, DEFAULT_PROPERTIES_NAME))) {
-      defaultProperties.load(is);
-    } catch (IOException e) {
-      throw new RuntimeException("Error loading " + DEFAULT_PROPERTIES_NAME, e);
-    }
-
-    Properties properties = new Properties(defaultProperties);
-    try (InputStream is = new FileInputStream(new File(confFolder, PROPERTIES_NAME))) {
-      if (is != null) { // parse if brs.properties was loaded
-        properties.load(is);
-      }
-    } catch (IOException e) {
-      logger.info("Custom user properties file {} not loaded", PROPERTIES_NAME);
-    }
-
-    return new PropertyServiceImpl(properties);
-  }
-
-  private Signum() {
-  } // never
-
-  public static Blockchain getBlockchain() {
-    return blockchain;
-  }
-
-  public static BlockchainProcessorImpl getBlockchainProcessor() {
-    return blockchainProcessor;
-  }
-
-  public static TransactionProcessorImpl getTransactionProcessor() {
-    return transactionProcessor;
-  }
-
-  public static TransactionService getTransactionService() {
-    return transactionService;
-  }
-
-  public static SubscriptionService getSubscriptionService() {
-    return subscriptionService;
-  }
-
-  public static AssetExchange getAssetExchange() {
-    return assetExchange;
-  }
-
-  public static Stores getStores() {
-    return stores;
-  }
-
-  public static Dbs getDbs() {
-    return dbs;
-  }
-
-  public static void main(String[] args) {
-    Runtime.getRuntime().addShutdownHook(new Thread(Signum::shutdown));
-    String confFolder = CONF_FOLDER;
-    try {
-      CommandLine cmd = new DefaultParser().parse(CLI_OPTIONS, args);
-      if (cmd.hasOption(CONF_FOLDER_OPTION.getOpt()))
-        confFolder = cmd.getOptionValue(CONF_FOLDER_OPTION.getOpt());
-    } catch (Exception e) {
-      logger.error("Exception parsing command line arguments", e);
-    }
-    init(confFolder);
-  }
-
-  private static boolean validateVersionNotDev(PropertyService propertyService) {
-    if (VERSION.isPrelease() && propertyService.getString(Props.NETWORK_NAME).equals(Constants.SIGNUM_NETWORK_NAME)) {
-      logger.error("THIS IS A DEVELOPMENT VERSION, PLEASE DO NOT USE THIS ON Signum MAINNET");
-      return false;
-    }
-    return true;
-  }
-
-  public static void init(Properties customProperties) {
-    loadWallet(new PropertyServiceImpl(customProperties));
-  }
-
-  private static void init(String confFolder) {
-    loadWallet(loadProperties(confFolder));
-  }
-
-  private static void loadWallet(PropertyService propertyService) {
-    LoggerConfigurator.init();
-
-    Signum.propertyService = propertyService;
-
-    String networkParametersClass = propertyService.getString(Props.NETWORK_PARAMETERS);
-    NetworkParameters params = null;
-    if (networkParametersClass != null) {
-      try {
-        params = (NetworkParameters) Class.forName(networkParametersClass).getConstructor().newInstance();
-        propertyService.setNetworkParameters(params);
-      } catch (Exception e) {
-        logger.error(e.getMessage(), e);
-        System.exit(1);
-      }
-    }
-
-    if (!validateVersionNotDev(propertyService))
-      return;
-
-    try {
-      long startTime = System.currentTimeMillis();
-
-      // Address prefix and coin name
-      SignumUtils.setAddressPrefix(propertyService.getString(Props.ADDRESS_PREFIX));
-      SignumUtils.addAddressPrefix("BURST");
-      SignumUtils.setValueSuffix(propertyService.getString(Props.VALUE_SUFIX));
-
-      final TimeService timeService = new TimeServiceImpl();
-
-      final DerivedTableManager derivedTableManager = new DerivedTableManager();
-
-      final StatisticsManagerImpl statisticsManager = new StatisticsManagerImpl(timeService);
-      dbCacheManager = new DBCacheManagerImpl(statisticsManager);
-
-      threadPool = new ThreadPool(propertyService);
-
-      Db.init(propertyService, dbCacheManager);
-      dbs = Db.getDbsByDatabaseType();
-
-      stores = new Stores(derivedTableManager, dbCacheManager, timeService, propertyService, dbs.getTransactionDb(),
-          params);
-
-      final TransactionDb transactionDb = dbs.getTransactionDb();
-      final BlockDb blockDb = dbs.getBlockDb();
-      final BlockchainStore blockchainStore = stores.getBlockchainStore();
-      blockchain = new BlockchainImpl(transactionDb, blockDb, blockchainStore, propertyService);
-
-      final AliasService aliasService = new AliasServiceImpl(stores.getAliasStore());
-      fluxCapacitor = new FluxCapacitorImpl(blockchain, propertyService);
-      aliasService.addDefaultTLDs();
-
-      EconomicClustering economicClustering = new EconomicClustering(blockchain);
-
-      final AccountService accountService = new AccountServiceImpl(stores.getAccountStore(),
-          stores.getAssetTransferStore());
-
-      final DownloadCacheImpl downloadCache = new DownloadCacheImpl(propertyService, fluxCapacitor, blockchain);
-
-      final Generator generator = propertyService.getBoolean(Props.DEV_MOCK_MINING)
-          ? new GeneratorImpl.MockGenerator(propertyService, blockchain, accountService, timeService, fluxCapacitor)
-          : new GeneratorImpl(blockchain, downloadCache, accountService, timeService, fluxCapacitor);
-
-      transactionService = new TransactionServiceImpl(accountService, blockchain);
-
-      transactionProcessor = new TransactionProcessorImpl(propertyService, economicClustering, blockchain, stores,
-          timeService, dbs,
-          accountService, transactionService, threadPool);
-
-      final ATService atService = new ATServiceImpl(stores.getAtStore());
-      subscriptionService = new SubscriptionServiceImpl(stores.getSubscriptionStore(), transactionDb, blockchain,
-          aliasService, accountService);
-      final DGSGoodsStoreService digitalGoodsStoreService = new DGSGoodsStoreServiceImpl(blockchain,
-          stores.getDigitalGoodsStoreStore(), accountService);
-      final EscrowService escrowService = new EscrowServiceImpl(stores.getEscrowStore(), blockchain, aliasService,
-          accountService);
-
-      assetExchange = new AssetExchangeImpl(accountService, stores.getTradeStore(), stores.getAccountStore(),
-          stores.getAssetTransferStore(), stores.getAssetStore(), stores.getOrderStore());
-
-      final IndirectIncomingService indirectIncomingService = new IndirectIncomingServiceImpl(
-          stores.getIndirectIncomingStore(), propertyService);
-
-      TransactionType.init(blockchain, fluxCapacitor, accountService, digitalGoodsStoreService, aliasService,
-          assetExchange, subscriptionService, escrowService);
-
-      final BlockService blockService = new BlockServiceImpl(accountService, transactionService, blockchain,
-          downloadCache, generator, params);
-      blockchainProcessor = new BlockchainProcessorImpl(threadPool, blockService, transactionProcessor, blockchain,
-          propertyService, subscriptionService,
-          timeService, derivedTableManager,
-          blockDb, transactionDb, economicClustering, blockchainStore, stores, escrowService, transactionService,
-          downloadCache, generator, statisticsManager,
-          dbCacheManager, accountService, indirectIncomingService, aliasService);
-
-      generator.generateForBlockchainProcessor(threadPool, blockchainProcessor);
-
-      final DeeplinkQRCodeGenerator deepLinkQRCodeGenerator = new DeeplinkQRCodeGenerator();
-
-      final ParameterService parameterService = new ParameterServiceImpl(accountService, aliasService, assetExchange,
-          digitalGoodsStoreService, blockchain, blockchainProcessor, transactionProcessor, atService);
-
-      addBlockchainListeners(blockchainProcessor, accountService, assetExchange, digitalGoodsStoreService, blockchain,
-          dbs.getTransactionDb());
-
-      final APITransactionManager apiTransactionManager = new APITransactionManagerImpl(parameterService,
-          transactionProcessor, blockchain, accountService, transactionService);
-
-      Peers.init(timeService, accountService, blockchain, transactionProcessor, blockchainProcessor, propertyService,
-          threadPool);
-      if (params != null) {
-        params.initialize(parameterService, accountService, apiTransactionManager);
-        TransactionType.setNetworkParameters(params);
-      }
-
-      final FeeSuggestionCalculator feeSuggestionCalculator = new FeeSuggestionCalculator(blockchainProcessor,
-          stores.getUnconfirmedTransactionStore());
-
-      webServer = new WebServerImpl(new WebServerContext(transactionProcessor,
-          blockchain,
-          blockchainProcessor,
-          parameterService,
-          accountService,
-          aliasService,
-          assetExchange,
-          escrowService,
-          digitalGoodsStoreService,
-          subscriptionService,
-          atService,
-          timeService,
-          economicClustering,
-          propertyService,
-          threadPool,
-          transactionService,
-          blockService,
-          generator,
-          apiTransactionManager,
-          feeSuggestionCalculator,
-          deepLinkQRCodeGenerator,
-          indirectIncomingService,
-          params));
-      webServer.start();
-
-      if (propertyService.getBoolean(Props.BRS_DEBUG_TRACE_ENABLED)) {
-        DebugTrace.init(propertyService, blockchainProcessor, accountService, assetExchange, digitalGoodsStoreService);
-      }
-
-      int timeMultiplier = (propertyService.getBoolean(Props.DEV_OFFLINE))
-          ? Math.max(propertyService.getInt(Props.DEV_TIMEWARP), 1)
-          : 1;
-
-      threadPool.start(timeMultiplier);
-      if (timeMultiplier > 1) {
-        timeService.setTime(new Time.FasterTime(
-            Math.max(timeService.getEpochTime(), getBlockchain().getLastBlock().getTimestamp()), timeMultiplier));
-        logger.info("TIME WILL FLOW {} TIMES FASTER!", timeMultiplier);
-      }
-
-      long currentTime = System.currentTimeMillis();
-      logger.info("Initialization took {} ms", currentTime - startTime);
-      logger.info("Signum Multiverse {} started successfully.", VERSION);
-      logger.info("Running network: {}", propertyService.getString(Props.NETWORK_NAME));
-    } catch (Exception e) {
-      logger.error(e.getMessage(), e);
-      System.exit(1);
-    }
-    (new Thread(Signum::commandHandler)).start();
-  }
-
-  private static void addBlockchainListeners(BlockchainProcessor blockchainProcessor, AccountService accountService,
-      AssetExchange assetExchange, DGSGoodsStoreService goodsService, Blockchain blockchain,
-      TransactionDb transactionDb) {
-
-    final AT.HandleATBlockTransactionsListener handleATBlockTransactionListener = new AT.HandleATBlockTransactionsListener(
-        accountService, transactionDb);
-    final DGSGoodsStoreServiceImpl.ExpiredPurchaseListener devNullListener = new DGSGoodsStoreServiceImpl.ExpiredPurchaseListener(
-        accountService, goodsService);
-
-    blockchainProcessor.addListener(handleATBlockTransactionListener, BlockchainProcessor.Event.AFTER_BLOCK_APPLY);
-    blockchainProcessor.addListener(devNullListener, BlockchainProcessor.Event.AFTER_BLOCK_APPLY);
-  }
-
-  private static void shutdown() {
-    shutdown(false);
-  }
-
-  private static void commandHandler() {
-    BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
-    try {
-      String command;
-      while ((command = reader.readLine()) != null) {
-        logger.debug("received command: >{}<", command);
-        if (command.equals(".shutdown")) {
-          shutdown(false);
-          System.exit(0);
-        } else if (command.startsWith(".popoff ")) {
-          Pattern r = Pattern.compile("^\\.popoff (\\d+)$");
-          Matcher m = r.matcher(command);
-          if (m.find()) {
-            int numBlocks = Integer.parseInt(m.group(1));
-            if (numBlocks > 0) {
-              blockchainProcessor.popOffTo(blockchain.getHeight() - numBlocks);
-            }
-          }
+    public static final Version VERSION = Version.parse("v3.8.0");
+    public static final String APPLICATION = "BRS";
+
+    public static final String CONF_FOLDER = "./conf";
+    public static final String DEFAULT_PROPERTIES_NAME = "node-default.properties";
+    public static final String PROPERTIES_NAME = "node.properties";
+
+    public static final Option CONF_FOLDER_OPTION = Option.builder("c")
+            .longOpt("config")
+            .argName("conf folder")
+            .numberOfArgs(1)
+            .desc("The configuration folder to use")
+            .build();
+
+    public static final Options CLI_OPTIONS = new Options()
+            .addOption(CONF_FOLDER_OPTION)
+            .addOption(Option.builder("l")
+                    .longOpt("headless")
+                    .desc("Run in headless mode")
+                    .build())
+            .addOption(Option.builder("h")
+                    .longOpt("help")
+                    .build());
+
+    private static final Logger logger = LoggerFactory.getLogger(Signum.class);
+
+    private static Stores stores;
+    private static Dbs dbs;
+
+    private static ThreadPool threadPool;
+
+    private static BlockchainImpl blockchain;
+    private static BlockchainProcessorImpl blockchainProcessor;
+    private static TransactionProcessorImpl transactionProcessor;
+    private static TransactionService transactionService;
+    private static SubscriptionService subscriptionService;
+    private static AssetExchange assetExchange;
+
+    private static PropertyService propertyService;
+    private static FluxCapacitor fluxCapacitor;
+
+    private static DBCacheManagerImpl dbCacheManager;
+
+    private static WebServer webServer;
+
+    private static AtomicBoolean shuttingdown = new AtomicBoolean(false);
+
+    private static PropertyService loadProperties(String confFolder) {
+        logger.info("Initializing Signum Node version {}", VERSION);
+
+        logger.info("Configurations from folder {}", confFolder);
+        Properties defaultProperties = new Properties();
+        try (InputStream is = new FileInputStream(new File(confFolder, DEFAULT_PROPERTIES_NAME))) {
+            defaultProperties.load(is);
+        } catch (IOException e) {
+            throw new RuntimeException("Error loading " + DEFAULT_PROPERTIES_NAME, e);
         }
-      }
-    } catch (IOException e) {
-      // ignore
-    }
-  }
 
-  public static void shutdown(boolean ignoreDBShutdown) {
-    if (!shuttingdown.get()) {
-      logger.info("Shutting down...");
-      logger.info("Do not force exit or kill the node process.");
-    }
+        Properties properties = new Properties(defaultProperties);
+        try (InputStream is = new FileInputStream(new File(confFolder, PROPERTIES_NAME))) {
+            if (is != null) { // parse if brs.properties was loaded
+                properties.load(is);
+            }
+        } catch (IOException e) {
+            logger.info("Custom user properties file {} not loaded", PROPERTIES_NAME);
+        }
 
-    if (webServer != null) {
-      webServer.shutdown();
-    }
-    if (threadPool != null) {
-      Peers.shutdown(threadPool);
-      threadPool.shutdown();
-    }
-    if (!ignoreDBShutdown && !shuttingdown.get()) {
-      shuttingdown.set(true);
-      Db.shutdown();
+        return new PropertyServiceImpl(properties);
     }
 
-    if (dbCacheManager != null)
-      dbCacheManager.close();
-    if (blockchainProcessor != null && blockchainProcessor.getOclVerify()) {
-      OCLPoC.destroy();
+    private Signum() {
+    } // never
+
+    public static Blockchain getBlockchain() {
+        return blockchain;
     }
-    logger.info("BRS {} stopped.", VERSION);
-    LoggerConfigurator.shutdown();
-  }
 
-  public static PropertyService getPropertyService() {
-    return propertyService;
-  }
+    public static BlockchainProcessorImpl getBlockchainProcessor() {
+        return blockchainProcessor;
+    }
 
-  public static FluxCapacitor getFluxCapacitor() {
-    return fluxCapacitor;
-  }
+    public static TransactionProcessorImpl getTransactionProcessor() {
+        return transactionProcessor;
+    }
+
+    public static TransactionService getTransactionService() {
+        return transactionService;
+    }
+
+    public static SubscriptionService getSubscriptionService() {
+        return subscriptionService;
+    }
+
+    public static AssetExchange getAssetExchange() {
+        return assetExchange;
+    }
+
+    public static Stores getStores() {
+        return stores;
+    }
+
+    public static Dbs getDbs() {
+        return dbs;
+    }
+
+    /**
+     * The main entry point for the node.
+     *
+     * @param args arguments for the node.
+     */
+    public static void main(String[] args) {
+        Runtime.getRuntime().addShutdownHook(new Thread(Signum::shutdown));
+        String confFolder = CONF_FOLDER;
+        try {
+            CommandLine cmd = new DefaultParser().parse(CLI_OPTIONS, args);
+            if (cmd.hasOption(CONF_FOLDER_OPTION.getOpt())) {
+                confFolder = cmd.getOptionValue(CONF_FOLDER_OPTION.getOpt());
+            }
+        } catch (Exception e) {
+            logger.error("Exception parsing command line arguments", e);
+        }
+        init(confFolder);
+    }
+
+    private static boolean validateVersionNotDev(PropertyService propertyService) {
+        if (VERSION.isPrelease()
+                && propertyService
+                        .getString(Props.NETWORK_NAME)
+                        .equals(Constants.SIGNUM_NETWORK_NAME)) {
+            logger.error("THIS IS A DEVELOPMENT VERSION, PLEASE DO NOT USE THIS ON Signum MAINNET");
+            return false;
+        }
+        return true;
+    }
+
+    public static void init(Properties customProperties) {
+        loadWallet(new PropertyServiceImpl(customProperties));
+    }
+
+    private static void init(String confFolder) {
+        loadWallet(loadProperties(confFolder));
+    }
+
+    private static void loadWallet(PropertyService propertyService) {
+        LoggerConfigurator.init();
+
+        Signum.propertyService = propertyService;
+
+        String networkParametersClass = propertyService.getString(Props.NETWORK_PARAMETERS);
+        NetworkParameters params = null;
+        if (networkParametersClass != null) {
+            try {
+                params = (NetworkParameters) Class
+                        .forName(networkParametersClass)
+                        .getConstructor()
+                        .newInstance();
+                propertyService.setNetworkParameters(params);
+            } catch (Exception e) {
+                logger.error(e.getMessage(), e);
+                System.exit(1);
+            }
+        }
+
+        if (!validateVersionNotDev(propertyService)) {
+            return;
+        }
+
+        try {
+            final long startTime = System.currentTimeMillis();
+
+            // Address prefix and coin name
+            SignumUtils.setAddressPrefix(propertyService.getString(Props.ADDRESS_PREFIX));
+            SignumUtils.addAddressPrefix("BURST");
+            SignumUtils.setValueSuffix(propertyService.getString(Props.VALUE_SUFIX));
+
+            final TimeService timeService = new TimeServiceImpl();
+
+            final DerivedTableManager derivedTableManager = new DerivedTableManager();
+
+            final StatisticsManagerImpl statisticsManager = new StatisticsManagerImpl(timeService);
+            dbCacheManager = new DBCacheManagerImpl(statisticsManager);
+
+            threadPool = new ThreadPool(propertyService);
+
+            Db.init(propertyService, dbCacheManager);
+            dbs = Db.getDbsByDatabaseType();
+
+            stores = new Stores(derivedTableManager, dbCacheManager, timeService, propertyService,
+                    dbs.getTransactionDb(),
+                    params);
+
+            final TransactionDb transactionDb = dbs.getTransactionDb();
+            final BlockDb blockDb = dbs.getBlockDb();
+            final BlockchainStore blockchainStore = stores.getBlockchainStore();
+            blockchain = new BlockchainImpl(
+                    transactionDb,
+                    blockDb,
+                    blockchainStore,
+                    propertyService);
+
+            final AliasService aliasService = new AliasServiceImpl(stores.getAliasStore());
+            fluxCapacitor = new FluxCapacitorImpl(blockchain, propertyService);
+            aliasService.addDefaultTLDs();
+
+            EconomicClustering economicClustering = new EconomicClustering(blockchain);
+
+            final AccountService accountService = new AccountServiceImpl(stores.getAccountStore(),
+                    stores.getAssetTransferStore());
+
+            final DownloadCacheImpl downloadCache = new DownloadCacheImpl(
+                    propertyService,
+                    fluxCapacitor,
+                    blockchain);
+
+            final Generator generator = propertyService.getBoolean(Props.DEV_MOCK_MINING)
+                    ? new GeneratorImpl.MockGenerator(
+                            propertyService,
+                            blockchain,
+                            accountService,
+                            timeService,
+                            fluxCapacitor)
+                    : new GeneratorImpl(
+                            blockchain,
+                            downloadCache,
+                            accountService,
+                            timeService,
+                            fluxCapacitor);
+
+            transactionService = new TransactionServiceImpl(accountService, blockchain);
+
+            transactionProcessor = new TransactionProcessorImpl(
+                    propertyService,
+                    economicClustering,
+                    blockchain,
+                    stores,
+                    timeService, dbs,
+                    accountService,
+                    transactionService,
+                    threadPool);
+
+            final ATService atService = new ATServiceImpl(stores.getAtStore());
+            subscriptionService = new SubscriptionServiceImpl(
+                    stores.getSubscriptionStore(),
+                    transactionDb,
+                    blockchain,
+                    aliasService,
+                    accountService);
+            final DGSGoodsStoreService digitalGoodsStoreService = new DGSGoodsStoreServiceImpl(
+                    blockchain,
+                    stores.getDigitalGoodsStoreStore(),
+                    accountService);
+            final EscrowService escrowService = new EscrowServiceImpl(
+                    stores.getEscrowStore(),
+                    blockchain,
+                    aliasService,
+                    accountService);
+
+            assetExchange = new AssetExchangeImpl(
+                    accountService,
+                    stores.getTradeStore(),
+                    stores.getAccountStore(),
+                    stores.getAssetTransferStore(),
+                    stores.getAssetStore(),
+                    stores.getOrderStore());
+
+            final IndirectIncomingService indirectIncomingService = new IndirectIncomingServiceImpl(
+                    stores.getIndirectIncomingStore(), propertyService);
+
+            TransactionType.init(
+                    blockchain,
+                    fluxCapacitor,
+                    accountService,
+                    digitalGoodsStoreService,
+                    aliasService,
+                    assetExchange,
+                    subscriptionService,
+                    escrowService);
+
+            final BlockService blockService = new BlockServiceImpl(
+                    accountService,
+                    transactionService,
+                    blockchain,
+                    downloadCache,
+                    generator,
+                    params);
+            blockchainProcessor = new BlockchainProcessorImpl(
+                    threadPool,
+                    blockService,
+                    transactionProcessor,
+                    blockchain,
+                    propertyService,
+                    subscriptionService,
+                    timeService,
+                    derivedTableManager,
+                    blockDb,
+                    transactionDb,
+                    economicClustering,
+                    blockchainStore,
+                    stores,
+                    escrowService,
+                    transactionService,
+                    downloadCache,
+                    generator,
+                    statisticsManager,
+                    dbCacheManager,
+                    accountService,
+                    indirectIncomingService,
+                    aliasService);
+
+            generator.generateForBlockchainProcessor(threadPool, blockchainProcessor);
+
+            final DeeplinkQRCodeGenerator deepLinkQrCodeGenerator = new DeeplinkQRCodeGenerator();
+
+            final ParameterService parameterService = new ParameterServiceImpl(
+                    accountService,
+                    aliasService,
+                    assetExchange,
+                    digitalGoodsStoreService,
+                    blockchain,
+                    blockchainProcessor,
+                    transactionProcessor,
+                    atService);
+
+            addBlockchainListeners(blockchainProcessor,
+                    accountService,
+                    assetExchange,
+                    digitalGoodsStoreService,
+                    blockchain,
+                    dbs.getTransactionDb());
+
+            final APITransactionManager apiTransactionManager = new APITransactionManagerImpl(
+                    parameterService,
+                    transactionProcessor,
+                    blockchain,
+                    accountService,
+                    transactionService);
+
+            Peers.init(
+                    timeService,
+                    accountService,
+                    blockchain,
+                    transactionProcessor,
+                    blockchainProcessor,
+                    propertyService,
+                    threadPool);
+            if (params != null) {
+                params.initialize(parameterService, accountService, apiTransactionManager);
+                TransactionType.setNetworkParameters(params);
+            }
+
+            final FeeSuggestionCalculator feeSuggestionCalculator = new FeeSuggestionCalculator(
+                    blockchainProcessor,
+                    stores.getUnconfirmedTransactionStore());
+
+            webServer = new WebServerImpl(new WebServerContext(transactionProcessor,
+                    blockchain,
+                    blockchainProcessor,
+                    parameterService,
+                    accountService,
+                    aliasService,
+                    assetExchange,
+                    escrowService,
+                    digitalGoodsStoreService,
+                    subscriptionService,
+                    atService,
+                    timeService,
+                    economicClustering,
+                    propertyService,
+                    threadPool,
+                    transactionService,
+                    blockService,
+                    generator,
+                    apiTransactionManager,
+                    feeSuggestionCalculator,
+                    deepLinkQrCodeGenerator,
+                    indirectIncomingService,
+                    params));
+            webServer.start();
+
+            if (propertyService.getBoolean(Props.BRS_DEBUG_TRACE_ENABLED)) {
+                DebugTrace.init(propertyService, blockchainProcessor, accountService, assetExchange,
+                        digitalGoodsStoreService);
+            }
+
+            int timeMultiplier = (propertyService.getBoolean(Props.DEV_OFFLINE))
+                    ? Math.max(propertyService.getInt(Props.DEV_TIMEWARP), 1)
+                    : 1;
+
+            threadPool.start(timeMultiplier);
+            if (timeMultiplier > 1) {
+                timeService.setTime(new Time.FasterTime(
+                        Math.max(
+                                timeService.getEpochTime(),
+                                getBlockchain()
+                                        .getLastBlock()
+                                        .getTimestamp()),
+                        timeMultiplier));
+                logger.info("TIME WILL FLOW {} TIMES FASTER!", timeMultiplier);
+            }
+
+            long currentTime = System.currentTimeMillis();
+            logger.info("Initialization took {} ms", currentTime - startTime);
+            logger.info("Signum Multiverse {} started successfully.", VERSION);
+            logger.info("Running network: {}", propertyService.getString(Props.NETWORK_NAME));
+        } catch (Exception e) {
+            logger.error(e.getMessage(), e);
+            System.exit(1);
+        }
+        (new Thread(Signum::commandHandler)).start();
+    }
+
+    private static void addBlockchainListeners(
+            BlockchainProcessor blockchainProcessor,
+            AccountService accountService,
+            AssetExchange assetExchange,
+            DGSGoodsStoreService goodsService,
+            Blockchain blockchain,
+            TransactionDb transactionDb) {
+
+        @SuppressWarnings("checkstyle:linelengthcheck")
+        final AT.HandleATBlockTransactionsListener handleAtBlockTransactionListener = new AT.HandleATBlockTransactionsListener(
+                accountService,
+                transactionDb);
+
+        @SuppressWarnings("checkstyle:linelengthcheck")
+        final DGSGoodsStoreServiceImpl.ExpiredPurchaseListener devNullListener = new DGSGoodsStoreServiceImpl.ExpiredPurchaseListener(
+                accountService,
+                goodsService);
+
+        blockchainProcessor.addListener(
+                handleAtBlockTransactionListener,
+                BlockchainProcessor.Event.AFTER_BLOCK_APPLY);
+        blockchainProcessor.addListener(
+                devNullListener,
+                BlockchainProcessor.Event.AFTER_BLOCK_APPLY);
+    }
+
+    private static void commandHandler() {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+        try {
+            String command;
+            while ((command = reader.readLine()) != null) {
+                logger.debug("received command: >{}<", command);
+                if (command.equals(".shutdown")) {
+                    shutdown(false);
+                    System.exit(0);
+                } else if (command.startsWith(".popoff ")) {
+                    Pattern r = Pattern.compile("^\\.popoff (\\d+)$");
+                    Matcher m = r.matcher(command);
+                    if (m.find()) {
+                        int numBlocks = Integer.parseInt(m.group(1));
+                        if (numBlocks > 0) {
+                            blockchainProcessor.popOffTo(blockchain.getHeight() - numBlocks);
+                        }
+                    }
+                }
+            }
+        } catch (IOException e) {
+            // ignore
+        }
+    }
+
+    private static void shutdown() {
+        shutdown(false);
+    }
+
+    /**
+     * Cleans up the node prior to shutting down.
+     *
+     * @param ignoreDbShutdown if true, shuts down everything but the H2 database.
+     */
+    public static void shutdown(boolean ignoreDbShutdown) {
+        if (!shuttingdown.get()) {
+            logger.info("Shutting down...");
+            logger.info("Do not force exit or kill the node process.");
+        }
+
+        if (webServer != null) {
+            webServer.shutdown();
+        }
+        if (threadPool != null) {
+            Peers.shutdown(threadPool);
+            threadPool.shutdown();
+        }
+        if (!ignoreDbShutdown && !shuttingdown.get()) {
+            shuttingdown.set(true);
+            Db.shutdown();
+        }
+
+        if (dbCacheManager != null) {
+            dbCacheManager.close();
+        }
+        if (blockchainProcessor != null && blockchainProcessor.getOclVerify()) {
+            OCLPoC.destroy();
+        }
+        logger.info("BRS {} stopped.", VERSION);
+        LoggerConfigurator.shutdown();
+    }
+
+    public static PropertyService getPropertyService() {
+        return propertyService;
+    }
+
+    public static FluxCapacitor getFluxCapacitor() {
+        return fluxCapacitor;
+    }
 
 }

--- a/src/brs/Signum.java
+++ b/src/brs/Signum.java
@@ -15,8 +15,6 @@ import brs.deeplink.DeeplinkQRCodeGenerator;
 import brs.feesuggestions.FeeSuggestionCalculator;
 import brs.fluxcapacitor.FluxCapacitor;
 import brs.fluxcapacitor.FluxCapacitorImpl;
-import brs.web.api.http.common.APITransactionManager;
-import brs.web.api.http.common.APITransactionManagerImpl;
 import brs.peer.Peers;
 import brs.props.PropertyService;
 import brs.props.PropertyServiceImpl;
@@ -28,24 +26,24 @@ import brs.util.DownloadCacheImpl;
 import brs.util.LoggerConfigurator;
 import brs.util.ThreadPool;
 import brs.util.Time;
+import brs.web.api.http.common.APITransactionManager;
+import brs.web.api.http.common.APITransactionManagerImpl;
 import brs.web.server.WebServer;
 import brs.web.server.WebServerContext;
 import brs.web.server.WebServerImpl;
-import signum.net.NetworkParameters;
-import signumj.util.SignumUtils;
-
+import java.io.*;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.*;
-import java.util.Properties;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import signum.net.NetworkParameters;
+import signumj.util.SignumUtils;
 
 public final class Signum {
 


### PR DESCRIPTION
This is a proof of concept of using a formatter and style guide to force formatting a specific way.

In this PR, I have added two new files:
1. `eclipse-java-style.xml` - contains auto-formatting rules based on Google java style.
    This file is an Eclipse formatter xml, which many IDEs can use, eclipse and vscode included.
3. `checkstyle.xml` - contains style lints for the CheckStyle program/extension based on Google java style.

I have also formatted Burst.java in accordance with the rules. I think it makes things more readable and explicit.

My suggestion is to adopt the very slightly modified Google java style and format all source code to this new style. The work of reformatting can be done over time, but new code should all be written to the standard.

The CheckStyle program is capable of being used in CI runners and GH actions to force a style check and fail a PR/commit if the format is not correct. I have not enabled this in this proof of concept PR. If this policy is adopted, reformatting of the code base in its entirety will need to be completed before using CI to check, or every build will fail every time.

Future work if approved:
1. Update contributing guide to explain that code must be correctly formatted, and how this can be done in several different editors using the provided files.
3. Reformat the entire code base.
4. Enable CheckStyle in GH with style errors failing the build.

Please look this over and let me know what you think. I tried to make each change type in the PR a separate commit for ease of reading the differences, instead of having to read the entire file changes at once.

Closes #525 if approved.

This is mutually exclusive with #788  at the moment, but I will rebase whichever doesn't get approved first and push corrections.