### PR TITLE
Rename burst to signum

### DIFF
--- a/html/ui/assets/main.css
+++ b/html/ui/assets/main.css
@@ -10,7 +10,7 @@
 body {
   font-family: 'Montserrat', sans-serif;
   height: 100vh;
-  background-color: var(--burst-blue);
+  background-color: var(--signum-blue);
   overflow: hidden;
   color: #fefefe;
 }

--- a/html/ui/assets/vars.css
+++ b/html/ui/assets/vars.css
@@ -1,3 +1,3 @@
 :root {
-    --burst-blue: #00579d
+    --signum-blue: #00579d
 }

--- a/src/brs/Account.java
+++ b/src/brs/Account.java
@@ -225,19 +225,19 @@ public class Account {
   }
 
   private static BurstKey.LongKeyFactory<Account> accountBurstKeyFactory() {
-    return Burst.getStores().getAccountStore().getAccountKeyFactory();
+    return Signum.getStores().getAccountStore().getAccountKeyFactory();
   }
 
   private static BurstKey.LongKeyFactory<Account.Balance> accountBalanceBurstKeyFactory() {
-    return Burst.getStores().getAccountStore().getAccountBalanceKeyFactory();
+    return Signum.getStores().getAccountStore().getAccountBalanceKeyFactory();
   }
 
   private static VersionedBatchEntityTable<Account> accountTable() {
-    return Burst.getStores().getAccountStore().getAccountTable();
+    return Signum.getStores().getAccountStore().getAccountTable();
   }
 
   private static VersionedBatchEntityTable<Account.Balance> accountBalanceTable() {
-    return Burst.getStores().getAccountStore().getAccountBalanceTable();
+    return Signum.getStores().getAccountStore().getAccountBalanceTable();
   }
 
   public static Account getAccount(long id) {
@@ -249,7 +249,7 @@ public class Account {
   }
 
   public static Account.AccountAsset getAccountAssetBalance(long id, long assetId) {
-    return Burst.getStores().getAccountStore().getAccountAsset(id, assetId);
+    return Signum.getStores().getAccountStore().getAccountAsset(id, assetId);
   }
 
   public static long getId(byte[] publicKey) {
@@ -272,7 +272,7 @@ public class Account {
     }
     this.id = id;
     this.nxtKey = accountBurstKeyFactory().newKey(this.id);
-    this.creationHeight = Burst.getBlockchain().getHeight();
+    this.creationHeight = Signum.getBlockchain().getHeight();
   }
 
   protected Account(long id, BurstKey burstKey, int creationHeight) {
@@ -353,7 +353,7 @@ public class Account {
   // or
   // this.publicKey is already set to an array equal to key
   public boolean setOrVerify(byte[] key, int height) {
-    return Burst.getStores().getAccountStore().setOrVerify(this, key, height);
+    return Signum.getStores().getAccountStore().setOrVerify(this, key, height);
   }
 
   public void apply(byte[] key, int height) {

--- a/src/brs/Account.java
+++ b/src/brs/Account.java
@@ -2,7 +2,7 @@ package brs;
 
 import brs.crypto.Crypto;
 import brs.crypto.EncryptedData;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.VersionedBatchEntityTable;
 import brs.util.Convert;
 
@@ -17,7 +17,7 @@ public class Account {
   private static final Logger logger = Logger.getLogger(Account.class.getSimpleName());
 
   public final long id;
-  public final BurstKey nxtKey;
+  public final SignumKey nxtKey;
   private final int creationHeight;
   private byte[] publicKey;
   private int keyHeight;
@@ -28,7 +28,7 @@ public class Account {
 
   public static class Balance {
     public final long id;
-    public final BurstKey nxtKey;
+    public final SignumKey nxtKey;
 
     protected long balanceNQT;
     protected long unconfirmedBalanceNQT;
@@ -106,12 +106,12 @@ public class Account {
   public static class AccountAsset {
     public final long accountId;
     public final long assetId;
-    public final BurstKey burstKey;
+    public final SignumKey burstKey;
     private long quantityQNT;
     private long unconfirmedQuantityQNT;
     private boolean isTreasury;
 
-    protected AccountAsset(long accountId, long assetId, long quantityQNT, long unconfirmedQuantityQNT, BurstKey burstKey) {
+    protected AccountAsset(long accountId, long assetId, long quantityQNT, long unconfirmedQuantityQNT, SignumKey burstKey) {
       this.accountId = accountId;
       this.assetId = assetId;
       this.quantityQNT = quantityQNT;
@@ -120,7 +120,7 @@ public class Account {
       this.isTreasury = false;
     }
 
-    public AccountAsset(BurstKey burstKey, long accountId, long assetId, long quantityQNT, long unconfirmedQuantityQNT) {
+    public AccountAsset(SignumKey burstKey, long accountId, long assetId, long quantityQNT, long unconfirmedQuantityQNT) {
       this.accountId = accountId;
       this.assetId = assetId;
       this.burstKey = burstKey;
@@ -184,9 +184,9 @@ public class Account {
     private Long prevRecipientId;
     private Long recipientId;
     private int fromHeight;
-    public final BurstKey burstKey;
+    public final SignumKey burstKey;
 
-    public RewardRecipientAssignment(Long accountId, Long prevRecipientId, Long recipientId, int fromHeight, BurstKey burstKey) {
+    public RewardRecipientAssignment(Long accountId, Long prevRecipientId, Long recipientId, int fromHeight, SignumKey burstKey) {
       this.accountId = accountId;
       this.prevRecipientId = prevRecipientId;
       this.recipientId = recipientId;
@@ -224,11 +224,11 @@ public class Account {
 
   }
 
-  private static BurstKey.LongKeyFactory<Account> accountBurstKeyFactory() {
+  private static SignumKey.LongKeyFactory<Account> accountBurstKeyFactory() {
     return Signum.getStores().getAccountStore().getAccountKeyFactory();
   }
 
-  private static BurstKey.LongKeyFactory<Account.Balance> accountBalanceBurstKeyFactory() {
+  private static SignumKey.LongKeyFactory<Account.Balance> accountBalanceBurstKeyFactory() {
     return Signum.getStores().getAccountStore().getAccountBalanceKeyFactory();
   }
 
@@ -275,7 +275,7 @@ public class Account {
     this.creationHeight = Signum.getBlockchain().getHeight();
   }
 
-  protected Account(long id, BurstKey burstKey, int creationHeight) {
+  protected Account(long id, SignumKey burstKey, int creationHeight) {
     if (id != Crypto.rsDecode(Crypto.rsEncode(id))) {
       logger.log(Level.INFO, "CRITICAL ERROR: Reed-Solomon encoding fails for {0}", id);
     }

--- a/src/brs/Account.java
+++ b/src/brs/Account.java
@@ -36,7 +36,7 @@ public class Account {
 
     public Balance(long id) {
       this.id = id;
-      this.nxtKey = accountBurstKeyFactory().newKey(this.id);
+      this.nxtKey = accountSignumKeyFactory().newKey(this.id);
     }
 
     public void setForgedBalanceNQT(long forgedBalanceNQT) {
@@ -106,24 +106,24 @@ public class Account {
   public static class AccountAsset {
     public final long accountId;
     public final long assetId;
-    public final SignumKey burstKey;
+    public final SignumKey signumKey;
     private long quantityQNT;
     private long unconfirmedQuantityQNT;
     private boolean isTreasury;
 
-    protected AccountAsset(long accountId, long assetId, long quantityQNT, long unconfirmedQuantityQNT, SignumKey burstKey) {
+    protected AccountAsset(long accountId, long assetId, long quantityQNT, long unconfirmedQuantityQNT, SignumKey signumKey) {
       this.accountId = accountId;
       this.assetId = assetId;
       this.quantityQNT = quantityQNT;
       this.unconfirmedQuantityQNT = unconfirmedQuantityQNT;
-      this.burstKey = burstKey;
+      this.signumKey = signumKey;
       this.isTreasury = false;
     }
 
-    public AccountAsset(SignumKey burstKey, long accountId, long assetId, long quantityQNT, long unconfirmedQuantityQNT) {
+    public AccountAsset(SignumKey signumKey, long accountId, long assetId, long quantityQNT, long unconfirmedQuantityQNT) {
       this.accountId = accountId;
       this.assetId = assetId;
-      this.burstKey = burstKey;
+      this.signumKey = signumKey;
       this.quantityQNT = quantityQNT;
       this.unconfirmedQuantityQNT = unconfirmedQuantityQNT;
       this.isTreasury = false;
@@ -184,14 +184,14 @@ public class Account {
     private Long prevRecipientId;
     private Long recipientId;
     private int fromHeight;
-    public final SignumKey burstKey;
+    public final SignumKey signumKey;
 
-    public RewardRecipientAssignment(Long accountId, Long prevRecipientId, Long recipientId, int fromHeight, SignumKey burstKey) {
+    public RewardRecipientAssignment(Long accountId, Long prevRecipientId, Long recipientId, int fromHeight, SignumKey signumKey) {
       this.accountId = accountId;
       this.prevRecipientId = prevRecipientId;
       this.recipientId = recipientId;
       this.fromHeight = fromHeight;
-      this.burstKey = burstKey;
+      this.signumKey = signumKey;
     }
 
     public long getAccountId() {
@@ -224,11 +224,11 @@ public class Account {
 
   }
 
-  private static SignumKey.LongKeyFactory<Account> accountBurstKeyFactory() {
+  private static SignumKey.LongKeyFactory<Account> accountSignumKeyFactory() {
     return Signum.getStores().getAccountStore().getAccountKeyFactory();
   }
 
-  private static SignumKey.LongKeyFactory<Account.Balance> accountBalanceBurstKeyFactory() {
+  private static SignumKey.LongKeyFactory<Account.Balance> accountBalanceSignumKeyFactory() {
     return Signum.getStores().getAccountStore().getAccountBalanceKeyFactory();
   }
 
@@ -241,11 +241,11 @@ public class Account {
   }
 
   public static Account getAccount(long id) {
-    return id == 0 ? null : accountTable().get(accountBurstKeyFactory().newKey(id));
+    return id == 0 ? null : accountTable().get(accountSignumKeyFactory().newKey(id));
   }
 
   public static Account.Balance getAccountBalance(long id) {
-    return id == 0 ? null : accountBalanceTable().get(accountBalanceBurstKeyFactory().newKey(id));
+    return id == 0 ? null : accountBalanceTable().get(accountBalanceSignumKeyFactory().newKey(id));
   }
 
   public static Account.AccountAsset getAccountAssetBalance(long id, long assetId) {
@@ -271,16 +271,16 @@ public class Account {
       logger.log(Level.INFO, "CRITICAL ERROR: Reed-Solomon encoding fails for {0}", id);
     }
     this.id = id;
-    this.nxtKey = accountBurstKeyFactory().newKey(this.id);
+    this.nxtKey = accountSignumKeyFactory().newKey(this.id);
     this.creationHeight = Signum.getBlockchain().getHeight();
   }
 
-  protected Account(long id, SignumKey burstKey, int creationHeight) {
+  protected Account(long id, SignumKey signumKey, int creationHeight) {
     if (id != Crypto.rsDecode(Crypto.rsEncode(id))) {
       logger.log(Level.INFO, "CRITICAL ERROR: Reed-Solomon encoding fails for {0}", id);
     }
     this.id = id;
-    this.nxtKey = burstKey;
+    this.nxtKey = signumKey;
     this.creationHeight = creationHeight;
   }
 

--- a/src/brs/Alias.java
+++ b/src/brs/Alias.java
@@ -1,18 +1,18 @@
 package brs;
 
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 
 public class Alias {
 
   private long accountId;
   private final long id;
-  public final BurstKey dbKey;
+  public final SignumKey dbKey;
   private final String aliasName;
   private final Long tld;
   private String aliasURI;
   private int timestamp;
 
-  private Alias(BurstKey dbKey, long id, long accountId, String aliasName, Long tld, String aliasURI, int timestamp) {
+  private Alias(SignumKey dbKey, long id, long accountId, String aliasName, Long tld, String aliasURI, int timestamp) {
     this.id = id;
     this.dbKey = dbKey;
     this.accountId = accountId;
@@ -22,7 +22,7 @@ public class Alias {
     this.timestamp = timestamp;
   }
 
-  protected Alias(long id, long accountId, String aliasName, Long tld, String aliasURI, int timestamp, BurstKey dbKey) {
+  protected Alias(long id, long accountId, String aliasName, Long tld, String aliasURI, int timestamp, SignumKey dbKey) {
     this.id = id;
     this.dbKey = dbKey;
     this.accountId = accountId;
@@ -32,12 +32,12 @@ public class Alias {
     this.timestamp = timestamp;
   }
 
-  public Alias(long aliasId, BurstKey dbKey, Transaction transaction, Attachment.MessagingAliasAssignment attachment) {
+  public Alias(long aliasId, SignumKey dbKey, Transaction transaction, Attachment.MessagingAliasAssignment attachment) {
     this(dbKey, aliasId, transaction.getSenderId(), attachment.getAliasName(), attachment.getTLD(), attachment.getAliasURI(),
         transaction.getBlockTimestamp());
   }
   
-  public Alias(long aliasId, BurstKey dbKey, Transaction transaction, Attachment.MessagingTLDAssignment attachment) {
+  public Alias(long aliasId, SignumKey dbKey, Transaction transaction, Attachment.MessagingTLDAssignment attachment) {
     this(dbKey, aliasId, transaction == null ? 0L : transaction.getSenderId(), attachment.getTLDName(), null, "",
         transaction == null ? 0 : transaction.getBlockTimestamp());
   }
@@ -83,16 +83,16 @@ public class Alias {
     private long priceNQT;
     private long buyerId;
     private final long aliasId;
-    public final BurstKey dbKey;
+    public final SignumKey dbKey;
 
-    public Offer(BurstKey dbKey, long aliasId, long priceNQT, long buyerId) {
+    public Offer(SignumKey dbKey, long aliasId, long priceNQT, long buyerId) {
       this.dbKey = dbKey;
       this.priceNQT = priceNQT;
       this.buyerId = buyerId;
       this.aliasId = aliasId;
     }
 
-    protected Offer(long aliasId, long priceNQT, long buyerId, BurstKey nxtKey) {
+    protected Offer(long aliasId, long priceNQT, long buyerId, SignumKey nxtKey) {
       this.priceNQT = priceNQT;
       this.buyerId = buyerId;
       this.aliasId = aliasId;

--- a/src/brs/Appendix.java
+++ b/src/brs/Appendix.java
@@ -34,7 +34,7 @@ public interface Appendix {
     }
 
     AbstractAppendix(int blockchainHeight) {
-      this.version = (byte)(Burst.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE, blockchainHeight) ? 1 : 0);
+      this.version = (byte)(Signum.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE, blockchainHeight) ? 1 : 0);
     }
 
     protected abstract String getAppendixName();
@@ -400,15 +400,15 @@ public interface Appendix {
       if (recipientAccount != null && recipientAccount.getPublicKey() != null && ! Arrays.equals(publicKey, recipientAccount.getPublicKey())) {
         throw new BurstException.NotCurrentlyValidException("A different public key for this account has already been announced");
       }
-      if(Burst.getFluxCapacitor().getValue(FluxValues.PK_FREEZE2)){
+      if(Signum.getFluxCapacitor().getValue(FluxValues.PK_FREEZE2)){
         if(recipientAccount != null && recipientAccount.getPublicKey() == null
-        && Burst.getBlockchain().getHeight() - recipientAccount.getCreationHeight() > Burst.getPropertyService().getInt(Props.PK_BLOCKS_PAST)) {
+        && Signum.getBlockchain().getHeight() - recipientAccount.getCreationHeight() > Signum.getPropertyService().getInt(Props.PK_BLOCKS_PAST)) {
           throw new BurstException.NotCurrentlyValidException("Setting a new key for an old inactivated account");
         }
       }
       else // TODO: the conditional below can be removed after PK_FREEZE2 is activated
-      if(Burst.getFluxCapacitor().getValue(FluxValues.PK_FREEZE)
-        && Burst.getBlockchain().getHeight() - recipientAccount.getCreationHeight() > Burst.getPropertyService().getInt(Props.PK_BLOCKS_PAST)) {
+      if(Signum.getFluxCapacitor().getValue(FluxValues.PK_FREEZE)
+        && Signum.getBlockchain().getHeight() - recipientAccount.getCreationHeight() > Signum.getPropertyService().getInt(Props.PK_BLOCKS_PAST)) {
           throw new BurstException.NotCurrentlyValidException("Setting a new key for an old inactivated account");
       }
     }

--- a/src/brs/Appendix.java
+++ b/src/brs/Appendix.java
@@ -77,7 +77,7 @@ public interface Appendix {
       return transactionVersion == 0 ? version == 0 : version > 0;
     }
 
-    public abstract void validate(Transaction transaction) throws BurstException.ValidationException;
+    public abstract void validate(Transaction transaction) throws SignumException.ValidationException;
 
     public abstract void apply(Transaction transaction, Account senderAccount, Account recipientAccount);
   }
@@ -94,7 +94,7 @@ public interface Appendix {
     private final byte[] messageBytes;
     private final boolean isText;
 
-    public Message(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+    public Message(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
       super(buffer, transactionVersion);
       int messageLength = buffer.getInt();
       this.isText = messageLength < 0; // ugly hack
@@ -102,7 +102,7 @@ public interface Appendix {
         messageLength &= Integer.MAX_VALUE;
       }
       if (messageLength > Constants.MAX_ARBITRARY_MESSAGE_LENGTH) {
-        throw new BurstException.NotValidException("Invalid arbitrary message length: " + messageLength);
+        throw new SignumException.NotValidException("Invalid arbitrary message length: " + messageLength);
       }
       this.messageBytes = new byte[messageLength];
       buffer.get(this.messageBytes);
@@ -150,15 +150,15 @@ public interface Appendix {
     }
 
     @Override
-    public void validate(Transaction transaction) throws BurstException.ValidationException {
+    public void validate(Transaction transaction) throws SignumException.ValidationException {
       if (this.isText && transaction.getVersion() == 0) {
-        throw new BurstException.NotValidException("Text messages not yet enabled");
+        throw new SignumException.NotValidException("Text messages not yet enabled");
       }
       if (transaction.getVersion() == 0 && transaction.getAttachment() != Attachment.ARBITRARY_MESSAGE) {
-        throw new BurstException.NotValidException("Message attachments not enabled for version 0 transactions");
+        throw new SignumException.NotValidException("Message attachments not enabled for version 0 transactions");
       }
       if (messageBytes.length > Constants.MAX_ARBITRARY_MESSAGE_LENGTH) {
-        throw new BurstException.NotValidException("Invalid arbitrary message length: " + messageBytes.length);
+        throw new SignumException.NotValidException("Invalid arbitrary message length: " + messageBytes.length);
       }
     }
 
@@ -181,7 +181,7 @@ public interface Appendix {
     private final EncryptedData encryptedData;
     private final boolean isText;
 
-    private AbstractEncryptedMessage(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+    private AbstractEncryptedMessage(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
       super(buffer, transactionVersion);
       int length = buffer.getInt();
       this.isText = length < 0;
@@ -225,13 +225,13 @@ public interface Appendix {
     }
 
     @Override
-    public void validate(Transaction transaction) throws BurstException.ValidationException {
+    public void validate(Transaction transaction) throws SignumException.ValidationException {
       if (encryptedData.getData().length > Constants.MAX_ENCRYPTED_MESSAGE_LENGTH) {
-        throw new BurstException.NotValidException("Max encrypted message length exceeded");
+        throw new SignumException.NotValidException("Max encrypted message length exceeded");
       }
       if ((encryptedData.getNonce().length != 32 && encryptedData.getData().length > 0)
           || (encryptedData.getNonce().length != 0 && encryptedData.getData().length == 0)) {
-        throw new BurstException.NotValidException("Invalid nonce length " + encryptedData.getNonce().length);
+        throw new SignumException.NotValidException("Invalid nonce length " + encryptedData.getNonce().length);
       }
     }
 
@@ -255,7 +255,7 @@ public interface Appendix {
       return new EncryptedMessage(attachmentData);
     }
 
-    public EncryptedMessage(ByteBuffer buffer, byte transactionVersion) throws BurstException.ValidationException {
+    public EncryptedMessage(ByteBuffer buffer, byte transactionVersion) throws SignumException.ValidationException {
       super(buffer, transactionVersion);
     }
 
@@ -280,13 +280,13 @@ public interface Appendix {
     }
 
     @Override
-    public void validate(Transaction transaction) throws BurstException.ValidationException {
+    public void validate(Transaction transaction) throws SignumException.ValidationException {
       super.validate(transaction);
       if (! transaction.getType().hasRecipient()) {
-        throw new BurstException.NotValidException("Encrypted messages cannot be attached to transactions with no recipient");
+        throw new SignumException.NotValidException("Encrypted messages cannot be attached to transactions with no recipient");
       }
       if (transaction.getVersion() == 0) {
-        throw new BurstException.NotValidException("Encrypted message attachments not enabled for version 0 transactions");
+        throw new SignumException.NotValidException("Encrypted message attachments not enabled for version 0 transactions");
       }
     }
   }
@@ -300,7 +300,7 @@ public interface Appendix {
       return new EncryptToSelfMessage(attachmentData);
     }
 
-    public  EncryptToSelfMessage(ByteBuffer buffer, byte transactionVersion) throws BurstException.ValidationException {
+    public  EncryptToSelfMessage(ByteBuffer buffer, byte transactionVersion) throws SignumException.ValidationException {
       super(buffer, transactionVersion);
     }
 
@@ -325,10 +325,10 @@ public interface Appendix {
     }
 
     @Override
-    public void validate(Transaction transaction) throws BurstException.ValidationException {
+    public void validate(Transaction transaction) throws SignumException.ValidationException {
       super.validate(transaction);
       if (transaction.getVersion() == 0) {
-        throw new BurstException.NotValidException("Encrypt-to-self message attachments not enabled for version 0 transactions");
+        throw new SignumException.NotValidException("Encrypt-to-self message attachments not enabled for version 0 transactions");
       }
     }
 
@@ -382,34 +382,34 @@ public interface Appendix {
     }
 
     @Override
-    public void validate(Transaction transaction) throws BurstException.ValidationException {
+    public void validate(Transaction transaction) throws SignumException.ValidationException {
       if (! transaction.getType().hasRecipient()) {
-        throw new BurstException.NotValidException("PublicKeyAnnouncement cannot be attached to transactions with no recipient");
+        throw new SignumException.NotValidException("PublicKeyAnnouncement cannot be attached to transactions with no recipient");
       }
       if (publicKey.length != 32) {
-        throw new BurstException.NotValidException("Invalid recipient public key length: " + Convert.toHexString(publicKey));
+        throw new SignumException.NotValidException("Invalid recipient public key length: " + Convert.toHexString(publicKey));
       }
       long recipientId = transaction.getRecipientId();
       if (Account.getId(this.publicKey) != recipientId) {
-        throw new BurstException.NotValidException("Announced public key does not match recipient accountId");
+        throw new SignumException.NotValidException("Announced public key does not match recipient accountId");
       }
       if (transaction.getVersion() == 0) {
-        throw new BurstException.NotValidException("Public key announcements not enabled for version 0 transactions");
+        throw new SignumException.NotValidException("Public key announcements not enabled for version 0 transactions");
       }
       Account recipientAccount = Account.getAccount(recipientId);
       if (recipientAccount != null && recipientAccount.getPublicKey() != null && ! Arrays.equals(publicKey, recipientAccount.getPublicKey())) {
-        throw new BurstException.NotCurrentlyValidException("A different public key for this account has already been announced");
+        throw new SignumException.NotCurrentlyValidException("A different public key for this account has already been announced");
       }
       if(Signum.getFluxCapacitor().getValue(FluxValues.PK_FREEZE2)){
         if(recipientAccount != null && recipientAccount.getPublicKey() == null
         && Signum.getBlockchain().getHeight() - recipientAccount.getCreationHeight() > Signum.getPropertyService().getInt(Props.PK_BLOCKS_PAST)) {
-          throw new BurstException.NotCurrentlyValidException("Setting a new key for an old inactivated account");
+          throw new SignumException.NotCurrentlyValidException("Setting a new key for an old inactivated account");
         }
       }
       else // TODO: the conditional below can be removed after PK_FREEZE2 is activated
       if(Signum.getFluxCapacitor().getValue(FluxValues.PK_FREEZE)
         && Signum.getBlockchain().getHeight() - recipientAccount.getCreationHeight() > Signum.getPropertyService().getInt(Props.PK_BLOCKS_PAST)) {
-          throw new BurstException.NotCurrentlyValidException("Setting a new key for an old inactivated account");
+          throw new SignumException.NotCurrentlyValidException("Setting a new key for an old inactivated account");
       }
     }
 

--- a/src/brs/Asset.java
+++ b/src/brs/Asset.java
@@ -2,12 +2,12 @@ package brs;
 
 import java.util.Collection;
 
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 
 public class Asset {
 
   private final long assetId;
-  public final BurstKey dbKey;
+  public final SignumKey dbKey;
   private final long issuerId;
   private long accountId;
   private final String name;
@@ -16,7 +16,7 @@ public class Asset {
   private final byte decimals;
   private final boolean mintable;
 
-  protected Asset(long assetId, BurstKey dbKey, long accountId, String name, String description, long quantityQNT, byte decimals, boolean mintable) {
+  protected Asset(long assetId, SignumKey dbKey, long accountId, String name, String description, long quantityQNT, byte decimals, boolean mintable) {
     this.assetId = assetId;
     this.dbKey = dbKey;
     this.accountId = accountId;
@@ -28,7 +28,7 @@ public class Asset {
     this.mintable = mintable;
   }
 
-  public Asset(BurstKey dbKey, long assetId, long accountId, Attachment.ColoredCoinsAssetIssuance attachment) {
+  public Asset(SignumKey dbKey, long assetId, long accountId, Attachment.ColoredCoinsAssetIssuance attachment) {
     this.dbKey = dbKey;
     this.assetId = assetId;
     this.accountId = accountId;

--- a/src/brs/Asset.java
+++ b/src/brs/Asset.java
@@ -41,7 +41,7 @@ public class Asset {
   }
 
   public void updateCurrentOwnerAccount() {
-    Blockchain blockchain = Burst.getBlockchain();
+    Blockchain blockchain = Signum.getBlockchain();
 
     Transaction issuanceTransaction = blockchain.getTransaction(assetId);
     if(issuanceTransaction == null){

--- a/src/brs/AssetTransfer.java
+++ b/src/brs/AssetTransfer.java
@@ -1,6 +1,6 @@
 package brs;
 
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 
 public class AssetTransfer {
 
@@ -9,7 +9,7 @@ public class AssetTransfer {
   }
 
   private final long id;
-  private final BurstKey dbKey;
+  private final SignumKey dbKey;
   private final long assetId;
   private final int height;
   private final long senderId;
@@ -17,7 +17,7 @@ public class AssetTransfer {
   private final long quantityQNT;
   private final int timestamp;
 
-  public AssetTransfer(BurstKey dbKey, Transaction transaction, long assetId, long quantityQNT) {
+  public AssetTransfer(SignumKey dbKey, Transaction transaction, long assetId, long quantityQNT) {
     this.dbKey = dbKey;
     this.id = transaction.getId();
     this.height = transaction.getHeight();
@@ -28,7 +28,7 @@ public class AssetTransfer {
     this.timestamp = transaction.getBlockTimestamp();
   }
 
-  protected AssetTransfer(long id, BurstKey dbKey, long assetId, int height, long senderId, long recipientId, long quantityQNT, int timestamp) {
+  protected AssetTransfer(long id, SignumKey dbKey, long assetId, int height, long senderId, long recipientId, long quantityQNT, int timestamp) {
     this.id = id;
     this.dbKey = dbKey;
     this.assetId = assetId;
@@ -39,7 +39,7 @@ public class AssetTransfer {
     this.timestamp = timestamp;
   }
 
-  public BurstKey getDbKey(){
+  public SignumKey getDbKey(){
     return dbKey;
   }
 

--- a/src/brs/Attachment.java
+++ b/src/brs/Attachment.java
@@ -382,8 +382,8 @@ public interface Attachment extends Appendix {
     }
 
     public MessagingAliasAssignment(String aliasName, String aliasURI, long tld, int blockchainHeight) {
-      super((byte)((Burst.getFluxCapacitor().getValue(FluxValues.SMART_ALIASES, blockchainHeight) ? 2 :
-            Burst.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE, blockchainHeight) ? 1 : 0)));
+      super((byte)((Signum.getFluxCapacitor().getValue(FluxValues.SMART_ALIASES, blockchainHeight) ? 2 :
+            Signum.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE, blockchainHeight) ? 1 : 0)));
 
       this.aliasName = aliasName.trim();
       this.aliasURI = aliasURI.trim();
@@ -527,8 +527,8 @@ public interface Attachment extends Appendix {
     }
 
     public MessagingAliasSell(long aliasId, String aliasName, long priceNQT, int blockchainHeight) {
-      super((byte)((Burst.getFluxCapacitor().getValue(FluxValues.SMART_ALIASES, blockchainHeight) ? 2 :
-            Burst.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE, blockchainHeight) ? 1 : 0)));
+      super((byte)((Signum.getFluxCapacitor().getValue(FluxValues.SMART_ALIASES, blockchainHeight) ? 2 :
+            Signum.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE, blockchainHeight) ? 1 : 0)));
       this.aliasId = aliasId;
       this.aliasName = aliasName;
       this.priceNQT = priceNQT;
@@ -606,8 +606,8 @@ public interface Attachment extends Appendix {
     }
 
     public MessagingAliasBuy(long aliasId, String aliasName, int blockchainHeight) {
-      super((byte)((Burst.getFluxCapacitor().getValue(FluxValues.SMART_ALIASES, blockchainHeight) ? 2 :
-            Burst.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE, blockchainHeight) ? 1 : 0)));
+      super((byte)((Signum.getFluxCapacitor().getValue(FluxValues.SMART_ALIASES, blockchainHeight) ? 2 :
+            Signum.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE, blockchainHeight) ? 1 : 0)));
 
       this.aliasId = aliasId;
       this.aliasName = aliasName;
@@ -751,7 +751,7 @@ public interface Attachment extends Appendix {
 
     public ColoredCoinsAssetIssuance(String name, String description, long quantityQNT, byte decimals, int blockchainHeight, boolean mintable) {
       super((byte)(mintable ? 2 :
-        Burst.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE, blockchainHeight) ? 1 : 0));
+        Signum.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE, blockchainHeight) ? 1 : 0));
       this.name = name;
       this.description = Convert.nullToEmpty(description);
       this.quantityQNT = quantityQNT;

--- a/src/brs/Attachment.java
+++ b/src/brs/Attachment.java
@@ -41,7 +41,7 @@ public interface Attachment extends Appendix {
     }
 
     @Override
-    public final void validate(Transaction transaction) throws BurstException.ValidationException {
+    public final void validate(Transaction transaction) throws SignumException.ValidationException {
       getTransactionType().validateAttachment(transaction);
     }
 
@@ -110,7 +110,7 @@ public interface Attachment extends Appendix {
 
     private final ArrayList<ArrayList<Long>> recipients = new ArrayList<>();
 
-    PaymentMultiOutCreation(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+    PaymentMultiOutCreation(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
       super(buffer, transactionVersion);
 
       int numberOfRecipients = Byte.toUnsignedInt(buffer.get());
@@ -121,21 +121,21 @@ public interface Attachment extends Appendix {
         long amountNQT = buffer.getLong();
 
         if (recipientOf.containsKey(recipientId))
-          throw new BurstException.NotValidException("Duplicate recipient on multi out transaction");
+          throw new SignumException.NotValidException("Duplicate recipient on multi out transaction");
 
         if (amountNQT <= 0)
-          throw new BurstException.NotValidException("Insufficient amountNQT on multi out transaction");
+          throw new SignumException.NotValidException("Insufficient amountNQT on multi out transaction");
 
         recipientOf.put(recipientId, true);
         this.recipients.add(new ArrayList<>(Arrays.asList(recipientId, amountNQT)));
       }
       if (recipients.size() > Constants.MAX_MULTI_OUT_RECIPIENTS || recipients.size() <= 1) {
-        throw new BurstException.NotValidException(
+        throw new SignumException.NotValidException(
             "Invalid number of recipients listed on multi out transaction");
       }
     }
 
-    PaymentMultiOutCreation(JsonObject attachmentData) throws BurstException.NotValidException {
+    PaymentMultiOutCreation(JsonObject attachmentData) throws SignumException.NotValidException {
       super(attachmentData);
 
       JsonArray receipientsJson = JSON.getAsJsonArray(attachmentData.get(RECIPIENTS_PARAMETER));
@@ -147,20 +147,20 @@ public interface Attachment extends Appendix {
         long recipientId = new BigInteger(JSON.getAsString(recipient.get(0))).longValue();
         long amountNQT = JSON.getAsLong(recipient.get(1));
         if (recipientOf.containsKey(recipientId))
-          throw new BurstException.NotValidException("Duplicate recipient on multi out transaction");
+          throw new SignumException.NotValidException("Duplicate recipient on multi out transaction");
 
         if (amountNQT  <=0)
-          throw new BurstException.NotValidException("Insufficient amountNQT on multi out transaction");
+          throw new SignumException.NotValidException("Insufficient amountNQT on multi out transaction");
 
         recipientOf.put(recipientId, true);
         this.recipients.add(new ArrayList<>(Arrays.asList(recipientId, amountNQT)));
       }
       if (receipientsJson.size() > Constants.MAX_MULTI_OUT_RECIPIENTS || receipientsJson.size() <= 1) {
-        throw new BurstException.NotValidException("Invalid number of recipients listed on multi out transaction");
+        throw new SignumException.NotValidException("Invalid number of recipients listed on multi out transaction");
       }
     }
 
-    public PaymentMultiOutCreation(Collection<Entry<String, Long>> recipients, int blockchainHeight) throws BurstException.NotValidException {
+    public PaymentMultiOutCreation(Collection<Entry<String, Long>> recipients, int blockchainHeight) throws SignumException.NotValidException {
       super(blockchainHeight);
 
       HashMap<Long,Boolean> recipientOf = new HashMap<>();
@@ -168,16 +168,16 @@ public interface Attachment extends Appendix {
         long recipientId = (new BigInteger(recipient.getKey())).longValue();
         long amountNQT   = recipient.getValue();
         if (recipientOf.containsKey(recipientId))
-          throw new BurstException.NotValidException("Duplicate recipient on multi out transaction");
+          throw new SignumException.NotValidException("Duplicate recipient on multi out transaction");
 
         if (amountNQT <= 0)
-          throw new BurstException.NotValidException("Insufficient amountNQT on multi out transaction");
+          throw new SignumException.NotValidException("Insufficient amountNQT on multi out transaction");
 
         recipientOf.put(recipientId, true);
         this.recipients.add(new ArrayList<>(Arrays.asList(recipientId, amountNQT)));
       }
       if (recipients.size() > Constants.MAX_MULTI_OUT_RECIPIENTS || recipients.size() <= 1) {
-        throw new BurstException.NotValidException("Invalid number of recipients listed on multi out transaction");
+        throw new SignumException.NotValidException("Invalid number of recipients listed on multi out transaction");
       }
     }
 
@@ -235,7 +235,7 @@ public interface Attachment extends Appendix {
 
     private final ArrayList<Long> recipients = new ArrayList<>();
 
-    PaymentMultiSameOutCreation(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+    PaymentMultiSameOutCreation(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
       super(buffer, transactionVersion);
 
       int numberOfRecipients = Byte.toUnsignedInt(buffer.get());
@@ -245,18 +245,18 @@ public interface Attachment extends Appendix {
         long recipientId = buffer.getLong();
 
         if (recipientOf.containsKey(recipientId))
-          throw new BurstException.NotValidException("Duplicate recipient on multi same out transaction");
+          throw new SignumException.NotValidException("Duplicate recipient on multi same out transaction");
 
         recipientOf.put(recipientId, true);
         this.recipients.add(recipientId);
       }
       if (recipients.size() > Constants.MAX_MULTI_SAME_OUT_RECIPIENTS || recipients.size() <= 1) {
-        throw new BurstException.NotValidException(
+        throw new SignumException.NotValidException(
             "Invalid number of recipients listed on multi same out transaction");
       }
     }
 
-    PaymentMultiSameOutCreation(JsonObject attachmentData) throws BurstException.NotValidException {
+    PaymentMultiSameOutCreation(JsonObject attachmentData) throws SignumException.NotValidException {
       super(attachmentData);
 
       JsonArray recipientsJson = JSON.getAsJsonArray(attachmentData.get(RECIPIENTS_PARAMETER));
@@ -265,30 +265,30 @@ public interface Attachment extends Appendix {
       for (JsonElement recipient : recipientsJson) {
         long recipientId = new BigInteger(JSON.getAsString(recipient)).longValue();
         if (recipientOf.containsKey(recipientId))
-          throw new BurstException.NotValidException("Duplicate recipient on multi same out transaction");
+          throw new SignumException.NotValidException("Duplicate recipient on multi same out transaction");
 
         recipientOf.put(recipientId, true);
         this.recipients.add(recipientId);
       }
       if (recipientsJson.size() > Constants.MAX_MULTI_SAME_OUT_RECIPIENTS || recipientsJson.size() <= 1) {
-        throw new BurstException.NotValidException(
+        throw new SignumException.NotValidException(
             "Invalid number of recipients listed on multi same out transaction");
       }
     }
 
-    public PaymentMultiSameOutCreation(Collection<Long> recipients, int blockchainHeight) throws BurstException.NotValidException {
+    public PaymentMultiSameOutCreation(Collection<Long> recipients, int blockchainHeight) throws SignumException.NotValidException {
       super(blockchainHeight);
 
       HashMap<Long,Boolean> recipientOf = new HashMap<>();
       for(Long recipientId : recipients ) {
         if (recipientOf.containsKey(recipientId))
-          throw new BurstException.NotValidException("Duplicate recipient on multi same out transaction");
+          throw new SignumException.NotValidException("Duplicate recipient on multi same out transaction");
 
         recipientOf.put(recipientId, true);
         this.recipients.add(recipientId);
       }
       if (recipients.size() > Constants.MAX_MULTI_SAME_OUT_RECIPIENTS || recipients.size() <= 1) {
-        throw new BurstException.NotValidException(
+        throw new SignumException.NotValidException(
             "Invalid number of recipients listed on multi same out transaction");
       }
     }
@@ -363,7 +363,7 @@ public interface Attachment extends Appendix {
     private final String aliasURI;
     private long tld;
 
-    MessagingAliasAssignment(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+    MessagingAliasAssignment(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
       super(buffer, transactionVersion);
       aliasName = Convert.readString(buffer, buffer.get(), Constants.MAX_ALIAS_LENGTH).trim();
       aliasURI = Convert.readString(buffer, buffer.getShort(), Constants.MAX_ALIAS_URI_LENGTH).trim();
@@ -445,7 +445,7 @@ public interface Attachment extends Appendix {
 
     private final String tldName;
 
-    MessagingTLDAssignment(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+    MessagingTLDAssignment(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
       super(buffer, transactionVersion);
       tldName = Convert.readString(buffer, buffer.get(), Constants.MAX_TLD_LENGTH).trim();
     }
@@ -498,7 +498,7 @@ public interface Attachment extends Appendix {
     private long aliasId;
     private final long priceNQT;
 
-    MessagingAliasSell(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+    MessagingAliasSell(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
       super(buffer, transactionVersion);
       if(getVersion() > 1) {
         this.aliasId = buffer.getLong();
@@ -587,7 +587,7 @@ public interface Attachment extends Appendix {
     private String aliasName;
     private long aliasId;
 
-    MessagingAliasBuy(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+    MessagingAliasBuy(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
       super(buffer, transactionVersion);
       if(getVersion() > 1) {
         aliasId = buffer.getLong();
@@ -659,7 +659,7 @@ public interface Attachment extends Appendix {
     private final String name;
     private final String description;
 
-    MessagingAccountInfo(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+    MessagingAccountInfo(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
       super(buffer, transactionVersion);
       this.name = Convert.readString(buffer, buffer.get(), Constants.MAX_ACCOUNT_NAME_LENGTH);
       this.description = Convert.readString(buffer, buffer.getShort(), Constants.MAX_ACCOUNT_DESCRIPTION_LENGTH);
@@ -726,7 +726,7 @@ public interface Attachment extends Appendix {
     private final byte decimals;
     private final boolean mintable;
 
-    ColoredCoinsAssetIssuance(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+    ColoredCoinsAssetIssuance(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
       super(buffer, transactionVersion);
       this.name = Convert.readString(buffer, buffer.get(), Constants.MAX_ASSET_NAME_LENGTH);
       this.description = Convert.readString(buffer, buffer.getShort(), Constants.MAX_ASSET_DESCRIPTION_LENGTH);
@@ -827,7 +827,7 @@ public interface Attachment extends Appendix {
     private final long quantityQNT;
     private final String comment;
 
-    ColoredCoinsAssetTransfer(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+    ColoredCoinsAssetTransfer(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
       super(buffer, transactionVersion);
       this.assetId = buffer.getLong();
       this.quantityQNT = buffer.getLong();
@@ -902,12 +902,12 @@ public interface Attachment extends Appendix {
     private final ArrayList<Long> assetIds;
     private final ArrayList<Long> quantitiesQNT;
 
-    ColoredCoinsAssetMultiTransfer(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+    ColoredCoinsAssetMultiTransfer(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
       super(buffer, transactionVersion);
 
       int numberOfAssets = Byte.toUnsignedInt(buffer.get());
       if (numberOfAssets > Constants.MAX_MULTI_ASSET_IDS) {
-        throw new BurstException.NotValidException("Invalid number of assets to transfer");
+        throw new SignumException.NotValidException("Invalid number of assets to transfer");
       }
       assetIds = new ArrayList<>(numberOfAssets);
       quantitiesQNT = new ArrayList<>(numberOfAssets);
@@ -917,17 +917,17 @@ public interface Attachment extends Appendix {
         long quantity = buffer.getLong();
 
         if(assetIds.contains(assetId)){
-          throw new BurstException.NotValidException("No repeated assets in a multi transfer");
+          throw new SignumException.NotValidException("No repeated assets in a multi transfer");
         }
         if (quantity <= 0){
-          throw new BurstException.NotValidException("Insufficient quantityQNT on asset multi transfer");
+          throw new SignumException.NotValidException("Insufficient quantityQNT on asset multi transfer");
         }
         assetIds.add(assetId);
         quantitiesQNT.add(quantity);
       }
     }
 
-    ColoredCoinsAssetMultiTransfer(JsonObject attachmentData) throws BurstException.NotValidException {
+    ColoredCoinsAssetMultiTransfer(JsonObject attachmentData) throws SignumException.NotValidException {
       super(attachmentData);
 
       assetIds = new ArrayList<>();
@@ -937,7 +937,7 @@ public interface Attachment extends Appendix {
       for(JsonElement assetIdJson : assetIdsJsonArray){
         long assetId = Convert.parseUnsignedLong(assetIdJson.getAsString());
         if(assetIds.contains(assetId)){
-          throw new BurstException.NotValidException("No repeated assets in a multi transfer");
+          throw new SignumException.NotValidException("No repeated assets in a multi transfer");
         }
         assetIds.add(assetId);
       }
@@ -945,13 +945,13 @@ public interface Attachment extends Appendix {
       for(JsonElement quantityJson : quantitiesJsonArray){
         long quantity = JSON.getAsLong(quantityJson);
         if (quantity <= 0){
-          throw new BurstException.NotValidException("Insufficient quantityQNT on asset multi transfer");
+          throw new SignumException.NotValidException("Insufficient quantityQNT on asset multi transfer");
         }
         quantitiesQNT.add(quantity);
       }
 
       if(assetIds.size() == 0 || assetIds.size() != quantitiesQNT.size() || assetIds.size() > Constants.MAX_MULTI_ASSET_IDS){
-        throw new BurstException.NotValidException("Invalid asset/quantity for multi asset transfer");
+        throw new SignumException.NotValidException("Invalid asset/quantity for multi asset transfer");
       }
     }
 
@@ -1027,7 +1027,7 @@ public interface Attachment extends Appendix {
     private final long assetId;
     private final long quantityQNT;
 
-    ColoredCoinsAssetMint(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+    ColoredCoinsAssetMint(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
       super(buffer, transactionVersion);
       this.assetId = buffer.getLong();
       this.quantityQNT = buffer.getLong();
@@ -1089,7 +1089,7 @@ public interface Attachment extends Appendix {
     private final long assetIdToDistribute;
     private final long quantityQNT;
 
-    ColoredCoinsAssetDistributeToHolders(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+    ColoredCoinsAssetDistributeToHolders(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
       super(buffer, transactionVersion);
       this.assetId = buffer.getLong();
       this.minimumAssetQuantityQNT = buffer.getLong();
@@ -1375,7 +1375,7 @@ public interface Attachment extends Appendix {
     private final int quantity;
     private final long priceNQT;
 
-    DigitalGoodsListing(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+    DigitalGoodsListing(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
       super(buffer, transactionVersion);
       this.name = Convert.readString(buffer, buffer.getShort(), Constants.MAX_DGS_LISTING_NAME_LENGTH);
       this.description = Convert.readString(buffer, buffer.getShort(), Constants.MAX_DGS_LISTING_DESCRIPTION_LENGTH);
@@ -1693,7 +1693,7 @@ public interface Attachment extends Appendix {
     private final long discountNQT;
     private final boolean goodsIsText;
 
-    DigitalGoodsDelivery(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+    DigitalGoodsDelivery(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
       super(buffer, transactionVersion);
       this.purchaseId = buffer.getLong();
       int length = buffer.getInt();
@@ -2064,7 +2064,7 @@ public interface Attachment extends Appendix {
     private final int deadline;
     private final Escrow.DecisionType deadlineAction;
 
-    AdvancedPaymentEscrowCreation(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+    AdvancedPaymentEscrowCreation(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
       super(buffer, transactionVersion);
       this.amountNQT = buffer.getLong();
       this.deadline = buffer.getInt();
@@ -2072,16 +2072,16 @@ public interface Attachment extends Appendix {
       this.requiredSigners = buffer.get();
       byte totalSigners = buffer.get();
       if(totalSigners > 10 || totalSigners <= 0) {
-        throw new BurstException.NotValidException("Invalid number of signers listed on create escrow transaction");
+        throw new SignumException.NotValidException("Invalid number of signers listed on create escrow transaction");
       }
       for(int i = 0; i < totalSigners; i++) {
         if(!this.signers.add(buffer.getLong())) {
-          throw new BurstException.NotValidException("Duplicate signer on escrow creation");
+          throw new SignumException.NotValidException("Duplicate signer on escrow creation");
         }
       }
     }
 
-    AdvancedPaymentEscrowCreation(JsonObject attachmentData) throws BurstException.NotValidException {
+    AdvancedPaymentEscrowCreation(JsonObject attachmentData) throws SignumException.NotValidException {
       super(attachmentData);
       this.amountNQT = Convert.parseUnsignedLong(JSON.getAsString(attachmentData.get(AMOUNT_NQT_PARAMETER)));
       this.deadline = JSON.getAsInt(attachmentData.get(DEADLINE_PARAMETER));
@@ -2089,30 +2089,30 @@ public interface Attachment extends Appendix {
       this.requiredSigners = JSON.getAsByte(attachmentData.get(REQUIRED_SIGNERS_PARAMETER));
       int totalSigners = (JSON.getAsJsonArray(attachmentData.get(SIGNERS_PARAMETER))).size();
       if(totalSigners > 10 || totalSigners <= 0) {
-        throw new BurstException.NotValidException("Invalid number of signers listed on create escrow transaction");
+        throw new SignumException.NotValidException("Invalid number of signers listed on create escrow transaction");
       }
       JsonArray signersJson = JSON.getAsJsonArray(attachmentData.get(SIGNERS_PARAMETER));
       for (JsonElement aSignersJson : signersJson) {
         this.signers.add(Convert.parseUnsignedLong(JSON.getAsString(aSignersJson)));
       }
       if(this.signers.size() != (JSON.getAsJsonArray(attachmentData.get(SIGNERS_PARAMETER))).size()) {
-        throw new BurstException.NotValidException("Duplicate signer on escrow creation");
+        throw new SignumException.NotValidException("Duplicate signer on escrow creation");
       }
     }
 
     public AdvancedPaymentEscrowCreation(Long amountNQT, int deadline, Escrow.DecisionType deadlineAction,
-                                         int requiredSigners, Collection<Long> signers, int blockchainHeight) throws BurstException.NotValidException {
+                                         int requiredSigners, Collection<Long> signers, int blockchainHeight) throws SignumException.NotValidException {
       super(blockchainHeight);
       this.amountNQT = amountNQT;
       this.deadline = deadline;
       this.deadlineAction = deadlineAction;
       this.requiredSigners = (byte)requiredSigners;
       if(signers.size() > 10 || signers.isEmpty()) {
-        throw new BurstException.NotValidException("Invalid number of signers listed on create escrow transaction");
+        throw new SignumException.NotValidException("Invalid number of signers listed on create escrow transaction");
       }
       this.signers.addAll(signers);
       if(this.signers.size() != signers.size()) {
-        throw new BurstException.NotValidException("Duplicate signer on escrow creation");
+        throw new SignumException.NotValidException("Duplicate signer on escrow creation");
       }
     }
 
@@ -2432,7 +2432,7 @@ public interface Attachment extends Appendix {
     private final byte[] creationBytes;
 
     AutomatedTransactionsCreation(ByteBuffer buffer,
-                                  byte transactionVersion) throws BurstException.NotValidException {
+                                  byte transactionVersion) throws SignumException.NotValidException {
       super(buffer, transactionVersion);
 
       this.name = Convert.readString( buffer , buffer.get() , Constants.MAX_AUTOMATED_TRANSACTION_NAME_LENGTH );

--- a/src/brs/Attachment.java
+++ b/src/brs/Attachment.java
@@ -1921,17 +1921,17 @@ public interface Attachment extends Appendix {
 
   }
 
-  final class BurstMiningRewardRecipientAssignment extends AbstractAttachment {
+  final class SignaMiningRewardRecipientAssignment extends AbstractAttachment {
 
-    BurstMiningRewardRecipientAssignment(ByteBuffer buffer, byte transactionVersion) {
+    SignaMiningRewardRecipientAssignment(ByteBuffer buffer, byte transactionVersion) {
       super(buffer, transactionVersion);
     }
 
-    BurstMiningRewardRecipientAssignment(JsonObject attachmentData) {
+    SignaMiningRewardRecipientAssignment(JsonObject attachmentData) {
       super(attachmentData);
     }
 
-    public BurstMiningRewardRecipientAssignment(int blockchainHeight) {
+    public SignaMiningRewardRecipientAssignment(int blockchainHeight) {
       super(blockchainHeight);
     }
 
@@ -1957,7 +1957,7 @@ public interface Attachment extends Appendix {
 
     @Override
     public TransactionType getTransactionType() {
-      return TransactionType.BurstMining.REWARD_RECIPIENT_ASSIGNMENT;
+      return TransactionType.SignaMining.REWARD_RECIPIENT_ASSIGNMENT;
     }
 
   }
@@ -2024,7 +2024,7 @@ public interface Attachment extends Appendix {
 
     @Override
     public TransactionType getTransactionType() {
-      return TransactionType.BurstMining.COMMITMENT_ADD;
+      return TransactionType.SignaMining.COMMITMENT_ADD;
     }
 
   }
@@ -2050,7 +2050,7 @@ public interface Attachment extends Appendix {
 
     @Override
     public TransactionType getTransactionType() {
-      return TransactionType.BurstMining.COMMITMENT_REMOVE;
+      return TransactionType.SignaMining.COMMITMENT_REMOVE;
     }
 
   }

--- a/src/brs/Block.java
+++ b/src/brs/Block.java
@@ -60,10 +60,10 @@ public class Block {
       long totalFeeCashBackNQT, long totalFeeBurntNQT,
       int payloadLength, byte[] payloadHash, byte[] generatorPublicKey, byte[] generationSignature,
       byte[] blockSignature, byte[] previousBlockHash, List<Transaction> transactions,
-      long nonce, byte[] blockATs, int height, long baseTarget) throws BurstException.ValidationException {
+      long nonce, byte[] blockATs, int height, long baseTarget) throws SignumException.ValidationException {
 
     if (payloadLength > Signum.getFluxCapacitor().getValue(FluxValues.MAX_PAYLOAD_LENGTH, height) || payloadLength < 0) {
-      throw new BurstException.NotValidException(
+      throw new SignumException.NotValidException(
           "attempted to create a block with payloadLength " + payloadLength + " height " + height + "previd " + previousBlockId);
     }
 
@@ -84,13 +84,13 @@ public class Block {
     if (transactions != null) {
       this.blockTransactions.set(Collections.unmodifiableList(transactions));
       if (blockTransactions.get().size() > (Signum.getFluxCapacitor().getValue(FluxValues.MAX_NUMBER_TRANSACTIONS, height))) {
-        throw new BurstException.NotValidException(
+        throw new SignumException.NotValidException(
             "attempted to create a block with " + blockTransactions.get().size() + " transactions");
       }
       long previousId = 0;
       for (Transaction transaction : this.blockTransactions.get()) {
         if (transaction.getId() <= previousId && previousId != 0) {
-          throw new BurstException.NotValidException("Block transactions are not sorted!");
+          throw new SignumException.NotValidException("Block transactions are not sorted!");
         }
         previousId = transaction.getId();
       }
@@ -103,7 +103,7 @@ public class Block {
   public Block(int version, int timestamp, long previousBlockId, long totalAmountNQT, long totalFeeNQT,
       long totalFeeCashBackNQT, long totalFeeBurntNQT,
       int payloadLength, byte[] payloadHash, byte[] generatorPublicKey, byte[] generationSignature, byte[] blockSignature, byte[] previousBlockHash, BigInteger cumulativeDifficulty, long baseTarget,
-      long nextBlockId, int height, Long id, long nonce, byte[] blockATs) throws BurstException.ValidationException {
+      long nextBlockId, int height, Long id, long nonce, byte[] blockATs) throws SignumException.ValidationException {
 
     this(version, timestamp, previousBlockId, totalAmountNQT, totalFeeNQT, totalFeeCashBackNQT, totalFeeBurntNQT, payloadLength, payloadHash, generatorPublicKey, generationSignature, blockSignature, previousBlockHash, null, nonce, blockATs, height, baseTarget);
 
@@ -317,7 +317,7 @@ public class Block {
     return json;
   }
 
-  static Block parseBlock(JsonObject blockData, int height) throws BurstException.ValidationException {
+  static Block parseBlock(JsonObject blockData, int height) throws SignumException.ValidationException {
     try {
       int version = JSON.getAsInt(blockData.get("version"));
       int timestamp = JSON.getAsInt(blockData.get("timestamp"));
@@ -340,7 +340,7 @@ public class Block {
       long baseTarget = Convert.parseUnsignedLong(JSON.getAsString(blockData.get("baseTarget")));
 
       if(Signum.getFluxCapacitor().getValue(FluxValues.POC_PLUS, height) && baseTarget == 0L) {
-        throw new BurstException.NotValidException("Block received without a baseTarget");
+        throw new SignumException.NotValidException("Block received without a baseTarget");
       }
 
       SortedMap<Long, Transaction> blockTransactions = new TreeMap<>();
@@ -349,7 +349,7 @@ public class Block {
       for (JsonElement transactionData : transactionsData) {
         Transaction transaction = Transaction.parseTransaction(JSON.getAsJsonObject(transactionData), height);
         if (transaction.getSignature() != null && blockTransactions.put(transaction.getId(), transaction) != null) {
-          throw new BurstException.NotValidException("Block contains duplicate transactions: " + transaction.getStringId());
+          throw new SignumException.NotValidException("Block contains duplicate transactions: " + transaction.getStringId());
         }
       }
 
@@ -358,7 +358,7 @@ public class Block {
           totalFeeCashBackNQT, totalFeeBurntNQT,
           payloadLength, payloadHash, generatorPublicKey, generationSignature, blockSignature,
           previousBlockHash, new ArrayList<>(blockTransactions.values()), nonce, blockATs, height, baseTarget);
-    } catch (BurstException.ValidationException | RuntimeException e) {
+    } catch (SignumException.ValidationException | RuntimeException e) {
       if (logger.isDebugEnabled()) {
         logger.debug("Failed to parse block: {}", JSON.toJsonString(blockData));
       }

--- a/src/brs/Block.java
+++ b/src/brs/Block.java
@@ -375,8 +375,8 @@ public class Block {
     buffer.putLong(previousBlockId);
     buffer.putInt(getTransactions().size());
     if (version < 3) {
-      buffer.putInt((int) (totalAmountNQT / Constants.ONE_BURST));
-      buffer.putInt((int) (totalFeeNQT / Constants.ONE_BURST));
+      buffer.putInt((int) (totalAmountNQT / Constants.ONE_SIGNA));
+      buffer.putInt((int) (totalFeeNQT / Constants.ONE_SIGNA));
     } else {
       buffer.putLong(totalAmountNQT);
       buffer.putLong(totalFeeNQT);

--- a/src/brs/Block.java
+++ b/src/brs/Block.java
@@ -62,7 +62,7 @@ public class Block {
       byte[] blockSignature, byte[] previousBlockHash, List<Transaction> transactions,
       long nonce, byte[] blockATs, int height, long baseTarget) throws BurstException.ValidationException {
 
-    if (payloadLength > Burst.getFluxCapacitor().getValue(FluxValues.MAX_PAYLOAD_LENGTH, height) || payloadLength < 0) {
+    if (payloadLength > Signum.getFluxCapacitor().getValue(FluxValues.MAX_PAYLOAD_LENGTH, height) || payloadLength < 0) {
       throw new BurstException.NotValidException(
           "attempted to create a block with payloadLength " + payloadLength + " height " + height + "previd " + previousBlockId);
     }
@@ -83,7 +83,7 @@ public class Block {
     this.previousBlockHash = previousBlockHash;
     if (transactions != null) {
       this.blockTransactions.set(Collections.unmodifiableList(transactions));
-      if (blockTransactions.get().size() > (Burst.getFluxCapacitor().getValue(FluxValues.MAX_NUMBER_TRANSACTIONS, height))) {
+      if (blockTransactions.get().size() > (Signum.getFluxCapacitor().getValue(FluxValues.MAX_NUMBER_TRANSACTIONS, height))) {
         throw new BurstException.NotValidException(
             "attempted to create a block with " + blockTransactions.get().size() + " transactions");
       }
@@ -114,7 +114,7 @@ public class Block {
   }
 
   private TransactionDb transactionDb() {
-    return Burst.getDbs().getTransactionDb();
+    return Signum.getDbs().getTransactionDb();
   }
 
   public boolean isVerified() {
@@ -211,7 +211,7 @@ public class Block {
 
   public long getCapacityBaseTarget() {
     long capacityBaseTarget = baseTarget;
-    if(Burst.getFluxCapacitor().getValue(FluxValues.POC_PLUS, height)) {
+    if(Signum.getFluxCapacitor().getValue(FluxValues.POC_PLUS, height)) {
       // Base target encoded as two floats, one for the commitment and the other the classical base target
       float capacityBaseTargetFloat = Float.intBitsToFloat((int)(baseTarget & 0xFFFFFFFFL));
       capacityBaseTarget = (long)capacityBaseTargetFloat;
@@ -220,7 +220,7 @@ public class Block {
   }
 
   public long getAverageCommitment() {
-    if(Burst.getFluxCapacitor().getValue(FluxValues.POC_PLUS, height)) {
+    if(Signum.getFluxCapacitor().getValue(FluxValues.POC_PLUS, height)) {
       // Base target encoded as two floats, one for the commitment and the other the classical base target
       float commitmentBaseTargetFloat = Float.intBitsToFloat((int)((baseTarget) >> 32));
       return (long)commitmentBaseTargetFloat;
@@ -339,7 +339,7 @@ public class Block {
       long nonce = Convert.parseUnsignedLong(JSON.getAsString(blockData.get("nonce")));
       long baseTarget = Convert.parseUnsignedLong(JSON.getAsString(blockData.get("baseTarget")));
 
-      if(Burst.getFluxCapacitor().getValue(FluxValues.POC_PLUS, height) && baseTarget == 0L) {
+      if(Signum.getFluxCapacitor().getValue(FluxValues.POC_PLUS, height) && baseTarget == 0L) {
         throw new BurstException.NotValidException("Block received without a baseTarget");
       }
 

--- a/src/brs/BlockchainProcessor.java
+++ b/src/brs/BlockchainProcessor.java
@@ -24,7 +24,7 @@ public interface BlockchainProcessor extends Observable<Block, BlockchainProcess
 
   int getMinRollbackHeight();
 
-  void processPeerBlock(JsonObject request, Peer peer) throws BurstException;
+  void processPeerBlock(JsonObject request, Peer peer) throws SignumException;
 
   void fullReset();
 
@@ -33,7 +33,7 @@ public interface BlockchainProcessor extends Observable<Block, BlockchainProcess
 
   List<Block> popOffTo(int height);
 
-  class BlockNotAcceptedException extends BurstException {
+  class BlockNotAcceptedException extends SignumException {
 
     BlockNotAcceptedException(String message) {
       super(message);

--- a/src/brs/BlockchainProcessorImpl.java
+++ b/src/brs/BlockchainProcessorImpl.java
@@ -216,7 +216,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
 
               // Keep the download cache below the rollback limit
               int cacheHeight = downloadCache.getLastBlock().getHeight();
-              if(Burst.getFluxCapacitor().getValue(FluxValues.POC_PLUS, cacheHeight) && cacheHeight - blockchain.getHeight() > Constants.MAX_ROLLBACK / 2) {
+              if(Signum.getFluxCapacitor().getValue(FluxValues.POC_PLUS, cacheHeight) && cacheHeight - blockchain.getHeight() > Constants.MAX_ROLLBACK / 2) {
                 logger.debug("GetMoreBlocks, skip download, wait for other threads to catch up");
                 return;
               }
@@ -232,7 +232,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
                   logger.debug("No peer connected.");
                   return;
                 }
-                if (!peer.isHigherOrEqualVersionThan(Burst.getFluxCapacitor().getValue(FluxValues.MIN_PEER_VERSION))
+                if (!peer.isHigherOrEqualVersionThan(Signum.getFluxCapacitor().getValue(FluxValues.MIN_PEER_VERSION))
                         || (peer.getNetworkName()!=null && !peer.getNetworkName().equals(propertyService.getString(Props.NETWORK_NAME)))) {
                   // ignore this peer, it will be removed by the peers discovery thread
                   continue;
@@ -331,7 +331,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
                 int height = lastBlock.getHeight() + 1;
                 blockData = JSON.getAsJsonObject(o);
                 try {
-                  if(Burst.getFluxCapacitor().getValue(FluxValues.POC_PLUS, height) && height - blockchain.getHeight() >= Constants.MAX_ROLLBACK) {
+                  if(Signum.getFluxCapacitor().getValue(FluxValues.POC_PLUS, height) && height - blockchain.getHeight() >= Constants.MAX_ROLLBACK) {
                     logger.debug("GetMoreBlocks, wait for other threads to catch up");
                     break;
                   }
@@ -874,7 +874,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
       Block lastBlock = blockDb.findLastBlock();
       blockchain.setLastBlock(lastBlock);
       logger.info("Last block height: {}, baseTarget: {}{}", lastBlock.getHeight(),
-          lastBlock.getCapacityBaseTarget(), Burst.getFluxCapacitor().getValue(FluxValues.POC_PLUS) ?
+          lastBlock.getCapacityBaseTarget(), Signum.getFluxCapacitor().getValue(FluxValues.POC_PLUS) ?
               ", averageCommitmentNQT " + lastBlock.getAverageCommitment() : "");
       return;
     }
@@ -886,7 +886,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
       ByteBuffer bf = ByteBuffer.allocate(0);
       bf.order(ByteOrder.LITTLE_ENDIAN);
       byte[] byteATs = bf.array();
-      int genesisTimestamp = Burst.getPropertyService().getInt(Props.GENESIS_TIMESTAMP);
+      int genesisTimestamp = Signum.getPropertyService().getInt(Props.GENESIS_TIMESTAMP);
       Block genesisBlock = new Block(-1, genesisTimestamp, 0, 0, 0, 0, 0, transactions.size() * 128,
           digest.digest(), Genesis.getCreatorPublicKey(), new byte[32],
           Genesis.getGenesisBlockSignature(), null, transactions, 0, byteATs, -1, Constants.INITIAL_BASE_TARGET);
@@ -949,7 +949,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
         long[] feeArray = new long[transactions.size()];
         int slotIdx = 0;
 
-        int maxIndirects = Burst.getPropertyService().getInt(Props.MAX_INDIRECTS_PER_BLOCK);
+        int maxIndirects = Signum.getPropertyService().getInt(Props.MAX_INDIRECTS_PER_BLOCK);
         int indirectsCount = 0;
 
         for (Transaction transaction : transactions) {
@@ -987,7 +987,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
                 + transaction.getStringId() + " at height " + previousLastBlock.getHeight(),
                 transaction);
           }
-            if (Burst.getFluxCapacitor().getValue(FluxValues.AUTOMATED_TRANSACTION_BLOCK) && !economicClustering.verifyFork(transaction)) {
+            if (Signum.getFluxCapacitor().getValue(FluxValues.AUTOMATED_TRANSACTION_BLOCK) && !economicClustering.verifyFork(transaction)) {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Block {} height {} contains transaction that was generated on a fork: {} ecBlockId {} ecBlockHeight {}", block.getStringId(), previousLastBlock.getHeight() + 1, transaction.getStringId(), transaction.getECBlockHeight(), Convert.toUnsignedLong(transaction.getECBlockId()));
                 }
@@ -1027,7 +1027,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
           throw new BlockNotAcceptedException("Total amount or fee don't match transaction totals for block " + block.getHeight());
         }
 
-        if (Burst.getFluxCapacitor().getValue(FluxValues.SODIUM) && !Burst.getFluxCapacitor().getValue(FluxValues.SPEEDWAY)) {
+        if (Signum.getFluxCapacitor().getValue(FluxValues.SODIUM) && !Signum.getFluxCapacitor().getValue(FluxValues.SPEEDWAY)) {
           Arrays.sort(feeArray);
           for (int i = 0; i < feeArray.length; i++) {
             if (feeArray[i] < Constants.FEE_QUANT_SIP3 * (i + 1)) {
@@ -1198,7 +1198,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
   }
 
   private int getBlockVersion() {
-    return Burst.getFluxCapacitor().getValue(FluxValues.SMART_FEES) ? 4 : 3;
+    return Signum.getFluxCapacitor().getValue(FluxValues.SMART_FEES) ? 4 : 3;
   }
 
   private boolean preCheckUnconfirmedTransaction(TransactionDuplicatesCheckerImpl transactionDuplicatesChecker, UnconfirmedTransactionStore unconfirmedTransactionStore, Transaction transaction) {
@@ -1223,8 +1223,8 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
       UnconfirmedTransactionStore unconfirmedTransactionStore = stores.getUnconfirmedTransactionStore();
       SortedSet<Transaction> orderedBlockTransactions = new TreeSet<>();
 
-      int blockSize   = Burst.getFluxCapacitor().getValue(FluxValues.MAX_NUMBER_TRANSACTIONS);
-      int payloadSize = Burst.getFluxCapacitor().getValue(FluxValues.MAX_PAYLOAD_LENGTH);
+      int blockSize   = Signum.getFluxCapacitor().getValue(FluxValues.MAX_NUMBER_TRANSACTIONS);
+      int payloadSize = Signum.getFluxCapacitor().getValue(FluxValues.MAX_PAYLOAD_LENGTH);
 
       long totalAmountNQT = 0;
       long totalFeeNQT = 0;
@@ -1252,7 +1252,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
           long feePriority = transaction.getFeeNQT() * (transaction.getSize()/Constants.ORDINARY_TRANSACTION_BYTES);
           // So the age has less priority (60 minutes to increase the priority to the next level)
           // TODO: consider giving priority based on the last sent transaction and not transaction age to improve spam protection
-          long priority = (feePriority * 60) + Burst.getFluxCapacitor().getValue(FluxValues.FEE_QUANT)*age;
+          long priority = (feePriority * 60) + Signum.getFluxCapacitor().getValue(FluxValues.FEE_QUANT)*age;
 
           return priority;
         };
@@ -1265,17 +1265,17 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
                                 && transaction.getExpiration() >= blockTimestamp
                                 && transaction.getTimestamp() <= blockTimestamp + MAX_TIMESTAMP_DIFFERENCE
                                 && (
-                                !Burst.getFluxCapacitor().getValue(FluxValues.AUTOMATED_TRANSACTION_BLOCK)
+                                !Signum.getFluxCapacitor().getValue(FluxValues.AUTOMATED_TRANSACTION_BLOCK)
                                         || economicClustering.verifyFork(transaction)
                         ))
                 .filter(transaction -> preCheckUnconfirmedTransaction(transactionDuplicatesChecker, unconfirmedTransactionStore, transaction)); // Extra check for transactions that are to be considered
 
-        if (Burst.getFluxCapacitor().getValue(FluxValues.PRE_POC2) && !Burst.getFluxCapacitor().getValue(FluxValues.SPEEDWAY)) {
+        if (Signum.getFluxCapacitor().getValue(FluxValues.PRE_POC2) && !Signum.getFluxCapacitor().getValue(FluxValues.SPEEDWAY)) {
           // In this step we get all unconfirmed transactions and then sort them by slot, followed by priority
           Map<Long, TreeMap<Long, Transaction>> unconfirmedTransactionsOrderedBySlotThenPriority = new HashMap<>();
             inclusionCandidates.collect(Collectors.toMap(Function.identity(), priorityCalculator::applyAsLong)).forEach((transaction, priority) -> {
             long slot = (transaction.getFeeNQT() - (transaction.getFeeNQT() % FEE_QUANT_SIP3)) / FEE_QUANT_SIP3;
-            slot = Math.min(Burst.getFluxCapacitor().getValue(FluxValues.MAX_NUMBER_TRANSACTIONS), slot);
+            slot = Math.min(Signum.getFluxCapacitor().getValue(FluxValues.MAX_NUMBER_TRANSACTIONS), slot);
             TreeMap<Long, Transaction> utxInSlot = unconfirmedTransactionsOrderedBySlotThenPriority.get(slot);
             if(utxInSlot == null) {
               // Use a tree map in reverse order so we automatically get a descending priority list
@@ -1291,7 +1291,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
 
           // Fill the unconfirmed transactions to be included from top to bottom
           Map<Long, Transaction> slotTransactionsToBeincluded = new HashMap<>();
-          int maxSlot = Burst.getFluxCapacitor().getValue(FluxValues.MAX_NUMBER_TRANSACTIONS);
+          int maxSlot = Signum.getFluxCapacitor().getValue(FluxValues.MAX_NUMBER_TRANSACTIONS);
           for (long slot = maxSlot; slot >= 1; slot--) {
             boolean slotFilled = false;
             for (long slotUnconfirmed = maxSlot; slotUnconfirmed >= slot; slotUnconfirmed--) {
@@ -1331,8 +1331,8 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
           transactionsToBeIncluded = transactionsOrderedBySlot;
         }
 
-        int maxIndirects = Burst.getPropertyService().getInt(Props.MAX_INDIRECTS_PER_BLOCK);
-        long FEE_QUANT = Burst.getFluxCapacitor().getValue(FluxValues.FEE_QUANT);
+        int maxIndirects = Signum.getPropertyService().getInt(Props.MAX_INDIRECTS_PER_BLOCK);
+        long FEE_QUANT = Signum.getFluxCapacitor().getValue(FluxValues.FEE_QUANT);
         transactionService.startNewBlock();
         for (Map.Entry<Long, Transaction> entry : transactionsToBeIncluded.entrySet()) {
           long slot = entry.getKey();
@@ -1351,8 +1351,8 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
           }
           indirectsCount += txIndirects;
 
-          long slotFee = Burst.getFluxCapacitor().getValue(FluxValues.PRE_POC2) ? slot * FEE_QUANT_SIP3 : ONE_BURST;
-          if(Burst.getFluxCapacitor().getValue(FluxValues.SPEEDWAY)) {
+          long slotFee = Signum.getFluxCapacitor().getValue(FluxValues.PRE_POC2) ? slot * FEE_QUANT_SIP3 : ONE_BURST;
+          if(Signum.getFluxCapacitor().getValue(FluxValues.SPEEDWAY)) {
             // we already got the list by priority, no need to check the fees again
             slotFee = FEE_QUANT;
           }
@@ -1363,7 +1363,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
                 payloadSize -= transaction.getSize();
                 totalAmountNQT += transaction.getAmountNQT();
                 totalFeeNQT += transaction.getFeeNQT();
-                if(Burst.getFluxCapacitor().getValue(FluxValues.SMART_FEES, blockHeight)){
+                if(Signum.getFluxCapacitor().getValue(FluxValues.SMART_FEES, blockHeight)){
                   totalFeeCashBackNQT += transaction.getFeeNQT() / propertyService.getInt(Props.CASH_BACK_FACTOR);
                 }
                 orderedBlockTransactions.add(transaction);
@@ -1385,7 +1385,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
           subscriptionService.clearRemovals();
           long subscriptionFeeNQT = subscriptionService.calculateFees(blockTimestamp, blockHeight);
           totalFeeNQT += subscriptionFeeNQT;
-          if (Burst.getFluxCapacitor().getValue(FluxValues.SMART_FEES, blockHeight)) {
+          if (Signum.getFluxCapacitor().getValue(FluxValues.SMART_FEES, blockHeight)) {
             totalFeeBurntNQT += subscriptionFeeNQT;
           }
         }
@@ -1409,7 +1409,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
       if (byteATs != null) {
         payloadSize    -= byteATs.length;
         totalFeeNQT    += atBlock.getTotalFees();
-        if (Burst.getFluxCapacitor().getValue(FluxValues.SMART_FEES, blockHeight)) {
+        if (Signum.getFluxCapacitor().getValue(FluxValues.SMART_FEES, blockHeight)) {
           totalFeeBurntNQT += atBlock.getTotalFees();
         }
         totalAmountNQT += atBlock.getTotalAmount();
@@ -1427,7 +1427,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
       try {
         block = new Block(getBlockVersion(), blockTimestamp,
             previousBlock.getId(), totalAmountNQT, totalFeeNQT, totalFeeCashBackNQT, totalFeeBurntNQT,
-            Burst.getFluxCapacitor().getValue(FluxValues.MAX_PAYLOAD_LENGTH) - payloadSize, payloadHash, publicKey,
+            Signum.getFluxCapacitor().getValue(FluxValues.MAX_PAYLOAD_LENGTH) - payloadSize, payloadHash, publicKey,
             generationSignature, null, previousBlockHash, new ArrayList<>(orderedBlockTransactions), nonce,
             byteATs, previousBlock.getHeight(), Constants.INITIAL_BASE_TARGET);
       } catch (BurstException.ValidationException e) {
@@ -1463,7 +1463,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
   private boolean hasAllReferencedTransactions(Transaction transaction, int timestamp, int count) {
     // TODO: consider cleaning this method after the upgrade.
     if (transaction.getReferencedTransactionFullHash() == null) {
-      if(Burst.getFluxCapacitor().getValue(FluxValues.SPEEDWAY)) {
+      if(Signum.getFluxCapacitor().getValue(FluxValues.SPEEDWAY)) {
         return true;
       }
       return timestamp - transaction.getTimestamp() < 60 * 1440 * 60 && count < 10;
@@ -1472,7 +1472,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
     if (!subscriptionService.isEnabled() && transaction != null && transaction.getSignature() == null) {
       transaction = null;
     }
-    if(Burst.getFluxCapacitor().getValue(FluxValues.SPEEDWAY)) {
+    if(Signum.getFluxCapacitor().getValue(FluxValues.SPEEDWAY)) {
       // No need to go deeper checking, if it is on the DB and confirmed already
       return transaction != null;
     }

--- a/src/brs/BlockchainProcessorImpl.java
+++ b/src/brs/BlockchainProcessorImpl.java
@@ -1,7 +1,7 @@
 package brs;
 
 import static brs.Constants.FEE_QUANT_SIP3;
-import static brs.Constants.ONE_BURST;
+import static brs.Constants.ONE_SIGNA;
 
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -1351,7 +1351,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
           }
           indirectsCount += txIndirects;
 
-          long slotFee = Signum.getFluxCapacitor().getValue(FluxValues.PRE_POC2) ? slot * FEE_QUANT_SIP3 : ONE_BURST;
+          long slotFee = Signum.getFluxCapacitor().getValue(FluxValues.PRE_POC2) ? slot * FEE_QUANT_SIP3 : ONE_SIGNA;
           if(Signum.getFluxCapacitor().getValue(FluxValues.SPEEDWAY)) {
             // we already got the list by priority, no need to check the fees again
             slotFee = FEE_QUANT;

--- a/src/brs/BlockchainProcessorImpl.java
+++ b/src/brs/BlockchainProcessorImpl.java
@@ -365,7 +365,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
                   logger.info(e.toString() + " - autoflushing cache to get rid of it", e);
                   downloadCache.resetCache();
                   return;
-                } catch (RuntimeException | BurstException.ValidationException e) {
+                } catch (RuntimeException | SignumException.ValidationException e) {
                   logger.info("Failed to parse block: {}", e.getMessage());
                   if(logger.isDebugEnabled()) {
                     logger.debug("Failed to parse block trace: {}", Arrays.toString(e.getStackTrace()));
@@ -400,7 +400,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
                 processFork(peer, downloadCache.getForkList(), commonBlockId);
               }
 
-            } catch (BurstException.StopException e) {
+            } catch (SignumException.StopException e) {
               logger.info("Blockchain download stopped: {}", e.getMessage());
             } catch (InterruptedException ignored) {
               // shutting down
@@ -803,7 +803,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
   }
 
   @Override
-  public void processPeerBlock(JsonObject request, Peer peer) throws BurstException {
+  public void processPeerBlock(JsonObject request, Peer peer) throws SignumException {
     Block newBlock = Block.parseBlock(request, blockchain.getHeight());
      //* This process takes care of the blocks that is announced by peers We do not want to be fed forks.
     Block chainblock = downloadCache.getLastBlock();
@@ -892,7 +892,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
           Genesis.getGenesisBlockSignature(), null, transactions, 0, byteATs, -1, Constants.INITIAL_BASE_TARGET);
       blockService.setPrevious(genesisBlock, null);
       addBlock(genesisBlock);
-    } catch (BurstException.ValidationException e) {
+    } catch (SignumException.ValidationException e) {
       logger.info(e.getMessage());
       throw new RuntimeException(e.toString(), e);
     }
@@ -1010,7 +1010,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
 
           try {
             transactionService.validate(transaction);
-          } catch (BurstException.ValidationException e) {
+          } catch (SignumException.ValidationException e) {
             throw new TransactionNotAcceptedException(e.getMessage(), transaction);
           }
 
@@ -1368,9 +1368,9 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
                 }
                 orderedBlockTransactions.add(transaction);
                 blockSize--;
-              } catch (BurstException.NotCurrentlyValidException e) {
+              } catch (SignumException.NotCurrentlyValidException e) {
                 transactionService.undoUnconfirmed(transaction);
-              } catch (BurstException.ValidationException e) {
+              } catch (SignumException.ValidationException e) {
                 unconfirmedTransactionStore.remove(transaction);
                 transactionService.undoUnconfirmed(transaction);
               }
@@ -1430,7 +1430,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
             Signum.getFluxCapacitor().getValue(FluxValues.MAX_PAYLOAD_LENGTH) - payloadSize, payloadHash, publicKey,
             generationSignature, null, previousBlockHash, new ArrayList<>(orderedBlockTransactions), nonce,
             byteATs, previousBlock.getHeight(), Constants.INITIAL_BASE_TARGET);
-      } catch (BurstException.ValidationException e) {
+      } catch (SignumException.ValidationException e) {
         // shouldn't happen because all transactions are already validated
         logger.info("Error generating block", e);
         return;

--- a/src/brs/BurstGUI.java
+++ b/src/brs/BurstGUI.java
@@ -74,7 +74,7 @@ public class BurstGUI extends JFrame {
     Color iconColor = Color.BLACK;
 
     public static void main(String []args) {
-        new BurstGUI("Signum Node", Props.ICON_LOCATION.getDefaultValue(), Burst.VERSION.toString(), args);
+        new BurstGUI("Signum Node", Props.ICON_LOCATION.getDefaultValue(), Signum.VERSION.toString(), args);
     }
 
     public BurstGUI(String programName, String iconLocation, String version, String []args) {
@@ -186,7 +186,7 @@ public class BurstGUI extends JFrame {
         showWindow();
         new Timer(5000, e -> {
         	try {
-        		Blockchain blockChain = Burst.getBlockchain();
+        		Blockchain blockChain = Signum.getBlockchain();
         		if(blockChain != null) {
         			Block block = blockChain.getLastBlock();
         			if(block != null) {
@@ -195,7 +195,7 @@ public class BurstGUI extends JFrame {
         						" Timestamp: " + DATE_FORMAT.format(blockDate));
 
         				Date now = new Date();
-        			    long blockTime = Burst.getFluxCapacitor().getValue(FluxValues.BLOCK_TIME);
+        			    long blockTime = Signum.getFluxCapacitor().getValue(FluxValues.BLOCK_TIME);
 
         				int missingBlocks = (int) ((now.getTime() - blockDate.getTime())/(blockTime * 1000));
         				int prog = block.getHeight()*100/(block.getHeight() + missingBlocks);
@@ -217,7 +217,7 @@ public class BurstGUI extends JFrame {
         userClosed = true;
 
         new Thread(() -> {
-          Burst.shutdown(false);
+          Signum.shutdown(false);
 
           if (trayIcon != null && SystemTray.isSupported()) {
               SystemTray.getSystemTray().remove(trayIcon);
@@ -268,7 +268,7 @@ public class BurstGUI extends JFrame {
         }
     	toolBar.add(editConfButton);
     	toolBar.add(openApiButton);
-    	if(Burst.getPropertyService().getBoolean(Props.EXPERIMENTAL)) {
+    	if(Signum.getPropertyService().getBoolean(Props.EXPERIMENTAL)) {
           toolBar.add(popOff10Button);
           toolBar.add(popOff100Button);
 //          toolBar.add(popOffMaxButton);
@@ -286,7 +286,7 @@ public class BurstGUI extends JFrame {
     	getContentPane().validate();
 
     	try {
-        String newIconLocation = Burst.getPropertyService().getString(Props.ICON_LOCATION);
+        String newIconLocation = Signum.getPropertyService().getString(Props.ICON_LOCATION);
         if(!newIconLocation.equals(iconLocation)){
           // update the icon
           iconLocation = newIconLocation;
@@ -316,21 +316,21 @@ public class BurstGUI extends JFrame {
 
     private void popOff(int blocks) {
     	LOGGER.info("Pop off requested, this can take a while...");
-    	int height = blocks > 0 ? Burst.getBlockchain().getLastBlock().getHeight() - blocks : Burst.getBlockchainProcessor().getMinRollbackHeight();
-    	new Thread(() -> Burst.getBlockchainProcessor().popOffTo(height)).start();
+    	int height = blocks > 0 ? Signum.getBlockchain().getLastBlock().getHeight() - blocks : Signum.getBlockchainProcessor().getMinRollbackHeight();
+    	new Thread(() -> Signum.getBlockchainProcessor().popOffTo(height)).start();
     }
 
     private void editConf() {
-    	File file = new File(Burst.CONF_FOLDER, Burst.PROPERTIES_NAME);
+    	File file = new File(Signum.CONF_FOLDER, Signum.PROPERTIES_NAME);
     	if(!file.exists()) {
-        	file = new File(Burst.CONF_FOLDER, Burst.DEFAULT_PROPERTIES_NAME);
+        	file = new File(Signum.CONF_FOLDER, Signum.DEFAULT_PROPERTIES_NAME);
         	if(!file.exists()) {
-        		file = new File(Burst.DEFAULT_PROPERTIES_NAME);
+        		file = new File(Signum.DEFAULT_PROPERTIES_NAME);
         	}
     	}
 
     	if(!file.exists()) {
-    		JOptionPane.showMessageDialog(this, "Could not find conf file: " + Burst.DEFAULT_PROPERTIES_NAME, "File not found", JOptionPane.ERROR_MESSAGE);
+    		JOptionPane.showMessageDialog(this, "Could not find conf file: " + Signum.DEFAULT_PROPERTIES_NAME, "File not found", JOptionPane.ERROR_MESSAGE);
     		return;
     	}
     	try {
@@ -342,7 +342,7 @@ public class BurstGUI extends JFrame {
 
     private void openWebUi(String path) {
         try {
-            PropertyService propertyService = Burst.getPropertyService();
+            PropertyService propertyService = Signum.getPropertyService();
             int port = propertyService.getInt(Props.API_PORT);
             String httpPrefix = propertyService.getBoolean(Props.API_SSL) ? "https://" : "http://";
             String address = httpPrefix + "localhost:" + port + path;
@@ -360,12 +360,12 @@ public class BurstGUI extends JFrame {
 
     private void runBrs() {
         try {
-            Burst.main(args);
+            Signum.main(args);
             try {
             	SwingUtilities.invokeLater(() -> showTrayIcon());
 
                 updateTitle();
-                if (Burst.getBlockchain() == null)
+                if (Signum.getBlockchain() == null)
                 	onBrsStopped();
             } catch (Exception t) {
                 LOGGER.error("Could not determine if running in testnet mode", t);
@@ -379,7 +379,7 @@ public class BurstGUI extends JFrame {
     }
 
     private void updateTitle() {
-        String networkName = Burst.getPropertyService().getString(Props.NETWORK_NAME);
+        String networkName = Signum.getPropertyService().getString(Props.NETWORK_NAME);
         SwingUtilities.invokeLater(() -> setTitle(
             this.programName + " [" + networkName + "] " + this.version)
             );

--- a/src/brs/Constants.java
+++ b/src/brs/Constants.java
@@ -7,27 +7,27 @@ public final class Constants {
 
   public static final String SIGNUM_NETWORK_NAME = "Signum";
 
-  public static final int BURST_DIFF_ADJUST_CHANGE_BLOCK = 2700;
+  public static final int SIGNUM_DIFF_ADJUST_CHANGE_BLOCK = 2700;
 
-  public static final long BURST_REWARD_RECIPIENT_ASSIGNMENT_WAIT_TIME = 4;
+  public static final long SIGNA_REWARD_RECIPIENT_ASSIGNMENT_WAIT_TIME = 4;
 
   // not sure when these were enabled, but they each do an alias lookup every block if greater than the current height
-  public static final long BURST_ESCROW_START_BLOCK = 0;
-  public static final long BURST_SUBSCRIPTION_START_BLOCK = 0;
-  public static final int BURST_SUBSCRIPTION_MIN_FREQ = 3600;
-  public static final int BURST_SUBSCRIPTION_MAX_FREQ = 31536000;
+  public static final long SIGNUM_ESCROW_START_BLOCK = 0;
+  public static final long SIGNUM_SUBSCRIPTION_START_BLOCK = 0;
+  public static final int SIGNUM_SUBSCRIPTION_MIN_FREQ = 3600;
+  public static final int SIGNUM_SUBSCRIPTION_MAX_FREQ = 31536000;
 
   public static final int BLOCK_HEADER_LENGTH = 232;
 
-  public static final long MAX_BALANCE_BURST = 2158812800L;
+  public static final long MAX_BALANCE_SIGNA = 2158812800L;
 
   public static final long FEE_QUANT_SIP3 = 735_000;
   public static final long FEE_QUANT_SIP34 = 1_000_000;
-  public static final long ONE_BURST = 100000000;
-  public static final long INITIAL_COMMITMENT = 1000 * ONE_BURST;
+  public static final long ONE_SIGNA = 100000000;
+  public static final long INITIAL_COMMITMENT = 1000 * ONE_SIGNA;
   public static final int COMMITMENT_WAIT = 60;
 
-  public static final long MAX_BALANCE_NQT = MAX_BALANCE_BURST * ONE_BURST;
+  public static final long MAX_BALANCE_NQT = MAX_BALANCE_SIGNA * ONE_SIGNA;
   public static final long INITIAL_BASE_TARGET = 18325193796L;
   public static final int CAPACITY_ESTIMATION_BLOCKS_MAX = 10800 * 3;
   public static final int CAPACITY_ESTIMATION_BLOCKS = 360;
@@ -53,7 +53,7 @@ public final class Constants {
   public static final int MAX_ACCOUNT_DESCRIPTION_LENGTH = 1000;
 
   public static final long MAX_ASSET_QUANTITY_QNT = 1000000000L * 100000000L;
-  public static final long ASSET_ISSUANCE_FEE_NQT = 1000 * ONE_BURST;
+  public static final long ASSET_ISSUANCE_FEE_NQT = 1000 * ONE_SIGNA;
   public static final int MIN_ASSET_NAME_LENGTH = 3;
   public static final int MAX_ASSET_NAME_LENGTH = 10;
   public static final int MAX_ASSET_DESCRIPTION_LENGTH = 1000;
@@ -77,7 +77,7 @@ public final class Constants {
 
   public static final String HTTP = "http://";
 
-  static final long UNCONFIRMED_POOL_DEPOSIT_NQT = 100 * ONE_BURST;
+  static final long UNCONFIRMED_POOL_DEPOSIT_NQT = 100 * ONE_SIGNA;
 
   // TODO burstkit4j integration
   public static final long EPOCH_BEGINNING;

--- a/src/brs/DebugTrace.java
+++ b/src/brs/DebugTrace.java
@@ -186,8 +186,8 @@ public final class DebugTrace {
     Account.Balance account = Account.getAccountBalance(accountId);
     map.put("balance", String.valueOf(account != null ? account.getBalanceNQT() : 0));
     map.put("unconfirmed balance", String.valueOf(account != null ? account.getUnconfirmedBalanceNQT() : 0));
-    map.put("timestamp", String.valueOf(Burst.getBlockchain().getLastBlock().getTimestamp()));
-    map.put("height", String.valueOf(Burst.getBlockchain().getHeight()));
+    map.put("timestamp", String.valueOf(Signum.getBlockchain().getLastBlock().getTimestamp()));
+    map.put("height", String.valueOf(Signum.getBlockchain().getHeight()));
     map.put("event", unconfirmed ? "unconfirmed balance" : "balance");
     return map;
   }
@@ -252,8 +252,8 @@ public final class DebugTrace {
     } else {
       map.put("asset balance", String.valueOf(accountAsset.getQuantityQNT()));
     }
-    map.put("timestamp", String.valueOf(Burst.getBlockchain().getLastBlock().getTimestamp()));
-    map.put("height", String.valueOf(Burst.getBlockchain().getHeight()));
+    map.put("timestamp", String.valueOf(Signum.getBlockchain().getLastBlock().getTimestamp()));
+    map.put("height", String.valueOf(Signum.getBlockchain().getHeight()));
     map.put("event", "asset balance");
     return map;
   }
@@ -351,8 +351,8 @@ public final class DebugTrace {
     else if (attachment == Attachment.ARBITRARY_MESSAGE) {
       map = new HashMap<>();
       map.put("account", Convert.toUnsignedLong(accountId));
-      map.put("timestamp", String.valueOf(Burst.getBlockchain().getLastBlock().getTimestamp()));
-      map.put("height", String.valueOf(Burst.getBlockchain().getHeight()));
+      map.put("timestamp", String.valueOf(Signum.getBlockchain().getLastBlock().getTimestamp()));
+      map.put("height", String.valueOf(Signum.getBlockchain().getHeight()));
       map.put("event", "message");
       if (isRecipient) {
         map.put("sender", Convert.toUnsignedLong(transaction.getSenderId()));

--- a/src/brs/DigitalGoodsStore.java
+++ b/src/brs/DigitalGoodsStore.java
@@ -19,11 +19,11 @@ public final class DigitalGoodsStore {
   public static class Goods {
 
     private static BurstKey.LongKeyFactory<Goods> goodsDbKeyFactory() {
-      return Burst.getStores().getDigitalGoodsStoreStore().getGoodsDbKeyFactory();
+      return Signum.getStores().getDigitalGoodsStoreStore().getGoodsDbKeyFactory();
     }
 
     private static VersionedEntityTable<Goods> goodsTable() {
-      return Burst.getStores().getDigitalGoodsStoreStore().getGoodsTable();
+      return Signum.getStores().getDigitalGoodsStoreStore().getGoodsTable();
     }
 
     private final long id;
@@ -122,23 +122,23 @@ public final class DigitalGoodsStore {
   public static class Purchase {
 
     private static BurstKey.LongKeyFactory<Purchase> purchaseDbKeyFactory() {
-      return Burst.getStores().getDigitalGoodsStoreStore().getPurchaseDbKeyFactory();
+      return Signum.getStores().getDigitalGoodsStoreStore().getPurchaseDbKeyFactory();
     }
 
     private static BurstKey.LongKeyFactory<Purchase> feedbackDbKeyFactory() {
-      return Burst.getStores().getDigitalGoodsStoreStore().getFeedbackDbKeyFactory();
+      return Signum.getStores().getDigitalGoodsStoreStore().getFeedbackDbKeyFactory();
     }
 
     private static VersionedValuesTable<Purchase, EncryptedData> feedbackTable() {
-      return Burst.getStores().getDigitalGoodsStoreStore().getFeedbackTable();
+      return Signum.getStores().getDigitalGoodsStoreStore().getFeedbackTable();
     }
 
     private static BurstKey.LongKeyFactory<Purchase> publicFeedbackDbKeyFactory() {
-      return Burst.getStores().getDigitalGoodsStoreStore().getPublicFeedbackDbKeyFactory();
+      return Signum.getStores().getDigitalGoodsStoreStore().getPublicFeedbackDbKeyFactory();
     }
 
     private static VersionedValuesTable<Purchase, String> publicFeedbackTable() {
-      return Burst.getStores().getDigitalGoodsStoreStore().getPublicFeedbackTable();
+      return Signum.getStores().getDigitalGoodsStoreStore().getPublicFeedbackTable();
     }
 
     private final long id;

--- a/src/brs/DigitalGoodsStore.java
+++ b/src/brs/DigitalGoodsStore.java
@@ -1,7 +1,7 @@
 package brs;
 
 import brs.crypto.EncryptedData;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.VersionedEntityTable;
 import brs.db.VersionedValuesTable;
 
@@ -18,7 +18,7 @@ public final class DigitalGoodsStore {
 
   public static class Goods {
 
-    private static BurstKey.LongKeyFactory<Goods> goodsDbKeyFactory() {
+    private static SignumKey.LongKeyFactory<Goods> goodsDbKeyFactory() {
       return Signum.getStores().getDigitalGoodsStoreStore().getGoodsDbKeyFactory();
     }
 
@@ -27,7 +27,7 @@ public final class DigitalGoodsStore {
     }
 
     private final long id;
-    public final BurstKey dbKey;
+    public final SignumKey dbKey;
     private final long sellerId;
     private final String name;
     private final String description;
@@ -37,7 +37,7 @@ public final class DigitalGoodsStore {
     private long priceNQT;
     private boolean delisted;
 
-    protected Goods(long id, BurstKey dbKey, long sellerId, String name, String description, String tags, int timestamp,
+    protected Goods(long id, SignumKey dbKey, long sellerId, String name, String description, String tags, int timestamp,
                     int quantity, long priceNQT, boolean delisted) {
       this.id = id;
       this.dbKey = dbKey;
@@ -51,7 +51,7 @@ public final class DigitalGoodsStore {
       this.delisted = delisted;
     }
 
-    public Goods(BurstKey dbKey, Transaction transaction, Attachment.DigitalGoodsListing attachment) {
+    public Goods(SignumKey dbKey, Transaction transaction, Attachment.DigitalGoodsListing attachment) {
       this.dbKey = dbKey;
       this.id = transaction.getId();
       this.sellerId = transaction.getSenderId();
@@ -121,11 +121,11 @@ public final class DigitalGoodsStore {
 
   public static class Purchase {
 
-    private static BurstKey.LongKeyFactory<Purchase> purchaseDbKeyFactory() {
+    private static SignumKey.LongKeyFactory<Purchase> purchaseDbKeyFactory() {
       return Signum.getStores().getDigitalGoodsStoreStore().getPurchaseDbKeyFactory();
     }
 
-    private static BurstKey.LongKeyFactory<Purchase> feedbackDbKeyFactory() {
+    private static SignumKey.LongKeyFactory<Purchase> feedbackDbKeyFactory() {
       return Signum.getStores().getDigitalGoodsStoreStore().getFeedbackDbKeyFactory();
     }
 
@@ -133,7 +133,7 @@ public final class DigitalGoodsStore {
       return Signum.getStores().getDigitalGoodsStoreStore().getFeedbackTable();
     }
 
-    private static BurstKey.LongKeyFactory<Purchase> publicFeedbackDbKeyFactory() {
+    private static SignumKey.LongKeyFactory<Purchase> publicFeedbackDbKeyFactory() {
       return Signum.getStores().getDigitalGoodsStoreStore().getPublicFeedbackDbKeyFactory();
     }
 
@@ -142,7 +142,7 @@ public final class DigitalGoodsStore {
     }
 
     private final long id;
-    public final BurstKey dbKey;
+    public final SignumKey dbKey;
     private final long buyerId;
     private final long goodsId;
     private final long sellerId;
@@ -176,7 +176,7 @@ public final class DigitalGoodsStore {
       this.isPending = true;
     }
 
-    protected Purchase(long id, BurstKey dbKey, long buyerId, long goodsId, long sellerId, int quantity,
+    protected Purchase(long id, SignumKey dbKey, long buyerId, long goodsId, long sellerId, int quantity,
                        long priceNQT, int deadline, EncryptedData note, int timestamp, boolean isPending,
                        EncryptedData encryptedGoods,EncryptedData refundNote,
                        boolean hasFeedbackNotes, boolean hasPublicFeedbacks,

--- a/src/brs/EconomicClustering.java
+++ b/src/brs/EconomicClustering.java
@@ -44,10 +44,10 @@ public final class EconomicClustering {
 
   public boolean verifyFork(Transaction transaction) {
     try {
-      if (!Burst.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE)) {
+      if (!Signum.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE)) {
         return true;
       }
-      if (transaction.getReferencedTransactionFullHash() != null && !Burst.getFluxCapacitor().getValue(FluxValues.SPEEDWAY)) {
+      if (transaction.getReferencedTransactionFullHash() != null && !Signum.getFluxCapacitor().getValue(FluxValues.SPEEDWAY)) {
         // TODO: remove this conditional above in the future, do the EC check regardless of a full hash reference
         return true;
       }

--- a/src/brs/Escrow.java
+++ b/src/brs/Escrow.java
@@ -1,6 +1,6 @@
 package brs;
 
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 
 import java.util.Collection;
 
@@ -77,10 +77,10 @@ public class Escrow {
 
     public final Long escrowId;
     public final Long accountId;
-    public final BurstKey dbKey;
+    public final SignumKey dbKey;
     private DecisionType decisionType;
 
-    public Decision(BurstKey dbKey, Long escrowId, Long accountId, DecisionType decisionType) {
+    public Decision(SignumKey dbKey, Long escrowId, Long accountId, DecisionType decisionType) {
       this.dbKey = dbKey;
       this.escrowId = escrowId;
       this.accountId = accountId;
@@ -108,13 +108,13 @@ public class Escrow {
   public final Long senderId;
   public final Long recipientId;
   public final Long id;
-  public final BurstKey dbKey;
+  public final SignumKey dbKey;
   public final Long amountNQT;
   public final int requiredSigners;
   public final int deadline;
   public final DecisionType deadlineAction;
 
-  public Escrow(BurstKey dbKey, Account sender,
+  public Escrow(SignumKey dbKey, Account sender,
       Account recipient,
       Long id,
       Long amountNQT,
@@ -131,7 +131,7 @@ public class Escrow {
     this.deadlineAction = deadlineAction;
   }
 
-  protected Escrow(Long id, Long senderId, Long recipientId, BurstKey dbKey, Long amountNQT,
+  protected Escrow(Long id, Long senderId, Long recipientId, SignumKey dbKey, Long amountNQT,
       int requiredSigners, int deadline, DecisionType deadlineAction) {
     this.senderId = senderId;
     this.recipientId = recipientId;

--- a/src/brs/Escrow.java
+++ b/src/brs/Escrow.java
@@ -164,7 +164,7 @@ public class Escrow {
   }
 
   public Collection<Decision> getDecisions() {
-    return Burst.getStores().getEscrowStore().getDecisions(id);
+    return Signum.getStores().getEscrowStore().getDecisions(id);
   }
 
   public int getDeadline() {

--- a/src/brs/GeneratorImpl.java
+++ b/src/brs/GeneratorImpl.java
@@ -319,11 +319,11 @@ public class GeneratorImpl implements Generator {
       }
       for(Transaction tx : blockIt.getTransactions()) {
         if(tx.getSenderId() == generatorId) {
-          if(blockIt.getHeight() <= height - commitmentWait && tx.getType() == TransactionType.BurstMining.COMMITMENT_ADD) {
+          if(blockIt.getHeight() <= height - commitmentWait && tx.getType() == TransactionType.SignaMining.COMMITMENT_ADD) {
             CommitmentAdd txAttachment = (CommitmentAdd) tx.getAttachment();
             committedAmountOnCache += txAttachment.getAmountNQT();
           }
-          if(tx.getType() == TransactionType.BurstMining.COMMITMENT_REMOVE) {
+          if(tx.getType() == TransactionType.SignaMining.COMMITMENT_REMOVE) {
             CommitmentRemove txAttachment = (CommitmentRemove) tx.getAttachment();
             committedAmountOnCache -= txAttachment.getAmountNQT();
           }

--- a/src/brs/GeneratorImpl.java
+++ b/src/brs/GeneratorImpl.java
@@ -34,7 +34,7 @@ public class GeneratorImpl implements Generator {
 
   private final Listeners<GeneratorState, Event> listeners = new Listeners<>();
   private final ConcurrentMap<Long, GeneratorStateImpl> generators = new ConcurrentHashMap<>();
-  private final SignumCrypto burstCrypto = SignumCrypto.getInstance();
+  private final SignumCrypto signumCrypto = SignumCrypto.getInstance();
   private final Blockchain blockchain;
   private final DownloadCacheImpl downloadCache;
   private final TimeService timeService;
@@ -120,12 +120,12 @@ public class GeneratorImpl implements Generator {
 
   @Override
   public byte[] calculateGenerationSignature(byte[] lastGenSig, long lastGenId) {
-    return burstCrypto.calculateGenerationSignature(lastGenSig, lastGenId);
+    return signumCrypto.calculateGenerationSignature(lastGenSig, lastGenId);
   }
 
   @Override
   public int calculateScoop(byte[] genSig, long height) {
-    return burstCrypto.calculateScoop(genSig, height);
+    return signumCrypto.calculateScoop(genSig, height);
   }
 
   private int getPocVersion(int blockHeight) {
@@ -134,12 +134,12 @@ public class GeneratorImpl implements Generator {
 
   @Override
   public BigInteger calculateHit(long accountId, long nonce, byte[] genSig, int scoop, int blockHeight) {
-    return burstCrypto.calculateHit(accountId, nonce, genSig, scoop, getPocVersion(blockHeight));
+    return signumCrypto.calculateHit(accountId, nonce, genSig, scoop, getPocVersion(blockHeight));
   }
 
   @Override
   public BigInteger calculateHit(byte[] genSig, byte[] scoopData) {
-    return burstCrypto.calculateHit(genSig, scoopData);
+    return signumCrypto.calculateHit(genSig, scoopData);
   }
 
   @Override

--- a/src/brs/OCLPoC.java
+++ b/src/brs/OCLPoC.java
@@ -47,7 +47,7 @@ final class OCLPoC {
       + MiningPlot.SCOOP_SIZE; // output scoop
 
   static {
-    PropertyService propertyService = Burst.getPropertyService();
+    PropertyService propertyService = Signum.getPropertyService();
     HASHES_PER_ENQUEUE = propertyService.getInt(Props.GPU_HASHES_PER_BATCH);
     MEM_PERCENT = propertyService.getInt(Props.GPU_MEM_PERCENT);
     

--- a/src/brs/Order.java
+++ b/src/brs/Order.java
@@ -2,7 +2,7 @@ package brs;
 
 import java.util.Collection;
 
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.util.Convert;
 
 public abstract class Order {
@@ -69,14 +69,14 @@ public abstract class Order {
 
   public static class Ask extends Order {
 
-    public final BurstKey dbKey;
+    public final SignumKey dbKey;
 
-    public Ask(BurstKey dbKey, Transaction transaction, Attachment.ColoredCoinsAskOrderPlacement attachment) {
+    public Ask(SignumKey dbKey, Transaction transaction, Attachment.ColoredCoinsAskOrderPlacement attachment) {
       super(transaction, attachment);
       this.dbKey = dbKey;
     }
 
-    protected Ask(long id, long accountId, long assetId, long priceNQT, int creationHeight, long quantityQNT, BurstKey dbKey) {
+    protected Ask(long id, long accountId, long assetId, long priceNQT, int creationHeight, long quantityQNT, SignumKey dbKey) {
       super(id, accountId, assetId, priceNQT, creationHeight, quantityQNT);
       this.dbKey = dbKey;
     }
@@ -85,14 +85,14 @@ public abstract class Order {
 
   public static class Bid extends Order {
 
-    public final BurstKey dbKey;
+    public final SignumKey dbKey;
 
-    public Bid(BurstKey dbKey, Transaction transaction, Attachment.ColoredCoinsBidOrderPlacement attachment) {
+    public Bid(SignumKey dbKey, Transaction transaction, Attachment.ColoredCoinsBidOrderPlacement attachment) {
       super(transaction, attachment);
       this.dbKey = dbKey;
     }
 
-    protected Bid(long id, long accountId, long assetId, long priceNQT, int creationHeight, long quantityQNT, BurstKey dbKey) {
+    protected Bid(long id, long accountId, long assetId, long priceNQT, int creationHeight, long quantityQNT, SignumKey dbKey) {
       super(id, accountId, assetId, priceNQT, creationHeight, quantityQNT);
       this.dbKey = dbKey;
     }

--- a/src/brs/Signum.java
+++ b/src/brs/Signum.java
@@ -47,7 +47,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-// TODO: rename to Signum
 public final class Signum {
 
   public static final Version VERSION = Version.parse("v3.8.0");

--- a/src/brs/Signum.java
+++ b/src/brs/Signum.java
@@ -48,7 +48,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 // TODO: rename to Signum
-public final class Burst {
+public final class Signum {
 
   public static final Version VERSION = Version.parse("v3.8.0");
   public static final String APPLICATION = "BRS";
@@ -74,7 +74,7 @@ public final class Burst {
 	        		.longOpt("help")
 	        		.build());
 
-  private static final Logger logger = LoggerFactory.getLogger(Burst.class);
+  private static final Logger logger = LoggerFactory.getLogger(Signum.class);
 
   private static Stores stores;
   private static Dbs dbs;
@@ -120,7 +120,7 @@ public final class Burst {
     return new PropertyServiceImpl(properties);
   }
 
-  private Burst() {
+  private Signum() {
   } // never
 
   public static Blockchain getBlockchain() {
@@ -156,7 +156,7 @@ public final class Burst {
   }
 
   public static void main(String []args) {
-    Runtime.getRuntime().addShutdownHook(new Thread(Burst::shutdown));
+    Runtime.getRuntime().addShutdownHook(new Thread(Signum::shutdown));
     String confFolder = CONF_FOLDER;
     try {
       CommandLine cmd = new DefaultParser().parse(CLI_OPTIONS, args);
@@ -189,7 +189,7 @@ public final class Burst {
   private static void loadWallet(PropertyService propertyService) {
     LoggerConfigurator.init();
 
-    Burst.propertyService = propertyService;
+    Signum.propertyService = propertyService;
 
     String networkParametersClass = propertyService.getString(Props.NETWORK_PARAMETERS);
     NetworkParameters params = null;
@@ -333,7 +333,7 @@ public final class Burst {
       logger.error(e.getMessage(), e);
       System.exit(1);
     }
-    (new Thread(Burst::commandHandler)).start();
+    (new Thread(Signum::commandHandler)).start();
   }
 
   private static void addBlockchainListeners(BlockchainProcessor blockchainProcessor, AccountService accountService, AssetExchange assetExchange, DGSGoodsStoreService goodsService, Blockchain blockchain,

--- a/src/brs/SignumException.java
+++ b/src/brs/SignumException.java
@@ -1,24 +1,24 @@
 package brs;
 
-public abstract class BurstException extends Exception {
+public abstract class SignumException extends Exception {
 
-  protected BurstException() {
+  protected SignumException() {
     super();
   }
 
-  BurstException(String message) {
+  SignumException(String message) {
     super(message);
   }
 
-  BurstException(String message, Throwable cause) {
+  SignumException(String message, Throwable cause) {
     super(message, cause);
   }
 
-  protected BurstException(Throwable cause) {
+  protected SignumException(Throwable cause) {
     super(cause);
   }
 
-  public abstract static class ValidationException extends BurstException {
+  public abstract static class ValidationException extends SignumException {
 
     private ValidationException(String message) {
       super(message);

--- a/src/brs/SignumGUI.java
+++ b/src/brs/SignumGUI.java
@@ -78,7 +78,7 @@ public class SignumGUI extends JFrame {
     }
 
     public SignumGUI(String programName, String iconLocation, String version, String []args) {
-        System.setSecurityManager(new BurstGUISecurityManager());
+        System.setSecurityManager(new SignaGUISecurityManager());
         SignumGUI.args = args;
         this.programName = programName;
         this.version = version;
@@ -443,7 +443,7 @@ public class SignumGUI extends JFrame {
         }
     }
 
-    private class BurstGUISecurityManager extends SecurityManager {
+    private class SignaGUISecurityManager extends SecurityManager {
 
         @Override
         public void checkExit(int status) {

--- a/src/brs/SignumGUI.java
+++ b/src/brs/SignumGUI.java
@@ -51,7 +51,7 @@ import jiconfont.icons.font_awesome.FontAwesome;
 import jiconfont.swing.IconFontSwing;
 
 @SuppressWarnings("serial")
-public class BurstGUI extends JFrame {
+public class SignumGUI extends JFrame {
     private static final String FAILED_TO_START_MESSAGE = "Signum caught exception while starting";
     private static final String UNEXPECTED_EXIT_MESSAGE = "Signum Quit unexpectedly! Exit code ";
 
@@ -59,7 +59,7 @@ public class BurstGUI extends JFrame {
 
     private static final int OUTPUT_MAX_LINES = 500;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(BurstGUI.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SignumGUI.class);
     private static String []args;
 
     private boolean userClosed = false;
@@ -74,12 +74,12 @@ public class BurstGUI extends JFrame {
     Color iconColor = Color.BLACK;
 
     public static void main(String []args) {
-        new BurstGUI("Signum Node", Props.ICON_LOCATION.getDefaultValue(), Signum.VERSION.toString(), args);
+        new SignumGUI("Signum Node", Props.ICON_LOCATION.getDefaultValue(), Signum.VERSION.toString(), args);
     }
 
-    public BurstGUI(String programName, String iconLocation, String version, String []args) {
+    public SignumGUI(String programName, String iconLocation, String version, String []args) {
         System.setSecurityManager(new BurstGUISecurityManager());
-        BurstGUI.args = args;
+        SignumGUI.args = args;
         this.programName = programName;
         this.version = version;
         setTitle(programName + " " + version);
@@ -169,7 +169,7 @@ public class BurstGUI extends JFrame {
         	@Override
         	public void windowClosing(WindowEvent e) {
         		if(trayIcon == null) {
-        			if (JOptionPane.showConfirmDialog(BurstGUI.this,
+        			if (JOptionPane.showConfirmDialog(SignumGUI.this,
         					"This will stop the node. Are you sure?", "Exit and stop node",
         					JOptionPane.YES_NO_OPTION,
         					JOptionPane.QUESTION_MESSAGE) == JOptionPane.YES_OPTION){
@@ -292,7 +292,7 @@ public class BurstGUI extends JFrame {
           iconLocation = newIconLocation;
           setIconImage(ImageIO.read(getClass().getResourceAsStream(iconLocation)));
         }
-    		TrayIcon newTrayIcon = new TrayIcon(Toolkit.getDefaultToolkit().createImage(BurstGUI.class.getResource(iconLocation)), "Signum Node", popupMenu);
+    		TrayIcon newTrayIcon = new TrayIcon(Toolkit.getDefaultToolkit().createImage(SignumGUI.class.getResource(iconLocation)), "Signum Node", popupMenu);
     		newTrayIcon.setImage(newTrayIcon.getImage().getScaledInstance(newTrayIcon.getSize().width, -1, Image.SCALE_SMOOTH));
     		if(phoenixIndex.isFile() && phoenixIndex.exists()) {
     		  newTrayIcon.addActionListener(e -> openWebUi("/phoenix"));

--- a/src/brs/Subscription.java
+++ b/src/brs/Subscription.java
@@ -1,6 +1,6 @@
 package brs;
 
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -9,7 +9,7 @@ public class Subscription {
   public Long senderId;
   public final Long recipientId;
   public final Long id;
-  public final BurstKey dbKey;
+  public final SignumKey dbKey;
   public final Long amountNQT;
   public final int frequency;
   private final AtomicInteger timeNext;
@@ -20,7 +20,7 @@ public class Subscription {
                          Long amountNQT,
                          int frequency,
                          int timeNext,
-                         BurstKey dbKey
+                         SignumKey dbKey
                          ) {
     this.senderId = senderId;
     this.recipientId = recipientId;

--- a/src/brs/Trade.java
+++ b/src/brs/Trade.java
@@ -1,6 +1,6 @@
 package brs;
 
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.util.Convert;
 
 public class Trade {
@@ -19,14 +19,14 @@ public class Trade {
   private final int bidOrderHeight;
   private final long sellerId;
   private final long buyerId;
-  public final BurstKey dbKey;
+  public final SignumKey dbKey;
   private final long quantityQNT;
   private final long priceNQT;
   private final boolean isBuy;
 
   protected Trade(int timestamp, long assetId, long blockId, int height,
                   long askOrderId, long bidOrderId, int askOrderHeight, int bidOrderHeight,
-                  long sellerId, long buyerId, BurstKey dbKey, long quantityQNT, long priceNQT) {
+                  long sellerId, long buyerId, SignumKey dbKey, long quantityQNT, long priceNQT) {
     this.timestamp = timestamp;
     this.assetId = assetId;
     this.blockId = blockId;
@@ -43,7 +43,7 @@ public class Trade {
     this.isBuy = askOrderHeight < bidOrderHeight || (askOrderHeight == bidOrderHeight && askOrderId < bidOrderId);
   }
 
-  public Trade(BurstKey dbKey, long assetId, Block block, Order.Ask askOrder, Order.Bid bidOrder) {
+  public Trade(SignumKey dbKey, long assetId, Block block, Order.Ask askOrder, Order.Bid bidOrder) {
     this.dbKey = dbKey;
     this.blockId = block.getId();
     this.height = block.getHeight();

--- a/src/brs/Transaction.java
+++ b/src/brs/Transaction.java
@@ -431,7 +431,7 @@ public class Transaction implements Comparable<Transaction> {
       buffer.put((byte) ((version << 4) | ( type.getSubtype() & 0xff ) ));
       buffer.putInt(timestamp);
       buffer.putShort(deadline);
-      if(type.isSigned() || !Burst.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_4)) {
+      if(type.isSigned() || !Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_4)) {
         buffer.put(senderPublicKey);
       } else {
         buffer.putLong(senderId.get());

--- a/src/brs/TransactionProcessor.java
+++ b/src/brs/TransactionProcessor.java
@@ -27,13 +27,13 @@ public interface TransactionProcessor extends Observable<List<? extends Transact
 
   void clearUnconfirmedTransactions();
 
-  Integer broadcast(Transaction transaction) throws BurstException.ValidationException;
+  Integer broadcast(Transaction transaction) throws SignumException.ValidationException;
 
-  void processPeerTransactions(JsonObject request, Peer peer) throws BurstException.ValidationException;
+  void processPeerTransactions(JsonObject request, Peer peer) throws SignumException.ValidationException;
 
-  Transaction parseTransaction(byte[] bytes) throws BurstException.ValidationException;
+  Transaction parseTransaction(byte[] bytes) throws SignumException.ValidationException;
 
-  Transaction parseTransaction(JsonObject json) throws BurstException.ValidationException;
+  Transaction parseTransaction(JsonObject json) throws SignumException.ValidationException;
 
   Transaction.Builder newTransactionBuilder(byte[] senderPublicKey, long amountNQT, long feeNQT, short deadline, Attachment attachment);
 

--- a/src/brs/TransactionProcessorImpl.java
+++ b/src/brs/TransactionProcessorImpl.java
@@ -1,6 +1,6 @@
 package brs;
 
-import brs.BurstException.ValidationException;
+import brs.SignumException.ValidationException;
 import brs.db.store.Dbs;
 import brs.db.store.Stores;
 import brs.fluxcapacitor.FluxValues;
@@ -193,9 +193,9 @@ public class TransactionProcessorImpl implements TransactionProcessor {
   }
 
   @Override
-  public Integer broadcast(Transaction transaction) throws BurstException.ValidationException {
+  public Integer broadcast(Transaction transaction) throws SignumException.ValidationException {
     if (! transaction.verifySignature()) {
-      throw new BurstException.NotValidException("Transaction signature verification failed");
+      throw new SignumException.NotValidException("Transaction signature verification failed");
     }
     List<Transaction> processedTransactions;
     if (dbs.getTransactionDb().hasTransaction(transaction.getId())) {
@@ -220,12 +220,12 @@ public class TransactionProcessorImpl implements TransactionProcessor {
       if (logger.isDebugEnabled()) {
         logger.debug("Could not accept new transaction {}", transaction.getStringId());
       }
-      throw new BurstException.NotValidException("Invalid transaction " + transaction.getStringId());
+      throw new SignumException.NotValidException("Invalid transaction " + transaction.getStringId());
     }
   }
 
   @Override
-  public void processPeerTransactions(JsonObject request, Peer peer) throws BurstException.ValidationException {
+  public void processPeerTransactions(JsonObject request, Peer peer) throws SignumException.ValidationException {
     JsonArray transactionsData = JSON.getAsJsonArray(request.get("transactions"));
     List<Transaction> processedTransactions = processPeerTransactions(transactionsData, peer);
 
@@ -235,12 +235,12 @@ public class TransactionProcessorImpl implements TransactionProcessor {
   }
 
   @Override
-  public Transaction parseTransaction(byte[] bytes) throws BurstException.ValidationException {
+  public Transaction parseTransaction(byte[] bytes) throws SignumException.ValidationException {
     return Transaction.parseTransaction(bytes);
   }
 
   @Override
-  public Transaction parseTransaction(JsonObject transactionData) throws BurstException.NotValidException {
+  public Transaction parseTransaction(JsonObject transactionData) throws SignumException.NotValidException {
     return Transaction.parseTransaction(transactionData, blockchain.getHeight());
   }
 
@@ -289,13 +289,13 @@ public class TransactionProcessorImpl implements TransactionProcessor {
       try {
         unconfirmedTransactionStore.put(transaction, null);
       }
-      catch ( BurstException.ValidationException e ) {
+      catch ( SignumException.ValidationException e ) {
         logger.debug("Discarding invalid transaction in for later processing: " + JSON.toJsonString(transaction.getJsonObject()), e);
       }
     }
   }
 
-  private List<Transaction> processPeerTransactions(JsonArray transactionsData, Peer peer) throws BurstException.ValidationException {
+  private List<Transaction> processPeerTransactions(JsonArray transactionsData, Peer peer) throws SignumException.ValidationException {
 	  if (blockchain.getLastBlock().getTimestamp() < timeService.getEpochTime() - 60 * 1440 && ! testUnconfirmedTransactions) {
       return new ArrayList<>();
     }
@@ -309,8 +309,8 @@ public class TransactionProcessorImpl implements TransactionProcessor {
           continue;
         }
         transactions.add(transaction);
-      } catch (BurstException.NotCurrentlyValidException ignore) {
-      } catch (BurstException.NotValidException e) {
+      } catch (SignumException.NotCurrentlyValidException ignore) {
+      } catch (SignumException.NotValidException e) {
         if (logger.isDebugEnabled()) {
           logger.debug("Invalid transaction from peer: {}", JSON.toJsonString(transactionData));
         }
@@ -320,7 +320,7 @@ public class TransactionProcessorImpl implements TransactionProcessor {
     return processTransactions(transactions, peer);
   }
 
-  private List<Transaction> processTransactions(Collection<Transaction> transactions, Peer peer) throws BurstException.ValidationException {
+  private List<Transaction> processTransactions(Collection<Transaction> transactions, Peer peer) throws SignumException.ValidationException {
     synchronized (unconfirmedTransactionsSyncObj) {
       if (transactions.isEmpty()) {
         return Collections.emptyList();

--- a/src/brs/TransactionProcessorImpl.java
+++ b/src/brs/TransactionProcessorImpl.java
@@ -274,8 +274,8 @@ public class TransactionProcessorImpl implements TransactionProcessor {
 
   @Override
   public int getTransactionVersion(int previousBlockHeight) {
-    if(Burst.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE, previousBlockHeight)){
-      if(Burst.getFluxCapacitor().getValue(FluxValues.SMART_FEES, previousBlockHeight)){
+    if(Signum.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE, previousBlockHeight)){
+      if(Signum.getFluxCapacitor().getValue(FluxValues.SMART_FEES, previousBlockHeight)){
         return 2;
       }
       return 1;

--- a/src/brs/TransactionType.java
+++ b/src/brs/TransactionType.java
@@ -272,7 +272,7 @@ public abstract class TransactionType {
   private Long calculateTransactionAmountNQT(Transaction transaction) {
     long totalAmountNQT = Convert.safeAdd(transaction.getAmountNQT(), transaction.getFeeNQT());
     if (transaction.getReferencedTransactionFullHash() != null &&
-        !Burst.getFluxCapacitor().getValue(FluxValues.SIGNUM, transaction.getHeight()) ) {
+        !Signum.getFluxCapacitor().getValue(FluxValues.SIGNUM, transaction.getHeight()) ) {
       totalAmountNQT = Convert.safeAdd(totalAmountNQT, Constants.UNCONFIRMED_POOL_DEPOSIT_NQT);
     }
     return totalAmountNQT;
@@ -287,15 +287,15 @@ public abstract class TransactionType {
   final void apply(Transaction transaction, Account senderAccount, Account recipientAccount) {
     accountService.addToBalanceNQT(senderAccount, - (Convert.safeAdd(transaction.getAmountNQT(), transaction.getFeeNQT())));
     if (transaction.getReferencedTransactionFullHash() != null &&
-        !Burst.getFluxCapacitor().getValue(FluxValues.SIGNUM, transaction.getHeight())) {
+        !Signum.getFluxCapacitor().getValue(FluxValues.SIGNUM, transaction.getHeight())) {
       accountService.addToUnconfirmedBalanceNQT(senderAccount, Constants.UNCONFIRMED_POOL_DEPOSIT_NQT);
     }
     if (recipientAccount != null && transaction.getAmountNQT() > 0L && !transaction.getType().isIndirect() ) {
       accountService.addToBalanceAndUnconfirmedBalanceNQT(recipientAccount, transaction.getAmountNQT());
     }
-    if (Burst.getFluxCapacitor().getValue(FluxValues.SMART_FEES, transaction.getHeight())) {
+    if (Signum.getFluxCapacitor().getValue(FluxValues.SMART_FEES, transaction.getHeight())) {
       Account cashBackAccount = accountService.getOrAddAccount(transaction.getCashBackId());
-      long cashBackAmountNQT = transaction.getFeeNQT() / Burst.getPropertyService().getInt(Props.CASH_BACK_FACTOR);
+      long cashBackAmountNQT = transaction.getFeeNQT() / Signum.getPropertyService().getInt(Props.CASH_BACK_FACTOR);
       accountService.addToBalanceAndUnconfirmedBalanceNQT(cashBackAccount, cashBackAmountNQT);
     }
     if (logger.isTraceEnabled()) {
@@ -702,7 +702,7 @@ public abstract class TransactionType {
                 || attachment.getAliasURI().length() > Constants.MAX_ALIAS_URI_LENGTH) {
           throw new BurstException.NotValidException("Invalid alias assignment: " + JSON.toJsonString(attachment.getJsonObject()));
         }
-        if (Burst.getFluxCapacitor().getValue(FluxValues.SMART_ALIASES)) {
+        if (Signum.getFluxCapacitor().getValue(FluxValues.SMART_ALIASES)) {
           if (!TextUtils.isInAlphabetOrUnderline(attachment.getAliasName())) {
             throw new BurstException.NotValidException("Invalid alias name: " + attachment.getAliasName());
           }
@@ -1069,9 +1069,9 @@ public abstract class TransactionType {
                 || attachment.getDecimals() < 0 || attachment.getDecimals() > 8
                 || attachment.getQuantityQNT() < 0
                 || attachment.getQuantityQNT() > Constants.MAX_ASSET_QUANTITY_QNT
-                || (attachment.getVersion()>1 && !Burst.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN))
-                || (attachment.getMintable() && !Burst.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN))
-                || (attachment.getQuantityQNT() == 0 && !attachment.getMintable() && !Burst.getFluxCapacitor().getValue(FluxValues.PK_FREEZE2))
+                || (attachment.getVersion()>1 && !Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN))
+                || (attachment.getMintable() && !Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN))
+                || (attachment.getQuantityQNT() == 0 && !attachment.getMintable() && !Signum.getFluxCapacitor().getValue(FluxValues.PK_FREEZE2))
         ) {
           throw new BurstException.NotValidException("Invalid asset issuance: " + JSON.toJsonString(attachment.getJsonObject()));
         }
@@ -1138,7 +1138,7 @@ public abstract class TransactionType {
       @Override
       protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
         Attachment.ColoredCoinsAssetTransfer attachment = (Attachment.ColoredCoinsAssetTransfer)transaction.getAttachment();
-        if ((!Burst.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN) && transaction.getAmountNQT() != 0)
+        if ((!Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN) && transaction.getAmountNQT() != 0)
                 || attachment.getComment() != null && attachment.getComment().length() > Constants.MAX_ASSET_TRANSFER_COMMENT_LENGTH
                 || attachment.getAssetId() == 0) {
           throw new BurstException.NotValidException("Invalid asset transfer amount or comment: " + JSON.toJsonString(attachment.getJsonObject()));
@@ -1195,7 +1195,7 @@ public abstract class TransactionType {
       protected boolean applyAttachmentUnconfirmed(Transaction transaction, Account senderAccount) {
         logger.trace("TransactionType ASSET_TRANSFER_OWNERSHIP");
 
-        if(!Burst.getFluxCapacitor().getValue(FluxValues.PK_FREEZE2)){
+        if(!Signum.getFluxCapacitor().getValue(FluxValues.PK_FREEZE2)){
           // not available yet
           return false;
         }
@@ -1238,7 +1238,7 @@ public abstract class TransactionType {
           asset = assetExchange.getAsset(assetIssuance.getId());
         }
 
-        if(!Burst.getFluxCapacitor().getValue(FluxValues.PK_FREEZE2)
+        if(!Signum.getFluxCapacitor().getValue(FluxValues.PK_FREEZE2)
           || transaction.getAmountNQT() != 0L
           || asset == null
           || transaction.getSenderId() != asset.getAccountId()){
@@ -1331,7 +1331,7 @@ public abstract class TransactionType {
       @Override
       protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
         Attachment.ColoredCoinsAssetMultiTransfer attachment = (Attachment.ColoredCoinsAssetMultiTransfer)transaction.getAttachment();
-        if ((!Burst.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN))
+        if ((!Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN))
                 || attachment.getAssetIds().size() < 2 || attachment.getAssetIds().size() > Constants.MAX_MULTI_ASSET_IDS) {
           throw new BurstException.NotValidException("Invalid asset multi transfer: " + JSON.toJsonString(attachment.getJsonObject()));
         }
@@ -1387,11 +1387,11 @@ public abstract class TransactionType {
         Asset asset = assetExchange.getAsset(attachment.getAssetId());
         if(asset == null || asset.getAccountId() != transaction.getSenderId() || !asset.getMintable()
             || attachment.getQuantityQNT() <= 0L
-            || !Burst.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
+            || !Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
           return false;
         }
 
-        boolean unconfirmed = !Burst.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX);
+        boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX);
         long circulatingSupply = assetExchange.getAssetCirculatingSupply(asset, false, unconfirmed);
         long newSupply = circulatingSupply + attachment.getQuantityQNT();
         if (newSupply > Constants.MAX_ASSET_QUANTITY_QNT) {
@@ -1421,7 +1421,7 @@ public abstract class TransactionType {
       @Override
       protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
         Attachment.ColoredCoinsAssetMint attachment = (Attachment.ColoredCoinsAssetMint)transaction.getAttachment();
-        if (!Burst.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
+        if (!Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
           throw new BurstException.NotValidException("Transaction type not yet enabled: " + JSON.toJsonString(attachment.getJsonObject()));
         }
 
@@ -1435,7 +1435,7 @@ public abstract class TransactionType {
           throw new BurstException.NotValidException("Invalid asset mint: " + JSON.toJsonString(attachment.getJsonObject()));
         }
 
-        boolean unconfirmed = !Burst.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX);
+        boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX);
         long circulatingSupply = assetExchange.getAssetCirculatingSupply(asset, false, unconfirmed);
         long newSupply = circulatingSupply + attachment.getQuantityQNT();
         if (newSupply > Constants.MAX_ASSET_QUANTITY_QNT) {
@@ -1476,17 +1476,17 @@ public abstract class TransactionType {
       protected boolean applyAttachmentUnconfirmed(Transaction transaction, Account senderAccount) {
         logger.trace("TransactionType ASSET_ADD_TREASURY_ACCOUNT");
 
-        if (!Burst.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
+        if (!Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
           return false;
         }
 
-        Transaction assetCreationTransaction = Burst.getBlockchain().getTransactionByFullHash(transaction.getReferencedTransactionFullHash());
+        Transaction assetCreationTransaction = Signum.getBlockchain().getTransactionByFullHash(transaction.getReferencedTransactionFullHash());
         if(transaction.getAmountNQT() != 0 || assetCreationTransaction == null)
           return false;
 
         Asset asset = assetExchange.getAsset(assetCreationTransaction.getId());
         if(asset == null || asset.getAccountId() != transaction.getSenderId()
-            || !Burst.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
+            || !Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
           return false;
         }
 
@@ -1505,11 +1505,11 @@ public abstract class TransactionType {
 
       @Override
       protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
-        if (!Burst.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
+        if (!Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
           throw new BurstException.NotValidException("Transaction type not yet enabled");
         }
 
-        Transaction assetCreationTransaction = Burst.getBlockchain().getTransactionByFullHash(transaction.getReferencedTransactionFullHash());
+        Transaction assetCreationTransaction = Signum.getBlockchain().getTransactionByFullHash(transaction.getReferencedTransactionFullHash());
         if(transaction.getAmountNQT() != 0 || assetCreationTransaction == null) {
           throw new BurstException.NotCurrentlyValidException("Invalid transaction amount or reference transaction");
         }
@@ -1519,7 +1519,7 @@ public abstract class TransactionType {
               " does not exist yet");
         }
         
-        if(asset.getAccountId()!= transaction.getSenderId() || !Burst.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
+        if(asset.getAccountId()!= transaction.getSenderId() || !Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
           throw new BurstException.NotValidException("Invalid add treasury account transaction");
         }
 
@@ -1561,7 +1561,7 @@ public abstract class TransactionType {
 
         Attachment.ColoredCoinsAssetDistributeToHolders attachment = (Attachment.ColoredCoinsAssetDistributeToHolders) transaction.getAttachment();
         Asset asset = assetExchange.getAsset(attachment.getAssetId());
-        boolean unconfirmed = !Burst.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, height);
+        boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, height);
         long numberOfHolders = assetExchange.getAssetAccountsCount(asset, attachment.getMinimumAssetQuantityQNT(), true, unconfirmed);
         long minFeeHolders = (numberOfHolders*minFee)/10L;
         minFee = Math.max(minFee, minFeeHolders);
@@ -1574,7 +1574,7 @@ public abstract class TransactionType {
         logger.trace("TransactionType ASSET_DISTRIBUTE_TO_HOLDERS");
         Attachment.ColoredCoinsAssetDistributeToHolders attachment = (Attachment.ColoredCoinsAssetDistributeToHolders) transaction.getAttachment();
 
-        if (!Burst.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
+        if (!Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
           return false;
         }
 
@@ -1588,11 +1588,11 @@ public abstract class TransactionType {
         accountService.addToUnconfirmedAssetBalanceQNT(senderAccount, assetToDistribute, -attachment.getQuantityQNT());
 
         Asset asset = assetExchange.getAsset(attachment.getAssetId());
-        boolean unconfirmed = !Burst.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX);
+        boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX);
         CollectionWithIndex<AccountAsset> assetHolders = assetExchange.getAssetAccounts(asset, true, attachment.getMinimumAssetQuantityQNT(), unconfirmed, -1, -1);
         long circulatingQuantityQNT = 0L;
         for(AccountAsset holder : assetHolders) {
-          if(Burst.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, transaction.getHeight()) && holder.getAccountId() == senderAccount.getId()){
+          if(Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, transaction.getHeight()) && holder.getAccountId() == senderAccount.getId()){
             continue;
           }
           circulatingQuantityQNT += holder.getUnconfirmedQuantityQNT();
@@ -1639,7 +1639,7 @@ public abstract class TransactionType {
       protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
         Attachment.ColoredCoinsAssetDistributeToHolders attachment = (Attachment.ColoredCoinsAssetDistributeToHolders) transaction.getAttachment();
 
-        if (!Burst.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
+        if (!Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
           throw new BurstException.NotValidException("Transaction type not yet enabled: " + JSON.toJsonString(attachment.getJsonObject()));
         }
 
@@ -1652,7 +1652,7 @@ public abstract class TransactionType {
                   " does not exist yet");
         }
 
-        boolean unconfirmed = !Burst.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX);
+        boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX);
         long circulatingQuantity = assetExchange.getAssetCirculatingSupply(asset, true, unconfirmed);
         if (circulatingQuantity <= 0L) {
           throw new BurstException.NotValidException("Asset has no circulating supply: " + JSON.toJsonString(attachment.getJsonObject()));
@@ -1684,16 +1684,16 @@ public abstract class TransactionType {
         // TODO: rework this so we do not run this more than once
         Attachment.ColoredCoinsAssetDistributeToHolders attachment = (Attachment.ColoredCoinsAssetDistributeToHolders) transaction.getAttachment();
 
-        boolean unconfirmed = !Burst.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, transaction.getHeight());
+        boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, transaction.getHeight());
         CollectionWithIndex<AccountAsset> assetHolders = assetExchange.getAssetAccounts(
             assetExchange.getAsset(attachment.getAssetId()),
             true, attachment.getMinimumAssetQuantityQNT(), unconfirmed, -1, -1);
         long circulatingQuantityQNT = 0L;
         for(AccountAsset holder : assetHolders) {
-          if(Burst.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, transaction.getHeight()) && holder.getAccountId() == transaction.getSenderId()){
+          if(Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, transaction.getHeight()) && holder.getAccountId() == transaction.getSenderId()){
             continue;
           }
-          long holderQuantity = Burst.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, transaction.getHeight()) ?
+          long holderQuantity = Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, transaction.getHeight()) ?
             holder.getQuantityQNT() : holder.getUnconfirmedQuantityQNT();
           circulatingQuantityQNT += holderQuantity;
         }
@@ -1711,7 +1711,7 @@ public abstract class TransactionType {
         long largestHolderQuantity = 0L;
         IndirectIncoming largestIndirect = null;
         for(AccountAsset holder : assetHolders) {
-          if(Burst.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, transaction.getHeight()) && holder.getAccountId() == transaction.getSenderId()){
+          if(Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, transaction.getHeight()) && holder.getAccountId() == transaction.getSenderId()){
             continue;
           }
           long holderQuantity = unconfirmed ? holder.getUnconfirmedQuantityQNT() : holder.getQuantityQNT();
@@ -2588,7 +2588,7 @@ public abstract class TransactionType {
 
       @Override
       protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
-        if (Burst.getFluxCapacitor().getValue(FluxValues.SODIUM)) throw new BurstException.NotCurrentlyValidException("Effective Balance Leasing disabled after Sodium HF");
+        if (Signum.getFluxCapacitor().getValue(FluxValues.SODIUM)) throw new BurstException.NotCurrentlyValidException("Effective Balance Leasing disabled after Sodium HF");
 
         Attachment.AccountControlEffectiveBalanceLeasing attachment = (Attachment.AccountControlEffectiveBalanceLeasing)transaction.getAttachment();
         Account recipientAccount = accountService.getAccount(transaction.getRecipientId());
@@ -2689,8 +2689,8 @@ public abstract class TransactionType {
           throw new BurstException.NotValidException("Reward recipient assignment transaction must have 0 send amount and at least minimum fee: " + JSON.toJsonString(transaction.getJsonObject()));
         }
 
-        if (!Burst.getFluxCapacitor().getValue(FluxValues.REWARD_RECIPIENT_ENABLE, height)) {
-          throw new BurstException.NotCurrentlyValidException("Reward recipient assignment not allowed before block " + Burst.getFluxCapacitor().getStartingHeight(FluxValues.REWARD_RECIPIENT_ENABLE));
+        if (!Signum.getFluxCapacitor().getValue(FluxValues.REWARD_RECIPIENT_ENABLE, height)) {
+          throw new BurstException.NotCurrentlyValidException("Reward recipient assignment not allowed before block " + Signum.getFluxCapacitor().getStartingHeight(FluxValues.REWARD_RECIPIENT_ENABLE));
         }
       }
 
@@ -2771,8 +2771,8 @@ public abstract class TransactionType {
           throw new BurstException.NotCurrentlyValidException("Sender not yet known ?!");
         }
 
-        if (!Burst.getFluxCapacitor().getValue(FluxValues.SIGNUM, height)) {
-          throw new BurstException.NotCurrentlyValidException("Add commitment not allowed before block " + Burst.getFluxCapacitor().getStartingHeight(FluxValues.SIGNUM));
+        if (!Signum.getFluxCapacitor().getValue(FluxValues.SIGNUM, height)) {
+          throw new BurstException.NotCurrentlyValidException("Add commitment not allowed before block " + Signum.getFluxCapacitor().getStartingHeight(FluxValues.SIGNUM));
         }
       }
 
@@ -2813,7 +2813,7 @@ public abstract class TransactionType {
         if(totalAmountNQT < 0L)
           return false;
 
-        blockchain = Burst.getBlockchain();
+        blockchain = Signum.getBlockchain();
         int nBlocksMined = blockchain.getBlocksCount(senderAccount.getId(), blockchain.getHeight() - Constants.MAX_ROLLBACK, blockchain.getHeight());
         if(nBlocksMined > 0) {
           // need to wait since the last block mined to remove any commitment
@@ -2855,8 +2855,8 @@ public abstract class TransactionType {
           throw new BurstException.NotCurrentlyValidException("Sender not yet known ?!");
         }
 
-        if (!Burst.getFluxCapacitor().getValue(FluxValues.SIGNUM, height)) {
-          throw new BurstException.NotCurrentlyValidException("Add commitment not allowed before block " + Burst.getFluxCapacitor().getStartingHeight(FluxValues.SIGNUM));
+        if (!Signum.getFluxCapacitor().getValue(FluxValues.SIGNUM, height)) {
+          throw new BurstException.NotCurrentlyValidException("Add commitment not allowed before block " + Signum.getFluxCapacitor().getStartingHeight(FluxValues.SIGNUM));
         }
       }
 
@@ -3184,7 +3184,7 @@ public abstract class TransactionType {
           throw new BurstException.NotValidException("Invalid subscription frequency");
         }
         if (transaction.getAmountNQT() < Constants.ONE_BURST || transaction.getAmountNQT() > Constants.MAX_BALANCE_NQT) {
-          throw new BurstException.NotValidException("Subscriptions must be at least one " + Burst.getPropertyService().getString(Props.VALUE_SUFIX));
+          throw new BurstException.NotValidException("Subscriptions must be at least one " + Signum.getPropertyService().getString(Props.VALUE_SUFIX));
         }
         if (transaction.getSenderId() == transaction.getRecipientId()) {
           throw new BurstException.NotValidException("Cannot create subscription to same address");
@@ -3409,7 +3409,7 @@ public abstract class TransactionType {
           AtMachineState thisNewAtCreation = new AtMachineState(null, null, attachment.getCreationBytes(), 0);
           if(thisNewAtCreation.getApCodeBytes().length == 0) {
             // check if we have a reference for the code
-            Transaction referenceTransaction = Burst.getBlockchain().getTransactionByFullHash(transaction.getReferencedTransactionFullHash());
+            Transaction referenceTransaction = Signum.getBlockchain().getTransactionByFullHash(transaction.getReferencedTransactionFullHash());
             minCodePages = 0;
 
             if(referenceTransaction!=null && referenceTransaction.getAttachment() instanceof Attachment.AutomatedTransactionsCreation) {
@@ -3454,7 +3454,7 @@ public abstract class TransactionType {
         long codeHashId = 0L;
         AtMachineState thisNewAtCreation = new AtMachineState(null, null, attachment.getCreationBytes(), 0);
         if(thisNewAtCreation.getApCodeBytes().length == 0) {
-          Transaction referenceTransaction = Burst.getBlockchain().getTransactionByFullHash(transaction.getReferencedTransactionFullHash());
+          Transaction referenceTransaction = Signum.getBlockchain().getTransactionByFullHash(transaction.getReferencedTransactionFullHash());
           Attachment.AutomatedTransactionsCreation atCreationAttachmentRef = (Attachment.AutomatedTransactionsCreation)referenceTransaction.getAttachment();
           AtMachineState atCreationRef = new AtMachineState(null, null, atCreationAttachmentRef.getCreationBytes(), referenceTransaction.getHeight());
           codeHashId = atCreationRef.getApCodeHashId();

--- a/src/brs/TransactionType.java
+++ b/src/brs/TransactionType.java
@@ -190,9 +190,9 @@ public abstract class TransactionType {
     accountControlTypes.put(SUBTYPE_ACCOUNT_CONTROL_EFFECTIVE_BALANCE_LEASING, AccountControl.EFFECTIVE_BALANCE_LEASING);
 
     Map<Byte, TransactionType> signumMiningTypes = new HashMap<>();
-    signumMiningTypes.put(SUBTYPE_SIGNA_MINING_REWARD_RECIPIENT_ASSIGNMENT, BurstMining.REWARD_RECIPIENT_ASSIGNMENT);
-    signumMiningTypes.put(SUBTYPE_SIGNA_MINING_COMMITMENT_ADD, BurstMining.COMMITMENT_ADD);
-    signumMiningTypes.put(SUBTYPE_SIGNA_MINING_COMMITMENT_REMOVE, BurstMining.COMMITMENT_REMOVE);
+    signumMiningTypes.put(SUBTYPE_SIGNA_MINING_REWARD_RECIPIENT_ASSIGNMENT, SignaMining.REWARD_RECIPIENT_ASSIGNMENT);
+    signumMiningTypes.put(SUBTYPE_SIGNA_MINING_COMMITMENT_ADD, SignaMining.COMMITMENT_ADD);
+    signumMiningTypes.put(SUBTYPE_SIGNA_MINING_COMMITMENT_REMOVE, SignaMining.COMMITMENT_REMOVE);
 
     Map<Byte, TransactionType> advancedPaymentTypes = new HashMap<>();
     advancedPaymentTypes.put(SUBTYPE_ADVANCED_PAYMENT_ESCROW_CREATION, AdvancedPayment.ESCROW_CREATION);
@@ -2613,16 +2613,16 @@ public abstract class TransactionType {
 
   }
 
-  public abstract static class BurstMining extends TransactionType {
+  public abstract static class SignaMining extends TransactionType {
 
-    private BurstMining() {}
+    private SignaMining() {}
 
     @Override
     public final byte getType() {
       return TransactionType.TYPE_SIGNA_MINING.getType();
     }
 
-    public static final TransactionType REWARD_RECIPIENT_ASSIGNMENT = new BurstMining() {
+    public static final TransactionType REWARD_RECIPIENT_ASSIGNMENT = new SignaMining() {
 
       @Override
       protected final boolean applyAttachmentUnconfirmed(Transaction transaction, Account senderAccount) {
@@ -2643,14 +2643,14 @@ public abstract class TransactionType {
       }
 
       @Override
-      public Attachment.BurstMiningRewardRecipientAssignment
+      public Attachment.SignaMiningRewardRecipientAssignment
       parseAttachment(ByteBuffer buffer, byte transactionVersion) {
-        return new Attachment.BurstMiningRewardRecipientAssignment(buffer, transactionVersion);
+        return new Attachment.SignaMiningRewardRecipientAssignment(buffer, transactionVersion);
       }
 
       @Override
-      protected Attachment.BurstMiningRewardRecipientAssignment parseAttachment(JsonObject attachmentData) {
-        return new Attachment.BurstMiningRewardRecipientAssignment(attachmentData);
+      protected Attachment.SignaMiningRewardRecipientAssignment parseAttachment(JsonObject attachmentData) {
+        return new Attachment.SignaMiningRewardRecipientAssignment(attachmentData);
       }
 
       @Override
@@ -2664,7 +2664,7 @@ public abstract class TransactionType {
           return TransactionDuplicationKey.IS_NEVER_DUPLICATE; // sync fails after 7007 without this
         }
 
-        return new TransactionDuplicationKey(BurstMining.REWARD_RECIPIENT_ASSIGNMENT, Convert.toUnsignedLong(transaction.getSenderId()));
+        return new TransactionDuplicationKey(SignaMining.REWARD_RECIPIENT_ASSIGNMENT, Convert.toUnsignedLong(transaction.getSenderId()));
       }
 
       @Override
@@ -2700,7 +2700,7 @@ public abstract class TransactionType {
       }
     };
 
-    public static final TransactionType COMMITMENT_ADD = new BurstMining() {
+    public static final TransactionType COMMITMENT_ADD = new SignaMining() {
 
       @Override
       public final byte getSubtype() {
@@ -2759,7 +2759,7 @@ public abstract class TransactionType {
       @Override
       public TransactionDuplicationKey getDuplicationKey(Transaction transaction) {
         CommitmentAdd attachment = (CommitmentAdd) transaction.getAttachment();
-        return new TransactionDuplicationKey(BurstMining.COMMITMENT_ADD, Convert.toUnsignedLong(transaction.getSenderId()) + ":" + attachment.getAmountNQT());
+        return new TransactionDuplicationKey(SignaMining.COMMITMENT_ADD, Convert.toUnsignedLong(transaction.getSenderId()) + ":" + attachment.getAmountNQT());
       }
 
       @Override
@@ -2782,7 +2782,7 @@ public abstract class TransactionType {
       }
     };
 
-    public static final TransactionType COMMITMENT_REMOVE = new BurstMining() {
+    public static final TransactionType COMMITMENT_REMOVE = new SignaMining() {
 
       @Override
       public final byte getSubtype() {
@@ -2843,7 +2843,7 @@ public abstract class TransactionType {
       @Override
       public TransactionDuplicationKey getDuplicationKey(Transaction transaction) {
         // All commitment remove transactions from the same account are considered duplicates, so just the one with highest fee is kept
-        return new TransactionDuplicationKey(BurstMining.COMMITMENT_REMOVE, Convert.toUnsignedLong(transaction.getSenderId()));
+        return new TransactionDuplicationKey(SignaMining.COMMITMENT_REMOVE, Convert.toUnsignedLong(transaction.getSenderId()));
       }
 
       @Override

--- a/src/brs/TransactionType.java
+++ b/src/brs/TransactionType.java
@@ -32,7 +32,7 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.*;
 
-import static brs.Constants.ONE_BURST;
+import static brs.Constants.ONE_SIGNA;
 
 public abstract class TransactionType {
 
@@ -45,7 +45,7 @@ public abstract class TransactionType {
   public static final Type TYPE_COLORED_COINS = new Type((byte)2, "Colored coins");
   public static final Type TYPE_DIGITAL_GOODS = new Type((byte)3, "Digital Goods");
   public static final Type TYPE_ACCOUNT_CONTROL = new Type((byte)4, "Account Control");
-  public static final Type TYPE_BURST_MINING = new Type((byte)20, "Mining");
+  public static final Type TYPE_SIGNA_MINING = new Type((byte)20, "Mining");
   public static final Type TYPE_ADVANCED_PAYMENT = new Type((byte)21, "Advanced Payment");
   public static final Type TYPE_AUTOMATED_TRANSACTIONS = new Type((byte)22, "Automated Transactions");
 
@@ -86,9 +86,9 @@ public abstract class TransactionType {
 
   public static final byte SUBTYPE_ACCOUNT_CONTROL_EFFECTIVE_BALANCE_LEASING = 0;
 
-  public static final byte SUBTYPE_BURST_MINING_REWARD_RECIPIENT_ASSIGNMENT = 0;
-  public static final byte SUBTYPE_BURST_MINING_COMMITMENT_ADD = 1;
-  public static final byte SUBTYPE_BURST_MINING_COMMITMENT_REMOVE = 2;
+  public static final byte SUBTYPE_SIGNA_MINING_REWARD_RECIPIENT_ASSIGNMENT = 0;
+  public static final byte SUBTYPE_SIGNA_MINING_COMMITMENT_ADD = 1;
+  public static final byte SUBTYPE_SIGNA_MINING_COMMITMENT_REMOVE = 2;
 
   public static final byte SUBTYPE_ADVANCED_PAYMENT_ESCROW_CREATION = 0;
   public static final byte SUBTYPE_ADVANCED_PAYMENT_ESCROW_SIGN = 1;
@@ -189,10 +189,10 @@ public abstract class TransactionType {
     Map<Byte, TransactionType> accountControlTypes = new HashMap<>();
     accountControlTypes.put(SUBTYPE_ACCOUNT_CONTROL_EFFECTIVE_BALANCE_LEASING, AccountControl.EFFECTIVE_BALANCE_LEASING);
 
-    Map<Byte, TransactionType> burstMiningTypes = new HashMap<>();
-    burstMiningTypes.put(SUBTYPE_BURST_MINING_REWARD_RECIPIENT_ASSIGNMENT, BurstMining.REWARD_RECIPIENT_ASSIGNMENT);
-    burstMiningTypes.put(SUBTYPE_BURST_MINING_COMMITMENT_ADD, BurstMining.COMMITMENT_ADD);
-    burstMiningTypes.put(SUBTYPE_BURST_MINING_COMMITMENT_REMOVE, BurstMining.COMMITMENT_REMOVE);
+    Map<Byte, TransactionType> signumMiningTypes = new HashMap<>();
+    signumMiningTypes.put(SUBTYPE_SIGNA_MINING_REWARD_RECIPIENT_ASSIGNMENT, BurstMining.REWARD_RECIPIENT_ASSIGNMENT);
+    signumMiningTypes.put(SUBTYPE_SIGNA_MINING_COMMITMENT_ADD, BurstMining.COMMITMENT_ADD);
+    signumMiningTypes.put(SUBTYPE_SIGNA_MINING_COMMITMENT_REMOVE, BurstMining.COMMITMENT_REMOVE);
 
     Map<Byte, TransactionType> advancedPaymentTypes = new HashMap<>();
     advancedPaymentTypes.put(SUBTYPE_ADVANCED_PAYMENT_ESCROW_CREATION, AdvancedPayment.ESCROW_CREATION);
@@ -207,7 +207,7 @@ public abstract class TransactionType {
     TRANSACTION_TYPES.put(TYPE_COLORED_COINS, coloredCoinsTypes);
     TRANSACTION_TYPES.put(TYPE_DIGITAL_GOODS, digitalGoodsTypes);
     TRANSACTION_TYPES.put(TYPE_ACCOUNT_CONTROL, accountControlTypes);
-    TRANSACTION_TYPES.put(TYPE_BURST_MINING, burstMiningTypes);
+    TRANSACTION_TYPES.put(TYPE_SIGNA_MINING, signumMiningTypes);
     TRANSACTION_TYPES.put(TYPE_ADVANCED_PAYMENT, advancedPaymentTypes);
     TRANSACTION_TYPES.put(TYPE_AUTOMATED_TRANSACTIONS, atTypes);
   }
@@ -2619,7 +2619,7 @@ public abstract class TransactionType {
 
     @Override
     public final byte getType() {
-      return TransactionType.TYPE_BURST_MINING.getType();
+      return TransactionType.TYPE_SIGNA_MINING.getType();
     }
 
     public static final TransactionType REWARD_RECIPIENT_ASSIGNMENT = new BurstMining() {
@@ -2634,7 +2634,7 @@ public abstract class TransactionType {
 
       @Override
       public final byte getSubtype() {
-        return TransactionType.SUBTYPE_BURST_MINING_REWARD_RECIPIENT_ASSIGNMENT;
+        return TransactionType.SUBTYPE_SIGNA_MINING_REWARD_RECIPIENT_ASSIGNMENT;
       }
 
       @Override
@@ -2704,7 +2704,7 @@ public abstract class TransactionType {
 
       @Override
       public final byte getSubtype() {
-        return TransactionType.SUBTYPE_BURST_MINING_COMMITMENT_ADD;
+        return TransactionType.SUBTYPE_SIGNA_MINING_COMMITMENT_ADD;
       }
 
       @Override
@@ -2786,7 +2786,7 @@ public abstract class TransactionType {
 
       @Override
       public final byte getSubtype() {
-        return TransactionType.SUBTYPE_BURST_MINING_COMMITMENT_REMOVE;
+        return TransactionType.SUBTYPE_SIGNA_MINING_COMMITMENT_REMOVE;
       }
 
       @Override
@@ -2913,7 +2913,7 @@ public abstract class TransactionType {
       @Override
       public Long calculateAttachmentTotalAmountNQT(Transaction transaction) {
         Attachment.AdvancedPaymentEscrowCreation attachment = (Attachment.AdvancedPaymentEscrowCreation) transaction.getAttachment();
-        return Convert.safeAdd(attachment.getAmountNQT(), Convert.safeMultiply(attachment.getTotalSigners(), Constants.ONE_BURST));
+        return Convert.safeAdd(attachment.getAmountNQT(), Convert.safeMultiply(attachment.getTotalSigners(), Constants.ONE_SIGNA));
       }
 
       @Override
@@ -2922,7 +2922,7 @@ public abstract class TransactionType {
         Long totalAmountNQT = calculateAttachmentTotalAmountNQT(transaction);
         accountService.addToBalanceNQT(senderAccount, -totalAmountNQT);
         Collection<Long> signers = attachment.getSigners();
-        signers.forEach(signer -> accountService.addToBalanceAndUnconfirmedBalanceNQT(accountService.getOrAddAccount(signer), Constants.ONE_BURST));
+        signers.forEach(signer -> accountService.addToBalanceAndUnconfirmedBalanceNQT(accountService.getOrAddAccount(signer), Constants.ONE_SIGNA));
         escrowService.addEscrowTransaction(senderAccount,
                 recipientAccount,
                 transaction.getId(),
@@ -2950,7 +2950,7 @@ public abstract class TransactionType {
         if (transaction.getSenderId() == transaction.getRecipientId()) {
           throw new SignumException.NotValidException("Escrow must have different sender and recipient");
         }
-        totalAmountNQT = Convert.safeAdd(totalAmountNQT, attachment.getTotalSigners() * Constants.ONE_BURST);
+        totalAmountNQT = Convert.safeAdd(totalAmountNQT, attachment.getTotalSigners() * Constants.ONE_SIGNA);
         if (transaction.getAmountNQT() != 0) {
           throw new SignumException.NotValidException("Transaction sent amount must be 0 for escrow");
         }
@@ -2959,7 +2959,7 @@ public abstract class TransactionType {
         {
           throw new SignumException.NotValidException("Invalid escrow creation amount");
         }
-        if (transaction.getFeeNQT() < Constants.ONE_BURST) {
+        if (transaction.getFeeNQT() < Constants.ONE_SIGNA) {
           throw new SignumException.NotValidException("Escrow transaction must have a fee at least 1 burst");
         }
         if (attachment.getRequiredSigners() < 1 || attachment.getRequiredSigners() > 10) {
@@ -3042,7 +3042,7 @@ public abstract class TransactionType {
       @Override
       protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.AdvancedPaymentEscrowSign attachment = (Attachment.AdvancedPaymentEscrowSign) transaction.getAttachment();
-        if (transaction.getAmountNQT() != 0 || transaction.getFeeNQT() != Constants.ONE_BURST) {
+        if (transaction.getAmountNQT() != 0 || transaction.getFeeNQT() != Constants.ONE_SIGNA) {
           throw new SignumException.NotValidException("Escrow signing must have amount 0 and fee of 1");
         }
         if (attachment.getEscrowId() == null || attachment.getDecision() == null) {
@@ -3179,11 +3179,11 @@ public abstract class TransactionType {
       protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.AdvancedPaymentSubscriptionSubscribe attachment = (Attachment.AdvancedPaymentSubscriptionSubscribe) transaction.getAttachment();
         if (attachment.getFrequency() == null ||
-                attachment.getFrequency() < Constants.BURST_SUBSCRIPTION_MIN_FREQ ||
-                attachment.getFrequency() > Constants.BURST_SUBSCRIPTION_MAX_FREQ) {
+                attachment.getFrequency() < Constants.SIGNUM_SUBSCRIPTION_MIN_FREQ ||
+                attachment.getFrequency() > Constants.SIGNUM_SUBSCRIPTION_MAX_FREQ) {
           throw new SignumException.NotValidException("Invalid subscription frequency");
         }
-        if (transaction.getAmountNQT() < Constants.ONE_BURST || transaction.getAmountNQT() > Constants.MAX_BALANCE_NQT) {
+        if (transaction.getAmountNQT() < Constants.ONE_SIGNA || transaction.getAmountNQT() > Constants.MAX_BALANCE_NQT) {
           throw new SignumException.NotValidException("Subscriptions must be at least one " + Signum.getPropertyService().getString(Props.VALUE_SUFIX));
         }
         if (transaction.getSenderId() == transaction.getRecipientId()) {
@@ -3530,7 +3530,7 @@ public abstract class TransactionType {
     if(fluxCapacitor.getValue(FluxValues.SPEEDWAY, height)) {
       return new Fee(FEE_QUANT, FEE_QUANT);
     }
-    return new Fee((fluxCapacitor.getValue(FluxValues.PRE_POC2, height) ? FEE_QUANT : ONE_BURST), 0);
+    return new Fee((fluxCapacitor.getValue(FluxValues.PRE_POC2, height) ? FEE_QUANT : ONE_SIGNA), 0);
   }
 
   public static final class Fee {

--- a/src/brs/TransactionType.java
+++ b/src/brs/TransactionType.java
@@ -5,8 +5,8 @@ import brs.Attachment.AbstractAttachment;
 import brs.Attachment.AutomatedTransactionsCreation;
 import brs.Attachment.CommitmentAdd;
 import brs.Attachment.CommitmentRemove;
-import brs.BurstException.NotValidException;
-import brs.BurstException.ValidationException;
+import brs.SignumException.NotValidException;
+import brs.SignumException.ValidationException;
 import brs.assetexchange.AssetExchange;
 import brs.at.AT;
 import brs.at.AtConstants;
@@ -239,11 +239,11 @@ public abstract class TransactionType {
 
   public abstract String getDescription();
 
-  public abstract Attachment.AbstractAttachment parseAttachment(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException;
+  public abstract Attachment.AbstractAttachment parseAttachment(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException;
 
-  protected abstract Attachment.AbstractAttachment parseAttachment(JsonObject attachmentData) throws BurstException.NotValidException;
+  protected abstract Attachment.AbstractAttachment parseAttachment(JsonObject attachmentData) throws SignumException.NotValidException;
 
-  protected abstract void validateAttachment(Transaction transaction) throws BurstException.ValidationException;
+  protected abstract void validateAttachment(Transaction transaction) throws SignumException.ValidationException;
 
   // return false if double spending
   public final boolean applyUnconfirmed(Transaction transaction, Account senderAccount) {
@@ -313,7 +313,7 @@ public abstract class TransactionType {
     builder.encryptToSelfMessage(Appendix.EncryptToSelfMessage.parse(attachmentData));
   }
 
-  public void parseAppendices(Transaction.Builder builder, int flags, byte version, ByteBuffer buffer) throws BurstException.ValidationException {
+  public void parseAppendices(Transaction.Builder builder, int flags, byte version, ByteBuffer buffer) throws SignumException.ValidationException {
     int position = 1;
     if ((flags & position) != 0) {
       builder.message(new Appendix.Message(buffer, version));
@@ -404,9 +404,9 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         if (transaction.getAmountNQT() <= 0 || transaction.getAmountNQT() >= Constants.MAX_BALANCE_NQT) {
-          throw new BurstException.NotValidException("Invalid ordinary payment");
+          throw new SignumException.NotValidException("Invalid ordinary payment");
         }
       }
 
@@ -428,19 +428,19 @@ public abstract class TransactionType {
       }
 
       @Override
-      public Attachment.PaymentMultiOutCreation parseAttachment(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+      public Attachment.PaymentMultiOutCreation parseAttachment(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
         return new Attachment.PaymentMultiOutCreation(buffer, transactionVersion);
       }
 
       @Override
-      protected Attachment.PaymentMultiOutCreation parseAttachment(JsonObject attachmentData) throws BurstException.NotValidException {
+      protected Attachment.PaymentMultiOutCreation parseAttachment(JsonObject attachmentData) throws SignumException.NotValidException {
         return new Attachment.PaymentMultiOutCreation(attachmentData);
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         if (!fluxCapacitor.getValue(FluxValues.PRE_POC2, transaction.getHeight())) {
-          throw new BurstException.NotCurrentlyValidException("Multi Out Payments are not allowed before the Pre POC2 block");
+          throw new SignumException.NotCurrentlyValidException("Multi Out Payments are not allowed before the Pre POC2 block");
         }
 
         Attachment.PaymentMultiOutCreation attachment = (Attachment.PaymentMultiOutCreation) transaction.getAttachment();
@@ -449,7 +449,7 @@ public abstract class TransactionType {
                 || amountNQT >= Constants.MAX_BALANCE_NQT
                 || amountNQT != transaction.getAmountNQT()
                 || attachment.getRecipients().size() < 2) {
-          throw new BurstException.NotValidException("Invalid multi out payment");
+          throw new SignumException.NotValidException("Invalid multi out payment");
         }
       }
 
@@ -505,24 +505,24 @@ public abstract class TransactionType {
       }
 
       @Override
-      public Attachment.PaymentMultiSameOutCreation parseAttachment(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+      public Attachment.PaymentMultiSameOutCreation parseAttachment(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
         return new Attachment.PaymentMultiSameOutCreation(buffer, transactionVersion);
       }
 
       @Override
-      protected Attachment.PaymentMultiSameOutCreation parseAttachment(JsonObject attachmentData) throws BurstException.NotValidException {
+      protected Attachment.PaymentMultiSameOutCreation parseAttachment(JsonObject attachmentData) throws SignumException.NotValidException {
         return new Attachment.PaymentMultiSameOutCreation(attachmentData);
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         if (!fluxCapacitor.getValue(FluxValues.PRE_POC2, transaction.getHeight())) {
-          throw new BurstException.NotCurrentlyValidException("Multi Same Out Payments are not allowed before the Pre POC2 block");
+          throw new SignumException.NotCurrentlyValidException("Multi Same Out Payments are not allowed before the Pre POC2 block");
         }
 
         Attachment.PaymentMultiSameOutCreation attachment = (Attachment.PaymentMultiSameOutCreation) transaction.getAttachment();
         if (attachment.getRecipients().size() < 2 && (transaction.getAmountNQT() % attachment.getRecipients().size() == 0 ) ) {
-          throw new BurstException.NotValidException("Invalid multi out payment");
+          throw new SignumException.NotValidException("Invalid multi out payment");
         }
       }
 
@@ -615,13 +615,13 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment attachment = transaction.getAttachment();
         if (transaction.getAmountNQT() != 0) {
-          throw new BurstException.NotValidException("Invalid arbitrary message: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Invalid arbitrary message: " + JSON.toJsonString(attachment.getJsonObject()));
         }
         if (! fluxCapacitor.getValue(FluxValues.DIGITAL_GOODS_STORE) && transaction.getMessage() == null) {
-          throw new BurstException.NotCurrentlyValidException("Missing message appendix not allowed before DGS block");
+          throw new SignumException.NotCurrentlyValidException("Missing message appendix not allowed before DGS block");
         }
       }
 
@@ -631,7 +631,7 @@ public abstract class TransactionType {
       }
 
       @Override
-      public void parseAppendices(Transaction.Builder builder, int flags, byte version, ByteBuffer buffer) throws BurstException.ValidationException {
+      public void parseAppendices(Transaction.Builder builder, int flags, byte version, ByteBuffer buffer) throws SignumException.ValidationException {
         int position = 1;
         if ((flags & position) != 0 || (version == 0)) {
           builder.message(new Appendix.Message(buffer, version));
@@ -672,7 +672,7 @@ public abstract class TransactionType {
       }
 
       @Override
-      public Attachment.MessagingAliasAssignment parseAttachment(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+      public Attachment.MessagingAliasAssignment parseAttachment(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
         return new Attachment.MessagingAliasAssignment(buffer, transactionVersion);
       }
 
@@ -695,26 +695,26 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.MessagingAliasAssignment attachment = (Attachment.MessagingAliasAssignment) transaction.getAttachment();
         if (attachment.getAliasName().isEmpty()
                 || Convert.toBytes(attachment.getAliasName()).length > Constants.MAX_ALIAS_LENGTH
                 || attachment.getAliasURI().length() > Constants.MAX_ALIAS_URI_LENGTH) {
-          throw new BurstException.NotValidException("Invalid alias assignment: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Invalid alias assignment: " + JSON.toJsonString(attachment.getJsonObject()));
         }
         if (Signum.getFluxCapacitor().getValue(FluxValues.SMART_ALIASES)) {
           if (!TextUtils.isInAlphabetOrUnderline(attachment.getAliasName())) {
-            throw new BurstException.NotValidException("Invalid alias name: " + attachment.getAliasName());
+            throw new SignumException.NotValidException("Invalid alias name: " + attachment.getAliasName());
           }
         }
         else{
           if (!TextUtils.isInAlphabet(attachment.getAliasName())) {
-            throw new BurstException.NotValidException("Invalid alias name: " + attachment.getAliasName());
+            throw new SignumException.NotValidException("Invalid alias name: " + attachment.getAliasName());
           }
         }
         Alias alias = aliasService.getAlias(attachment.getAliasName(), attachment.getTLD());
         if (alias != null && alias.getAccountId() != transaction.getSenderId()) {
-          throw new BurstException.NotCurrentlyValidException("Alias already owned by another account: " + attachment.getAliasName());
+          throw new SignumException.NotCurrentlyValidException("Alias already owned by another account: " + attachment.getAliasName());
         }
       }
 
@@ -743,7 +743,7 @@ public abstract class TransactionType {
       }
 
       @Override
-      public Attachment.MessagingTLDAssignment parseAttachment(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+      public Attachment.MessagingTLDAssignment parseAttachment(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
         return new Attachment.MessagingTLDAssignment(buffer, transactionVersion);
       }
 
@@ -765,26 +765,26 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         if(!fluxCapacitor.getValue(FluxValues.SMART_ALIASES, blockchain.getLastBlock().getHeight())) {
-          throw new BurstException.NotCurrentlyValidException("Smart Alias not yet active");
+          throw new SignumException.NotCurrentlyValidException("Smart Alias not yet active");
         }
         Attachment.MessagingTLDAssignment attachment = (Attachment.MessagingTLDAssignment) transaction.getAttachment();
         if (attachment.getTLDName().isEmpty()
                 || Convert.toBytes(attachment.getTLDName()).length > Constants.MAX_TLD_LENGTH) {
-          throw new BurstException.NotValidException("Invalid TLD assignment: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Invalid TLD assignment: " + JSON.toJsonString(attachment.getJsonObject()));
         }
         if (!TextUtils.isInAlphabet(attachment.getTLDName())) {
-          throw new BurstException.NotValidException("Invalid TLD name: " + attachment.getTLDName());
+          throw new SignumException.NotValidException("Invalid TLD name: " + attachment.getTLDName());
         }
         Alias tld = aliasService.getTLD(attachment.getTLDName());
         if (tld != null) {
-          throw new BurstException.NotCurrentlyValidException("TLD already registered by another account: " + attachment.getTLDName());
+          throw new SignumException.NotCurrentlyValidException("TLD already registered by another account: " + attachment.getTLDName());
         }
         
         if(transaction.getRecipientId() != 0L
                 || transaction.getAmountNQT() < BASELINE_TLD_ASSIGNMENT_FACTOR * fluxCapacitor.getValue(FluxValues.FEE_QUANT, blockchain.getLastBlock().getHeight())) {
-          throw new BurstException.NotCurrentlyValidException("Invalid TLD assignment: " + attachment.getTLDName());
+          throw new SignumException.NotCurrentlyValidException("Invalid TLD assignment: " + attachment.getTLDName());
         }
       }
 
@@ -808,7 +808,7 @@ public abstract class TransactionType {
       }
 
       @Override
-      public Attachment.MessagingAliasSell parseAttachment(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+      public Attachment.MessagingAliasSell parseAttachment(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
         return new Attachment.MessagingAliasSell(buffer, transactionVersion);
       }
 
@@ -832,43 +832,43 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         if (! fluxCapacitor.getValue(FluxValues.DIGITAL_GOODS_STORE, blockchain.getLastBlock().getHeight())) {
-          throw new BurstException.NotYetEnabledException("Alias transfer not yet enabled at height " + blockchain.getLastBlock().getHeight());
+          throw new SignumException.NotYetEnabledException("Alias transfer not yet enabled at height " + blockchain.getLastBlock().getHeight());
         }
         if (transaction.getAmountNQT() != 0) {
-          throw new BurstException.NotValidException("Invalid sell alias transaction: " + JSON.toJsonString(transaction.getJsonObject()));
+          throw new SignumException.NotValidException("Invalid sell alias transaction: " + JSON.toJsonString(transaction.getJsonObject()));
         }
         final Attachment.MessagingAliasSell attachment =
                 (Attachment.MessagingAliasSell) transaction.getAttachment();
         if(attachment.getVersion() > 1 && !fluxCapacitor.getValue(FluxValues.SMART_ALIASES)) {
-          throw new BurstException.NotCurrentlyValidException("Attachment version mismatch");
+          throw new SignumException.NotCurrentlyValidException("Attachment version mismatch");
         }
         if(attachment.getVersion() <= 1) {
           final String aliasName = attachment.getAliasName();
           if (aliasName == null || aliasName.isEmpty()) {
-            throw new BurstException.NotValidException("Missing alias name");
+            throw new SignumException.NotValidException("Missing alias name");
           }
         }
         else if(attachment.getAliasId() == 0L) {
-          throw new BurstException.NotValidException("Missing alias Id");
+          throw new SignumException.NotValidException("Missing alias Id");
         }
         long priceNQT = attachment.getPriceNQT();
         if (priceNQT < 0 || priceNQT > Constants.MAX_BALANCE_NQT) {
-          throw new BurstException.NotValidException("Invalid alias sell price: " + priceNQT);
+          throw new SignumException.NotValidException("Invalid alias sell price: " + priceNQT);
         }
         if (priceNQT == 0) {
           if (Genesis.CREATOR_ID == transaction.getRecipientId()) {
-            throw new BurstException.NotValidException("Transferring aliases to Genesis account not allowed");
+            throw new SignumException.NotValidException("Transferring aliases to Genesis account not allowed");
           } else if (transaction.getRecipientId() == 0) {
-            throw new BurstException.NotValidException("Missing alias transfer recipient");
+            throw new SignumException.NotValidException("Missing alias transfer recipient");
           }
         }
         final Alias alias = attachment.getVersion() > 1 ? aliasService.getAlias(attachment.getAliasId()) : aliasService.getAlias(attachment.getAliasName(), 0L);
         if (alias == null) {
-          throw new BurstException.NotCurrentlyValidException("Alias hasn't been registered yet");
+          throw new SignumException.NotCurrentlyValidException("Alias hasn't been registered yet");
         } else if (alias.getAccountId() != transaction.getSenderId()) {
-          throw new BurstException.NotCurrentlyValidException("Alias doesn't belong to sender: " + alias.getAliasName());
+          throw new SignumException.NotCurrentlyValidException("Alias doesn't belong to sender: " + alias.getAliasName());
         }
       }
 
@@ -892,7 +892,7 @@ public abstract class TransactionType {
       }
 
       @Override
-      public Attachment.MessagingAliasBuy parseAttachment(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+      public Attachment.MessagingAliasBuy parseAttachment(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
         return new Attachment.MessagingAliasBuy(buffer, transactionVersion);
       }
 
@@ -917,34 +917,34 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         if (! fluxCapacitor.getValue(FluxValues.DIGITAL_GOODS_STORE, blockchain.getLastBlock().getHeight())) {
-          throw new BurstException.NotYetEnabledException("Alias transfer not yet enabled at height " + blockchain.getLastBlock().getHeight());
+          throw new SignumException.NotYetEnabledException("Alias transfer not yet enabled at height " + blockchain.getLastBlock().getHeight());
         }
         final Attachment.MessagingAliasBuy attachment =
                 (Attachment.MessagingAliasBuy) transaction.getAttachment();
         if(attachment.getVersion() > 1 && !fluxCapacitor.getValue(FluxValues.SMART_ALIASES)) {
-          throw new BurstException.NotCurrentlyValidException("Attachment version mismatch");
+          throw new SignumException.NotCurrentlyValidException("Attachment version mismatch");
         }
         final String aliasName = attachment.getAliasName();
         final Alias alias = attachment.getVersion() > 1 ? aliasService.getAlias(attachment.getAliasId()) : aliasService.getAlias(attachment.getAliasName(), 0L);
         if (alias == null) {
-          throw new BurstException.NotCurrentlyValidException("Alias hasn't been registered yet: " + aliasName);
+          throw new SignumException.NotCurrentlyValidException("Alias hasn't been registered yet: " + aliasName);
         } else if (alias.getAccountId() != transaction.getRecipientId()) {
-          throw new BurstException.NotCurrentlyValidException("Alias is owned by account other than recipient: "
+          throw new SignumException.NotCurrentlyValidException("Alias is owned by account other than recipient: "
                   + Convert.toUnsignedLong(alias.getAccountId()));
         }
         Alias.Offer offer = aliasService.getOffer(alias);
         if (offer == null) {
-          throw new BurstException.NotCurrentlyValidException("Alias is not for sale: " + aliasName);
+          throw new SignumException.NotCurrentlyValidException("Alias is not for sale: " + aliasName);
         }
         if (transaction.getAmountNQT() < offer.getPriceNQT()) {
           String msg = "Price is too low for: " + aliasName + " ("
                   + transaction.getAmountNQT() + " < " + offer.getPriceNQT() + ")";
-          throw new BurstException.NotCurrentlyValidException(msg);
+          throw new SignumException.NotCurrentlyValidException(msg);
         }
         if (offer.getBuyerId() != 0 && offer.getBuyerId() != transaction.getSenderId()) {
-          throw new BurstException.NotCurrentlyValidException("Wrong buyer for " + aliasName + ": "
+          throw new SignumException.NotCurrentlyValidException("Wrong buyer for " + aliasName + ": "
                   + Convert.toUnsignedLong(transaction.getSenderId()) + " expected: "
                   + Convert.toUnsignedLong(offer.getBuyerId()));
         }
@@ -970,7 +970,7 @@ public abstract class TransactionType {
       }
 
       @Override
-      public Attachment.MessagingAccountInfo parseAttachment(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+      public Attachment.MessagingAccountInfo parseAttachment(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
         return new Attachment.MessagingAccountInfo(buffer, transactionVersion);
       }
 
@@ -980,12 +980,12 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.MessagingAccountInfo attachment = (Attachment.MessagingAccountInfo)transaction.getAttachment();
         if (Convert.toBytes(attachment.getName()).length > Constants.MAX_ACCOUNT_NAME_LENGTH
                 || Convert.toBytes(attachment.getDescription()).length > Constants.MAX_ACCOUNT_DESCRIPTION_LENGTH
         ) {
-          throw new BurstException.NotValidException("Invalid account info issuance: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Invalid account info issuance: " + JSON.toJsonString(attachment.getJsonObject()));
         }
       }
 
@@ -1033,7 +1033,7 @@ public abstract class TransactionType {
       }
 
       @Override
-      public Attachment.ColoredCoinsAssetIssuance parseAttachment(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+      public Attachment.ColoredCoinsAssetIssuance parseAttachment(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
         return new Attachment.ColoredCoinsAssetIssuance(buffer, transactionVersion);
       }
 
@@ -1061,7 +1061,7 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.ColoredCoinsAssetIssuance attachment = (Attachment.ColoredCoinsAssetIssuance)transaction.getAttachment();
         if (attachment.getName().length() < Constants.MIN_ASSET_NAME_LENGTH
                 || attachment.getName().length() > Constants.MAX_ASSET_NAME_LENGTH
@@ -1073,10 +1073,10 @@ public abstract class TransactionType {
                 || (attachment.getMintable() && !Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN))
                 || (attachment.getQuantityQNT() == 0 && !attachment.getMintable() && !Signum.getFluxCapacitor().getValue(FluxValues.PK_FREEZE2))
         ) {
-          throw new BurstException.NotValidException("Invalid asset issuance: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Invalid asset issuance: " + JSON.toJsonString(attachment.getJsonObject()));
         }
         if (!TextUtils.isInAlphabet(attachment.getName())) {
-          throw new BurstException.NotValidException("Invalid asset name: " + attachment.getName());
+          throw new SignumException.NotValidException("Invalid asset name: " + attachment.getName());
         }
       }
 
@@ -1100,7 +1100,7 @@ public abstract class TransactionType {
       }
 
       @Override
-      public Attachment.ColoredCoinsAssetTransfer parseAttachment(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+      public Attachment.ColoredCoinsAssetTransfer parseAttachment(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
         return new Attachment.ColoredCoinsAssetTransfer(buffer, transactionVersion);
       }
 
@@ -1136,23 +1136,23 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.ColoredCoinsAssetTransfer attachment = (Attachment.ColoredCoinsAssetTransfer)transaction.getAttachment();
         if ((!Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN) && transaction.getAmountNQT() != 0)
                 || attachment.getComment() != null && attachment.getComment().length() > Constants.MAX_ASSET_TRANSFER_COMMENT_LENGTH
                 || attachment.getAssetId() == 0) {
-          throw new BurstException.NotValidException("Invalid asset transfer amount or comment: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Invalid asset transfer amount or comment: " + JSON.toJsonString(attachment.getJsonObject()));
         }
         if (transaction.getVersion() > 0 && attachment.getComment() != null) {
-          throw new BurstException.NotValidException("Asset transfer comments no longer allowed, use message " +
+          throw new SignumException.NotValidException("Asset transfer comments no longer allowed, use message " +
                   "or encrypted message appendix instead");
         }
         Asset asset = assetExchange.getAsset(attachment.getAssetId());
         if (attachment.getQuantityQNT() <= 0) {
-          throw new BurstException.NotValidException("Invalid asset transfer asset or quantity: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Invalid asset transfer asset or quantity: " + JSON.toJsonString(attachment.getJsonObject()));
         }
         if (asset == null) {
-          throw new BurstException.NotCurrentlyValidException("Asset " + Convert.toUnsignedLong(attachment.getAssetId()) +
+          throw new SignumException.NotCurrentlyValidException("Asset " + Convert.toUnsignedLong(attachment.getAssetId()) +
                   " does not exist yet");
         }
       }
@@ -1182,7 +1182,7 @@ public abstract class TransactionType {
       }
 
       @Override
-      public Attachment.EmptyAttachment parseAttachment(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+      public Attachment.EmptyAttachment parseAttachment(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
         return Attachment.COLORED_COINS_ASSET_TRANSFER_OWNERSHIP;
       }
 
@@ -1230,7 +1230,7 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Asset asset = null;
         String fullHashRef = transaction.getReferencedTransactionFullHash();
         Transaction assetIssuance = blockchain.getTransactionByFullHash(fullHashRef);
@@ -1243,7 +1243,7 @@ public abstract class TransactionType {
           || asset == null
           || transaction.getSenderId() != asset.getAccountId()){
           // only the current owner can transfer it
-          throw new BurstException.NotValidException("Invalid asset ownership transfer");
+          throw new SignumException.NotValidException("Invalid asset ownership transfer");
         }
       }
 
@@ -1273,7 +1273,7 @@ public abstract class TransactionType {
       }
 
       @Override
-      public Attachment.ColoredCoinsAssetMultiTransfer parseAttachment(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+      public Attachment.ColoredCoinsAssetMultiTransfer parseAttachment(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
         return new Attachment.ColoredCoinsAssetMultiTransfer(buffer, transactionVersion);
       }
 
@@ -1329,11 +1329,11 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.ColoredCoinsAssetMultiTransfer attachment = (Attachment.ColoredCoinsAssetMultiTransfer)transaction.getAttachment();
         if ((!Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN))
                 || attachment.getAssetIds().size() < 2 || attachment.getAssetIds().size() > Constants.MAX_MULTI_ASSET_IDS) {
-          throw new BurstException.NotValidException("Invalid asset multi transfer: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Invalid asset multi transfer: " + JSON.toJsonString(attachment.getJsonObject()));
         }
         for(int i = 0; i < attachment.getAssetIds().size(); i++){
           long assetId = attachment.getAssetIds().get(i);
@@ -1341,10 +1341,10 @@ public abstract class TransactionType {
 
           Asset asset = assetExchange.getAsset(assetId);
           if (quantityQNT <= 0) {
-            throw new BurstException.NotValidException("Invalid asset transfer quantity: " + JSON.toJsonString(attachment.getJsonObject()));
+            throw new SignumException.NotValidException("Invalid asset transfer quantity: " + JSON.toJsonString(attachment.getJsonObject()));
           }
           if (asset == null) {
-            throw new BurstException.NotCurrentlyValidException("Asset " + Convert.toUnsignedLong(assetId) +
+            throw new SignumException.NotCurrentlyValidException("Asset " + Convert.toUnsignedLong(assetId) +
                     " does not exist yet");
           }
         }
@@ -1370,7 +1370,7 @@ public abstract class TransactionType {
       }
 
       @Override
-      public Attachment.ColoredCoinsAssetMint parseAttachment(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+      public Attachment.ColoredCoinsAssetMint parseAttachment(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
         return new Attachment.ColoredCoinsAssetMint(buffer, transactionVersion);
       }
 
@@ -1419,27 +1419,27 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.ColoredCoinsAssetMint attachment = (Attachment.ColoredCoinsAssetMint)transaction.getAttachment();
         if (!Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
-          throw new BurstException.NotValidException("Transaction type not yet enabled: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Transaction type not yet enabled: " + JSON.toJsonString(attachment.getJsonObject()));
         }
 
         Asset asset = assetExchange.getAsset(attachment.getAssetId());
         if (asset == null) {
-          throw new BurstException.NotCurrentlyValidException("Asset " + Convert.toUnsignedLong(attachment.getAssetId()) +
+          throw new SignumException.NotCurrentlyValidException("Asset " + Convert.toUnsignedLong(attachment.getAssetId()) +
                   " does not exist yet");
         }
         if(transaction.getAmountNQT() != 0 || asset.getAccountId() != transaction.getSenderId()
             || !asset.getMintable() || attachment.getQuantityQNT() <= 0L) {
-          throw new BurstException.NotValidException("Invalid asset mint: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Invalid asset mint: " + JSON.toJsonString(attachment.getJsonObject()));
         }
 
         boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX);
         long circulatingSupply = assetExchange.getAssetCirculatingSupply(asset, false, unconfirmed);
         long newSupply = circulatingSupply + attachment.getQuantityQNT();
         if (newSupply > Constants.MAX_ASSET_QUANTITY_QNT) {
-          throw new BurstException.NotCurrentlyValidException("Maximum circulating supply QNT is " + Constants.MAX_ASSET_QUANTITY_QNT);
+          throw new SignumException.NotCurrentlyValidException("Maximum circulating supply QNT is " + Constants.MAX_ASSET_QUANTITY_QNT);
         }
       }
 
@@ -1463,7 +1463,7 @@ public abstract class TransactionType {
       }
 
       @Override
-      public Attachment.AbstractAttachment parseAttachment(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+      public Attachment.AbstractAttachment parseAttachment(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
         return Attachment.ASSET_ADD_TREASURY_ACCOUNT_ATTACHMENT;
       }
 
@@ -1504,23 +1504,23 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         if (!Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
-          throw new BurstException.NotValidException("Transaction type not yet enabled");
+          throw new SignumException.NotValidException("Transaction type not yet enabled");
         }
 
         Transaction assetCreationTransaction = Signum.getBlockchain().getTransactionByFullHash(transaction.getReferencedTransactionFullHash());
         if(transaction.getAmountNQT() != 0 || assetCreationTransaction == null) {
-          throw new BurstException.NotCurrentlyValidException("Invalid transaction amount or reference transaction");
+          throw new SignumException.NotCurrentlyValidException("Invalid transaction amount or reference transaction");
         }
         Asset asset = assetExchange.getAsset(assetCreationTransaction.getId());
         if (asset == null) {
-          throw new BurstException.NotCurrentlyValidException("Asset " + Convert.toUnsignedLong(assetCreationTransaction.getId()) +
+          throw new SignumException.NotCurrentlyValidException("Asset " + Convert.toUnsignedLong(assetCreationTransaction.getId()) +
               " does not exist yet");
         }
         
         if(asset.getAccountId()!= transaction.getSenderId() || !Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
-          throw new BurstException.NotValidException("Invalid add treasury account transaction");
+          throw new SignumException.NotValidException("Invalid add treasury account transaction");
         }
 
       }
@@ -1546,7 +1546,7 @@ public abstract class TransactionType {
       }
 
       @Override
-      public Attachment.ColoredCoinsAssetDistributeToHolders parseAttachment(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+      public Attachment.ColoredCoinsAssetDistributeToHolders parseAttachment(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
         return new Attachment.ColoredCoinsAssetDistributeToHolders(buffer, transactionVersion);
       }
 
@@ -1636,34 +1636,34 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.ColoredCoinsAssetDistributeToHolders attachment = (Attachment.ColoredCoinsAssetDistributeToHolders) transaction.getAttachment();
 
         if (!Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
-          throw new BurstException.NotValidException("Transaction type not yet enabled: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Transaction type not yet enabled: " + JSON.toJsonString(attachment.getJsonObject()));
         }
 
         if (attachment.getAssetId() == 0L) {
-          throw new BurstException.NotValidException("Invalid asset transfer id: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Invalid asset transfer id: " + JSON.toJsonString(attachment.getJsonObject()));
         }
         Asset asset = assetExchange.getAsset(attachment.getAssetId());
         if (asset == null) {
-          throw new BurstException.NotCurrentlyValidException("Asset " + Convert.toUnsignedLong(attachment.getAssetId()) +
+          throw new SignumException.NotCurrentlyValidException("Asset " + Convert.toUnsignedLong(attachment.getAssetId()) +
                   " does not exist yet");
         }
 
         boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX);
         long circulatingQuantity = assetExchange.getAssetCirculatingSupply(asset, true, unconfirmed);
         if (circulatingQuantity <= 0L) {
-          throw new BurstException.NotValidException("Asset has no circulating supply: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Asset has no circulating supply: " + JSON.toJsonString(attachment.getJsonObject()));
         }
         if (attachment.getQuantityQNT() == 0L && transaction.getAmountNQT() == 0L){
-          throw new BurstException.NotValidException("Nothing to distribute");
+          throw new SignumException.NotValidException("Nothing to distribute");
         }
         if(attachment.getQuantityQNT() > 0L) {
           Asset assetToDistribute = assetExchange.getAsset(attachment.getAssetIdToDistribute());
           if (assetToDistribute == null) {
-            throw new BurstException.NotCurrentlyValidException("Asset " + Convert.toUnsignedLong(attachment.getAssetId()) +
+            throw new SignumException.NotCurrentlyValidException("Asset " + Convert.toUnsignedLong(attachment.getAssetId()) +
                     " does not exist yet");
           }
         }
@@ -1762,18 +1762,18 @@ public abstract class TransactionType {
     abstract static class ColoredCoinsOrderPlacement extends ColoredCoins {
 
       @Override
-      protected final void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected final void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.ColoredCoinsOrderPlacement attachment = (Attachment.ColoredCoinsOrderPlacement)transaction.getAttachment();
         if (attachment.getPriceNQT() <= 0 || attachment.getPriceNQT() > Constants.MAX_BALANCE_NQT
                 || attachment.getAssetId() == 0) {
-          throw new BurstException.NotValidException("Invalid asset order placement: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Invalid asset order placement: " + JSON.toJsonString(attachment.getJsonObject()));
         }
         Asset asset = assetExchange.getAsset(attachment.getAssetId());
         if (attachment.getQuantityQNT() <= 0 || (asset != null && !asset.getMintable() && attachment.getQuantityQNT() > asset.getQuantityQNT())) {
-          throw new BurstException.NotValidException("Invalid asset order placement asset or quantity: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Invalid asset order placement asset or quantity: " + JSON.toJsonString(attachment.getJsonObject()));
         }
         if (asset == null) {
-          throw new BurstException.NotCurrentlyValidException("Asset " + Convert.toUnsignedLong(attachment.getAssetId()) +
+          throw new SignumException.NotCurrentlyValidException("Asset " + Convert.toUnsignedLong(attachment.getAssetId()) +
                   " does not exist yet");
         }
       }
@@ -1941,14 +1941,14 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.ColoredCoinsAskOrderCancellation attachment = (Attachment.ColoredCoinsAskOrderCancellation) transaction.getAttachment();
         Order ask = assetExchange.getAskOrder(attachment.getOrderId());
         if (ask == null) {
-          throw new BurstException.NotCurrentlyValidException("Invalid ask order: " + Convert.toUnsignedLong(attachment.getOrderId()));
+          throw new SignumException.NotCurrentlyValidException("Invalid ask order: " + Convert.toUnsignedLong(attachment.getOrderId()));
         }
         if (ask.getAccountId() != transaction.getSenderId()) {
-          throw new BurstException.NotValidException("Order " + Convert.toUnsignedLong(attachment.getOrderId()) + " was created by account "
+          throw new SignumException.NotValidException("Order " + Convert.toUnsignedLong(attachment.getOrderId()) + " was created by account "
                   + Convert.toUnsignedLong(ask.getAccountId()));
         }
       }
@@ -1988,14 +1988,14 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.ColoredCoinsBidOrderCancellation attachment = (Attachment.ColoredCoinsBidOrderCancellation) transaction.getAttachment();
         Order bid = assetExchange.getBidOrder(attachment.getOrderId());
         if (bid == null) {
-          throw new BurstException.NotCurrentlyValidException("Invalid bid order: " + Convert.toUnsignedLong(attachment.getOrderId()));
+          throw new SignumException.NotCurrentlyValidException("Invalid bid order: " + Convert.toUnsignedLong(attachment.getOrderId()));
         }
         if (bid.getAccountId() != transaction.getSenderId()) {
-          throw new BurstException.NotValidException("Order " + Convert.toUnsignedLong(attachment.getOrderId()) + " was created by account "
+          throw new SignumException.NotValidException("Order " + Convert.toUnsignedLong(attachment.getOrderId()) + " was created by account "
                   + Convert.toUnsignedLong(bid.getAccountId()));
         }
       }
@@ -2023,17 +2023,17 @@ public abstract class TransactionType {
     }
 
     @Override
-    protected final void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+    protected final void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
       if (! fluxCapacitor.getValue(FluxValues.DIGITAL_GOODS_STORE, blockchain.getLastBlock().getHeight())) {
-        throw new BurstException.NotYetEnabledException("Digital goods listing not yet enabled at height " + blockchain.getLastBlock().getHeight());
+        throw new SignumException.NotYetEnabledException("Digital goods listing not yet enabled at height " + blockchain.getLastBlock().getHeight());
       }
       if (transaction.getAmountNQT() != 0) {
-        throw new BurstException.NotValidException("Invalid digital goods transaction");
+        throw new SignumException.NotValidException("Invalid digital goods transaction");
       }
       doValidateAttachment(transaction);
     }
 
-    abstract void doValidateAttachment(Transaction transaction) throws BurstException.ValidationException;
+    abstract void doValidateAttachment(Transaction transaction) throws SignumException.ValidationException;
 
 
     public static final TransactionType LISTING = new DigitalGoods() {
@@ -2049,7 +2049,7 @@ public abstract class TransactionType {
       }
 
       @Override
-      public Attachment.DigitalGoodsListing parseAttachment(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+      public Attachment.DigitalGoodsListing parseAttachment(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
         return new Attachment.DigitalGoodsListing(buffer, transactionVersion);
       }
 
@@ -2065,7 +2065,7 @@ public abstract class TransactionType {
       }
 
       @Override
-      void doValidateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      void doValidateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.DigitalGoodsListing attachment = (Attachment.DigitalGoodsListing) transaction.getAttachment();
         if (attachment.getName().isEmpty()
                 || attachment.getName().length() > Constants.MAX_DGS_LISTING_NAME_LENGTH
@@ -2073,7 +2073,7 @@ public abstract class TransactionType {
                 || attachment.getTags().length() > Constants.MAX_DGS_LISTING_TAGS_LENGTH
                 || attachment.getQuantity() < 0 || attachment.getQuantity() > Constants.MAX_DGS_LISTING_QUANTITY
                 || attachment.getPriceNQT() <= 0 || attachment.getPriceNQT() > Constants.MAX_BALANCE_NQT) {
-          throw new BurstException.NotValidException("Invalid digital goods listing: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Invalid digital goods listing: " + JSON.toJsonString(attachment.getJsonObject()));
         }
       }
 
@@ -2113,14 +2113,14 @@ public abstract class TransactionType {
       }
 
       @Override
-      void doValidateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      void doValidateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.DigitalGoodsDelisting attachment = (Attachment.DigitalGoodsDelisting) transaction.getAttachment();
         DigitalGoodsStore.Goods goods = dgsGoodsStoreService.getGoods(attachment.getGoodsId());
         if (goods != null && transaction.getSenderId() != goods.getSellerId()) {
-          throw new BurstException.NotValidException("Invalid digital goods delisting - seller is different: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Invalid digital goods delisting - seller is different: " + JSON.toJsonString(attachment.getJsonObject()));
         }
         if (goods == null || goods.isDelisted()) {
-          throw new BurstException.NotCurrentlyValidException("Goods " + Convert.toUnsignedLong(attachment.getGoodsId()) +
+          throw new SignumException.NotCurrentlyValidException("Goods " + Convert.toUnsignedLong(attachment.getGoodsId()) +
                   "not yet listed or already delisted");
         }
       }
@@ -2167,15 +2167,15 @@ public abstract class TransactionType {
       }
 
       @Override
-      void doValidateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      void doValidateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.DigitalGoodsPriceChange attachment = (Attachment.DigitalGoodsPriceChange) transaction.getAttachment();
         DigitalGoodsStore.Goods goods = dgsGoodsStoreService.getGoods(attachment.getGoodsId());
         if (attachment.getPriceNQT() <= 0 || attachment.getPriceNQT() > Constants.MAX_BALANCE_NQT
                 || (goods != null && transaction.getSenderId() != goods.getSellerId())) {
-          throw new BurstException.NotValidException("Invalid digital goods price change: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Invalid digital goods price change: " + JSON.toJsonString(attachment.getJsonObject()));
         }
         if (goods == null || goods.isDelisted()) {
-          throw new BurstException.NotCurrentlyValidException("Goods " + Convert.toUnsignedLong(attachment.getGoodsId()) +
+          throw new SignumException.NotCurrentlyValidException("Goods " + Convert.toUnsignedLong(attachment.getGoodsId()) +
                   "not yet listed or already delisted");
         }
       }
@@ -2223,16 +2223,16 @@ public abstract class TransactionType {
       }
 
       @Override
-      void doValidateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      void doValidateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.DigitalGoodsQuantityChange attachment = (Attachment.DigitalGoodsQuantityChange) transaction.getAttachment();
         DigitalGoodsStore.Goods goods = dgsGoodsStoreService.getGoods(attachment.getGoodsId());
         if (attachment.getDeltaQuantity() < -Constants.MAX_DGS_LISTING_QUANTITY
                 || attachment.getDeltaQuantity() > Constants.MAX_DGS_LISTING_QUANTITY
                 || (goods != null && transaction.getSenderId() != goods.getSellerId())) {
-          throw new BurstException.NotValidException("Invalid digital goods quantity change: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Invalid digital goods quantity change: " + JSON.toJsonString(attachment.getJsonObject()));
         }
         if (goods == null || goods.isDelisted()) {
-          throw new BurstException.NotCurrentlyValidException("Goods " + Convert.toUnsignedLong(attachment.getGoodsId()) +
+          throw new SignumException.NotCurrentlyValidException("Goods " + Convert.toUnsignedLong(attachment.getGoodsId()) +
                   "not yet listed or already delisted");
         }
       }
@@ -2302,26 +2302,26 @@ public abstract class TransactionType {
       }
 
       @Override
-      void doValidateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      void doValidateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.DigitalGoodsPurchase attachment = (Attachment.DigitalGoodsPurchase) transaction.getAttachment();
         DigitalGoodsStore.Goods goods = dgsGoodsStoreService.getGoods(attachment.getGoodsId());
         if (attachment.getQuantity() <= 0 || attachment.getQuantity() > Constants.MAX_DGS_LISTING_QUANTITY
                 || attachment.getPriceNQT() <= 0 || attachment.getPriceNQT() > Constants.MAX_BALANCE_NQT
                 || (goods != null && goods.getSellerId() != transaction.getRecipientId())) {
-          throw new BurstException.NotValidException("Invalid digital goods purchase: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Invalid digital goods purchase: " + JSON.toJsonString(attachment.getJsonObject()));
         }
         if (transaction.getEncryptedMessage() != null && ! transaction.getEncryptedMessage().isText()) {
-          throw new BurstException.NotValidException("Only text encrypted messages allowed");
+          throw new SignumException.NotValidException("Only text encrypted messages allowed");
         }
         if (goods == null || goods.isDelisted()) {
-          throw new BurstException.NotCurrentlyValidException("Goods " + Convert.toUnsignedLong(attachment.getGoodsId()) +
+          throw new SignumException.NotCurrentlyValidException("Goods " + Convert.toUnsignedLong(attachment.getGoodsId()) +
                   "not yet listed or already delisted");
         }
         if (attachment.getQuantity() > goods.getQuantity() || attachment.getPriceNQT() != goods.getPriceNQT()) {
-          throw new BurstException.NotCurrentlyValidException("Goods price or quantity changed: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotCurrentlyValidException("Goods price or quantity changed: " + JSON.toJsonString(attachment.getJsonObject()));
         }
         if (attachment.getDeliveryDeadlineTimestamp() <= blockchain.getLastBlock().getTimestamp()) {
-          throw new BurstException.NotCurrentlyValidException("Delivery deadline has already expired: " + attachment.getDeliveryDeadlineTimestamp());
+          throw new SignumException.NotCurrentlyValidException("Delivery deadline has already expired: " + attachment.getDeliveryDeadlineTimestamp());
         }
       }
 
@@ -2345,7 +2345,7 @@ public abstract class TransactionType {
       }
 
       @Override
-      public Attachment.DigitalGoodsDelivery parseAttachment(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+      public Attachment.DigitalGoodsDelivery parseAttachment(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
         return new Attachment.DigitalGoodsDelivery(buffer, transactionVersion);
       }
 
@@ -2361,7 +2361,7 @@ public abstract class TransactionType {
       }
 
       @Override
-      void doValidateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      void doValidateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.DigitalGoodsDelivery attachment = (Attachment.DigitalGoodsDelivery) transaction.getAttachment();
         DigitalGoodsStore.Purchase purchase = dgsGoodsStoreService.getPendingPurchase(attachment.getPurchaseId());
         if (attachment.getGoods().getData().length > Constants.MAX_DGS_GOODS_LENGTH
@@ -2372,10 +2372,10 @@ public abstract class TransactionType {
                 (purchase.getBuyerId() != transaction.getRecipientId()
                         || transaction.getSenderId() != purchase.getSellerId()
                         || attachment.getDiscountNQT() > Convert.safeMultiply(purchase.getPriceNQT(), purchase.getQuantity())))) {
-          throw new BurstException.NotValidException("Invalid digital goods delivery: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Invalid digital goods delivery: " + JSON.toJsonString(attachment.getJsonObject()));
         }
         if (purchase == null || purchase.getEncryptedGoods() != null) {
-          throw new BurstException.NotCurrentlyValidException("Purchase does not exist yet, or already delivered: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotCurrentlyValidException("Purchase does not exist yet, or already delivered: " + JSON.toJsonString(attachment.getJsonObject()));
         }
       }
 
@@ -2421,25 +2421,25 @@ public abstract class TransactionType {
       }
 
       @Override
-      void doValidateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      void doValidateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.DigitalGoodsFeedback attachment = (Attachment.DigitalGoodsFeedback) transaction.getAttachment();
         DigitalGoodsStore.Purchase purchase = dgsGoodsStoreService.getPurchase(attachment.getPurchaseId());
         if (purchase != null &&
                 (purchase.getSellerId() != transaction.getRecipientId()
                         || transaction.getSenderId() != purchase.getBuyerId())) {
-          throw new BurstException.NotValidException("Invalid digital goods feedback: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Invalid digital goods feedback: " + JSON.toJsonString(attachment.getJsonObject()));
         }
         if (transaction.getEncryptedMessage() == null && transaction.getMessage() == null) {
-          throw new BurstException.NotValidException("Missing feedback message");
+          throw new SignumException.NotValidException("Missing feedback message");
         }
         if (transaction.getEncryptedMessage() != null && ! transaction.getEncryptedMessage().isText()) {
-          throw new BurstException.NotValidException("Only text encrypted messages allowed");
+          throw new SignumException.NotValidException("Only text encrypted messages allowed");
         }
         if (transaction.getMessage() != null && ! transaction.getMessage().isText()) {
-          throw new BurstException.NotValidException("Only text public messages allowed");
+          throw new SignumException.NotValidException("Only text public messages allowed");
         }
         if (purchase == null || purchase.getEncryptedGoods() == null) {
-          throw new BurstException.NotCurrentlyValidException("Purchase does not exist yet or not yet delivered");
+          throw new SignumException.NotCurrentlyValidException("Purchase does not exist yet or not yet delivered");
         }
       }
 
@@ -2508,20 +2508,20 @@ public abstract class TransactionType {
       }
 
       @Override
-      void doValidateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      void doValidateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.DigitalGoodsRefund attachment = (Attachment.DigitalGoodsRefund) transaction.getAttachment();
         DigitalGoodsStore.Purchase purchase = dgsGoodsStoreService.getPurchase(attachment.getPurchaseId());
         if (attachment.getRefundNQT() < 0 || attachment.getRefundNQT() > Constants.MAX_BALANCE_NQT
                 || (purchase != null &&
                 (purchase.getBuyerId() != transaction.getRecipientId()
                         || transaction.getSenderId() != purchase.getSellerId()))) {
-          throw new BurstException.NotValidException("Invalid digital goods refund: " + JSON.toJsonString(attachment.getJsonObject()));
+          throw new SignumException.NotValidException("Invalid digital goods refund: " + JSON.toJsonString(attachment.getJsonObject()));
         }
         if (transaction.getEncryptedMessage() != null && ! transaction.getEncryptedMessage().isText()) {
-          throw new BurstException.NotValidException("Only text encrypted messages allowed");
+          throw new SignumException.NotValidException("Only text encrypted messages allowed");
         }
         if (purchase == null || purchase.getEncryptedGoods() == null || purchase.getRefundNQT() != 0) {
-          throw new BurstException.NotCurrentlyValidException("Purchase does not exist or is not delivered or is already refunded");
+          throw new SignumException.NotCurrentlyValidException("Purchase does not exist or is not delivered or is already refunded");
         }
       }
 
@@ -2587,19 +2587,19 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
-        if (Signum.getFluxCapacitor().getValue(FluxValues.SODIUM)) throw new BurstException.NotCurrentlyValidException("Effective Balance Leasing disabled after Sodium HF");
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
+        if (Signum.getFluxCapacitor().getValue(FluxValues.SODIUM)) throw new SignumException.NotCurrentlyValidException("Effective Balance Leasing disabled after Sodium HF");
 
         Attachment.AccountControlEffectiveBalanceLeasing attachment = (Attachment.AccountControlEffectiveBalanceLeasing)transaction.getAttachment();
         Account recipientAccount = accountService.getAccount(transaction.getRecipientId());
         if (transaction.getSenderId() == transaction.getRecipientId()
                 || transaction.getAmountNQT() != 0
                 || attachment.getPeriod() < 1440) {
-          throw new BurstException.NotValidException("Invalid effective balance leasing: " + JSON.toJsonString(transaction.getJsonObject()) + " transaction " + transaction.getStringId());
+          throw new SignumException.NotValidException("Invalid effective balance leasing: " + JSON.toJsonString(transaction.getJsonObject()) + " transaction " + transaction.getStringId());
         }
         if (recipientAccount == null
                 || (recipientAccount.getPublicKey() == null && ! transaction.getStringId().equals("5081403377391821646"))) {
-          throw new BurstException.NotCurrentlyValidException("Invalid effective balance leasing: "
+          throw new SignumException.NotCurrentlyValidException("Invalid effective balance leasing: "
                   + " recipient account " + transaction.getRecipientId() + " not found or no public key published");
         }
       }
@@ -2668,29 +2668,29 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         int height = blockchain.getLastBlock().getHeight() + 1;
         Account sender = accountService.getAccount(transaction.getSenderId());
 
         if (sender == null) {
-          throw new BurstException.NotCurrentlyValidException("Sender not yet known ?!");
+          throw new SignumException.NotCurrentlyValidException("Sender not yet known ?!");
         }
 
         Account.RewardRecipientAssignment rewardAssignment = accountService.getRewardRecipientAssignment(sender);
         if (rewardAssignment != null && rewardAssignment.getFromHeight() >= height) {
-          throw new BurstException.NotCurrentlyValidException("Cannot reassign reward recipient before previous goes into effect: " + JSON.toJsonString(transaction.getJsonObject()));
+          throw new SignumException.NotCurrentlyValidException("Cannot reassign reward recipient before previous goes into effect: " + JSON.toJsonString(transaction.getJsonObject()));
         }
         Account recip = accountService.getAccount(transaction.getRecipientId());
         if (recip == null || recip.getPublicKey() == null) {
-          throw new BurstException.NotValidException("Reward recipient must have public key saved in blockchain: " + JSON.toJsonString(transaction.getJsonObject()));
+          throw new SignumException.NotValidException("Reward recipient must have public key saved in blockchain: " + JSON.toJsonString(transaction.getJsonObject()));
         }
 
         if (transaction.getAmountNQT() != 0 || transaction.getFeeNQT() < fluxCapacitor.getValue(FluxValues.FEE_QUANT, height)) {
-          throw new BurstException.NotValidException("Reward recipient assignment transaction must have 0 send amount and at least minimum fee: " + JSON.toJsonString(transaction.getJsonObject()));
+          throw new SignumException.NotValidException("Reward recipient assignment transaction must have 0 send amount and at least minimum fee: " + JSON.toJsonString(transaction.getJsonObject()));
         }
 
         if (!Signum.getFluxCapacitor().getValue(FluxValues.REWARD_RECIPIENT_ENABLE, height)) {
-          throw new BurstException.NotCurrentlyValidException("Reward recipient assignment not allowed before block " + Signum.getFluxCapacitor().getStartingHeight(FluxValues.REWARD_RECIPIENT_ENABLE));
+          throw new SignumException.NotCurrentlyValidException("Reward recipient assignment not allowed before block " + Signum.getFluxCapacitor().getStartingHeight(FluxValues.REWARD_RECIPIENT_ENABLE));
         }
       }
 
@@ -2763,16 +2763,16 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         int height = blockchain.getLastBlock().getHeight() + 1;
         Account sender = accountService.getAccount(transaction.getSenderId());
 
         if (sender == null) {
-          throw new BurstException.NotCurrentlyValidException("Sender not yet known ?!");
+          throw new SignumException.NotCurrentlyValidException("Sender not yet known ?!");
         }
 
         if (!Signum.getFluxCapacitor().getValue(FluxValues.SIGNUM, height)) {
-          throw new BurstException.NotCurrentlyValidException("Add commitment not allowed before block " + Signum.getFluxCapacitor().getStartingHeight(FluxValues.SIGNUM));
+          throw new SignumException.NotCurrentlyValidException("Add commitment not allowed before block " + Signum.getFluxCapacitor().getStartingHeight(FluxValues.SIGNUM));
         }
       }
 
@@ -2847,16 +2847,16 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         int height = blockchain.getLastBlock().getHeight() + 1;
         Account sender = accountService.getAccount(transaction.getSenderId());
 
         if (sender == null) {
-          throw new BurstException.NotCurrentlyValidException("Sender not yet known ?!");
+          throw new SignumException.NotCurrentlyValidException("Sender not yet known ?!");
         }
 
         if (!Signum.getFluxCapacitor().getValue(FluxValues.SIGNUM, height)) {
-          throw new BurstException.NotCurrentlyValidException("Add commitment not allowed before block " + Signum.getFluxCapacitor().getStartingHeight(FluxValues.SIGNUM));
+          throw new SignumException.NotCurrentlyValidException("Add commitment not allowed before block " + Signum.getFluxCapacitor().getStartingHeight(FluxValues.SIGNUM));
         }
       }
 
@@ -2890,12 +2890,12 @@ public abstract class TransactionType {
       }
 
       @Override
-      public Attachment.AdvancedPaymentEscrowCreation parseAttachment(ByteBuffer buffer, byte transactionVersion) throws BurstException.NotValidException {
+      public Attachment.AdvancedPaymentEscrowCreation parseAttachment(ByteBuffer buffer, byte transactionVersion) throws SignumException.NotValidException {
         return new Attachment.AdvancedPaymentEscrowCreation(buffer, transactionVersion);
       }
 
       @Override
-      protected Attachment.AdvancedPaymentEscrowCreation parseAttachment(JsonObject attachmentData) throws BurstException.NotValidException {
+      protected Attachment.AdvancedPaymentEscrowCreation parseAttachment(JsonObject attachmentData) throws SignumException.NotValidException {
         return new Attachment.AdvancedPaymentEscrowCreation(attachmentData);
       }
 
@@ -2944,45 +2944,45 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.AdvancedPaymentEscrowCreation attachment = (Attachment.AdvancedPaymentEscrowCreation) transaction.getAttachment();
         Long totalAmountNQT = Convert.safeAdd(attachment.getAmountNQT(), transaction.getFeeNQT());
         if (transaction.getSenderId() == transaction.getRecipientId()) {
-          throw new BurstException.NotValidException("Escrow must have different sender and recipient");
+          throw new SignumException.NotValidException("Escrow must have different sender and recipient");
         }
         totalAmountNQT = Convert.safeAdd(totalAmountNQT, attachment.getTotalSigners() * Constants.ONE_BURST);
         if (transaction.getAmountNQT() != 0) {
-          throw new BurstException.NotValidException("Transaction sent amount must be 0 for escrow");
+          throw new SignumException.NotValidException("Transaction sent amount must be 0 for escrow");
         }
         if (totalAmountNQT.compareTo(0L) < 0 ||
                 totalAmountNQT.compareTo(Constants.MAX_BALANCE_NQT) > 0)
         {
-          throw new BurstException.NotValidException("Invalid escrow creation amount");
+          throw new SignumException.NotValidException("Invalid escrow creation amount");
         }
         if (transaction.getFeeNQT() < Constants.ONE_BURST) {
-          throw new BurstException.NotValidException("Escrow transaction must have a fee at least 1 burst");
+          throw new SignumException.NotValidException("Escrow transaction must have a fee at least 1 burst");
         }
         if (attachment.getRequiredSigners() < 1 || attachment.getRequiredSigners() > 10) {
-          throw new BurstException.NotValidException("Escrow required signers much be 1 - 10");
+          throw new SignumException.NotValidException("Escrow required signers much be 1 - 10");
         }
         if (attachment.getRequiredSigners() > attachment.getTotalSigners()) {
-          throw new BurstException.NotValidException("Cannot have more required than signers on escrow");
+          throw new SignumException.NotValidException("Cannot have more required than signers on escrow");
         }
         if (attachment.getTotalSigners() < 1 || attachment.getTotalSigners() > 10) {
-          throw new BurstException.NotValidException("Escrow transaction requires 1 - 10 signers");
+          throw new SignumException.NotValidException("Escrow transaction requires 1 - 10 signers");
         }
         if (attachment.getDeadline() < 1 || attachment.getDeadline() > 7776000) { // max deadline 3 months
-          throw new BurstException.NotValidException("Escrow deadline must be 1 - 7776000 seconds");
+          throw new SignumException.NotValidException("Escrow deadline must be 1 - 7776000 seconds");
         }
         if (attachment.getDeadlineAction() == null || attachment.getDeadlineAction() == Escrow.DecisionType.UNDECIDED) {
-          throw new BurstException.NotValidException("Invalid deadline action for escrow");
+          throw new SignumException.NotValidException("Invalid deadline action for escrow");
         }
         if (attachment.getSigners().contains(transaction.getSenderId()) ||
                 attachment.getSigners().contains(transaction.getRecipientId())) {
-          throw new BurstException.NotValidException("Escrow sender and recipient cannot be signers");
+          throw new SignumException.NotValidException("Escrow sender and recipient cannot be signers");
         }
         if (!escrowService.isEnabled()) {
-          throw new BurstException.NotYetEnabledException("Escrow not yet enabled");
+          throw new SignumException.NotYetEnabledException("Escrow not yet enabled");
         }
       }
 
@@ -3040,31 +3040,31 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.AdvancedPaymentEscrowSign attachment = (Attachment.AdvancedPaymentEscrowSign) transaction.getAttachment();
         if (transaction.getAmountNQT() != 0 || transaction.getFeeNQT() != Constants.ONE_BURST) {
-          throw new BurstException.NotValidException("Escrow signing must have amount 0 and fee of 1");
+          throw new SignumException.NotValidException("Escrow signing must have amount 0 and fee of 1");
         }
         if (attachment.getEscrowId() == null || attachment.getDecision() == null) {
-          throw new BurstException.NotValidException("Escrow signing requires escrow id and decision set");
+          throw new SignumException.NotValidException("Escrow signing requires escrow id and decision set");
         }
         Escrow escrow = escrowService.getEscrowTransaction(attachment.getEscrowId());
         if (escrow == null) {
-          throw new BurstException.NotValidException("Escrow transaction not found");
+          throw new SignumException.NotValidException("Escrow transaction not found");
         }
         if (!escrowService.isIdSigner(transaction.getSenderId(), escrow) &&
                 !escrow.getSenderId().equals(transaction.getSenderId()) &&
                 !escrow.getRecipientId().equals(transaction.getSenderId())) {
-          throw new BurstException.NotValidException("Sender is not a participant in specified escrow");
+          throw new SignumException.NotValidException("Sender is not a participant in specified escrow");
         }
         if (escrow.getSenderId().equals(transaction.getSenderId()) && attachment.getDecision() != Escrow.DecisionType.RELEASE) {
-          throw new BurstException.NotValidException("Escrow sender can only release");
+          throw new SignumException.NotValidException("Escrow sender can only release");
         }
         if (escrow.getRecipientId().equals(transaction.getSenderId()) && attachment.getDecision() != Escrow.DecisionType.REFUND) {
-          throw new BurstException.NotValidException("Escrow recipient can only refund");
+          throw new SignumException.NotValidException("Escrow recipient can only refund");
         }
         if (!escrowService.isEnabled()) {
-          throw new BurstException.NotYetEnabledException("Escrow not yet enabled");
+          throw new SignumException.NotYetEnabledException("Escrow not yet enabled");
         }
       }
 
@@ -3117,8 +3117,8 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
-        throw new BurstException.NotValidException("Escrow result never validates");
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
+        throw new SignumException.NotValidException("Escrow result never validates");
       }
 
       @Override
@@ -3176,21 +3176,21 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.AdvancedPaymentSubscriptionSubscribe attachment = (Attachment.AdvancedPaymentSubscriptionSubscribe) transaction.getAttachment();
         if (attachment.getFrequency() == null ||
                 attachment.getFrequency() < Constants.BURST_SUBSCRIPTION_MIN_FREQ ||
                 attachment.getFrequency() > Constants.BURST_SUBSCRIPTION_MAX_FREQ) {
-          throw new BurstException.NotValidException("Invalid subscription frequency");
+          throw new SignumException.NotValidException("Invalid subscription frequency");
         }
         if (transaction.getAmountNQT() < Constants.ONE_BURST || transaction.getAmountNQT() > Constants.MAX_BALANCE_NQT) {
-          throw new BurstException.NotValidException("Subscriptions must be at least one " + Signum.getPropertyService().getString(Props.VALUE_SUFIX));
+          throw new SignumException.NotValidException("Subscriptions must be at least one " + Signum.getPropertyService().getString(Props.VALUE_SUFIX));
         }
         if (transaction.getSenderId() == transaction.getRecipientId()) {
-          throw new BurstException.NotValidException("Cannot create subscription to same address");
+          throw new SignumException.NotValidException("Cannot create subscription to same address");
         }
         if (!subscriptionService.isEnabled()) {
-          throw new BurstException.NotYetEnabledException("Subscriptions not yet enabled");
+          throw new SignumException.NotYetEnabledException("Subscriptions not yet enabled");
         }
       }
 
@@ -3248,24 +3248,24 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.AdvancedPaymentSubscriptionCancel attachment = (Attachment.AdvancedPaymentSubscriptionCancel) transaction.getAttachment();
         if (attachment.getSubscriptionId() == null) {
-          throw new BurstException.NotValidException("Subscription cancel must include subscription id");
+          throw new SignumException.NotValidException("Subscription cancel must include subscription id");
         }
 
         Subscription subscription = subscriptionService.getSubscription(attachment.getSubscriptionId());
         if (subscription == null) {
-          throw new BurstException.NotValidException("Subscription cancel must contain current subscription id");
+          throw new SignumException.NotValidException("Subscription cancel must contain current subscription id");
         }
 
         if (!subscription.getSenderId().equals(transaction.getSenderId()) &&
                 !subscription.getRecipientId().equals(transaction.getSenderId())) {
-          throw new BurstException.NotValidException("Subscription cancel can only be done by participants");
+          throw new SignumException.NotValidException("Subscription cancel can only be done by participants");
         }
 
         if (!subscriptionService.isEnabled()) {
-          throw new BurstException.NotYetEnabledException("Subscription cancel not yet enabled");
+          throw new SignumException.NotYetEnabledException("Subscription cancel not yet enabled");
         }
       }
 
@@ -3318,8 +3318,8 @@ public abstract class TransactionType {
       }
 
       @Override
-      protected void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
-        throw new BurstException.NotValidException("Subscription payment never validates");
+      protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
+        throw new SignumException.NotValidException("Subscription payment never validates");
       }
 
       @Override
@@ -3355,14 +3355,14 @@ public abstract class TransactionType {
     }
 
     @Override
-    protected final void validateAttachment(Transaction transaction) throws BurstException.ValidationException {
+    protected final void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
       if (transaction.getAmountNQT() != 0) {
-        throw new BurstException.NotValidException("Invalid automated transaction transaction");
+        throw new SignumException.NotValidException("Invalid automated transaction transaction");
       }
       doValidateAttachment(transaction);
     }
 
-    abstract void doValidateAttachment(Transaction transaction) throws BurstException.ValidationException;
+    abstract void doValidateAttachment(Transaction transaction) throws SignumException.ValidationException;
 
 
     public static final TransactionType AUTOMATED_TRANSACTION_CREATION = new AutomatedTransactions(){
@@ -3392,16 +3392,16 @@ public abstract class TransactionType {
       void doValidateAttachment(Transaction transaction)
               throws ValidationException {
         if (! fluxCapacitor.getValue(FluxValues.AUTOMATED_TRANSACTION_BLOCK, blockchain.getLastBlock().getHeight())) {
-          throw new BurstException.NotYetEnabledException("Automated Transactions not yet enabled at height " + blockchain.getLastBlock().getHeight());
+          throw new SignumException.NotYetEnabledException("Automated Transactions not yet enabled at height " + blockchain.getLastBlock().getHeight());
         }
         if (transaction.getSignature() != null && accountService.getAccount(transaction.getId()) != null) {
           Account existingAccount = accountService.getAccount(transaction.getId());
           if (existingAccount.getPublicKey() != null && !Arrays.equals(existingAccount.getPublicKey(), new byte[32]))
-            throw new BurstException.NotValidException("Account with id already exists");
+            throw new SignumException.NotValidException("Account with id already exists");
         }
         Attachment.AutomatedTransactionsCreation attachment = (Attachment.AutomatedTransactionsCreation) transaction.getAttachment();
         if (attachment.getCreationBytes() == null) {
-          throw new BurstException.NotCurrentlyValidException("AT creation bytes cannot be null");
+          throw new SignumException.NotCurrentlyValidException("AT creation bytes cannot be null");
         }
         long totalPages;
         int minCodePages = 1;
@@ -3424,25 +3424,25 @@ public abstract class TransactionType {
               }
             }
             if(referenceTransaction == null) {
-              throw new BurstException.NotCurrentlyValidException("Invalid reference transaction for the AT code");
+              throw new SignumException.NotCurrentlyValidException("Invalid reference transaction for the AT code");
             }
           }
           totalPages = AtController.checkCreationBytes(attachment.getCreationBytes(), blockchain.getHeight(), minCodePages);
         }
         catch (AtException e) {
-          throw new BurstException.NotCurrentlyValidException("Invalid AT creation bytes", e);
+          throw new SignumException.NotCurrentlyValidException("Invalid AT creation bytes", e);
         }
         long requiredFee = totalPages * AtConstants.getInstance().costPerPage( blockchain.getHeight() );
         if (transaction.getFeeNQT() <  requiredFee){
-          throw new BurstException.NotValidException("Insufficient fee for AT creation, using " + transaction.getFeeNQT()
+          throw new SignumException.NotValidException("Insufficient fee for AT creation, using " + transaction.getFeeNQT()
             + ", minimum: " + requiredFee);
         }
         if (fluxCapacitor.getValue(FluxValues.AT_FIX_BLOCK_3)) {
           if (attachment.getName().length() > Constants.MAX_AUTOMATED_TRANSACTION_NAME_LENGTH) {
-            throw new BurstException.NotValidException("Name of automated transaction over size limit");
+            throw new SignumException.NotValidException("Name of automated transaction over size limit");
           }
           if (attachment.getDescription().length() > Constants.MAX_AUTOMATED_TRANSACTION_DESCRIPTION_LENGTH) {
-            throw new BurstException.NotValidException("Description of automated transaction over size limit");
+            throw new SignumException.NotValidException("Description of automated transaction over size limit");
           }
         }
       }
@@ -3492,8 +3492,8 @@ public abstract class TransactionType {
       }
 
       @Override
-      void doValidateAttachment(Transaction transaction) throws BurstException.ValidationException {
-        throw new BurstException.NotValidException("AT payment never validates");
+      void doValidateAttachment(Transaction transaction) throws SignumException.ValidationException {
+        throw new SignumException.NotValidException("AT payment never validates");
       }
 
       @Override

--- a/src/brs/assetexchange/AssetServiceImpl.java
+++ b/src/brs/assetexchange/AssetServiceImpl.java
@@ -2,7 +2,7 @@ package brs.assetexchange;
 
 import brs.Account.AccountAsset;
 import brs.*;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.sql.EntitySqlTable;
 import brs.db.store.AssetStore;
 import brs.util.CollectionWithIndex;
@@ -19,7 +19,7 @@ class AssetServiceImpl {
 
   private final EntitySqlTable<Asset> assetTable;
 
-  private final BurstKey.LongKeyFactory<Asset> assetDbKeyFactory;
+  private final SignumKey.LongKeyFactory<Asset> assetDbKeyFactory;
 
   public AssetServiceImpl(AssetAccountServiceImpl assetAccountService, TradeServiceImpl tradeService, AssetStore assetStore, AssetTransferServiceImpl assetTransferService) {
     this.assetAccountService = assetAccountService;
@@ -107,7 +107,7 @@ class AssetServiceImpl {
   }
 
   public void addAsset(long assetId, long senderId, Attachment.ColoredCoinsAssetIssuance attachment) {
-    final BurstKey dbKey = assetDbKeyFactory.newKey(assetId);
+    final SignumKey dbKey = assetDbKeyFactory.newKey(assetId);
     assetTable.insert(new Asset(dbKey, assetId, senderId, attachment));
   }
 

--- a/src/brs/assetexchange/AssetServiceImpl.java
+++ b/src/brs/assetexchange/AssetServiceImpl.java
@@ -80,7 +80,7 @@ class AssetServiceImpl {
     
     if(nextIndex < 0) {
       // now check for ownership transfers
-      Blockchain blockchain = Burst.getBlockchain();
+      Blockchain blockchain = Signum.getBlockchain();
       int remainingSize = from - to - assetsIssued.size();
 
       Collection<Long> txIds = blockchain.getTransactionIds(null, accountId, 0, 

--- a/src/brs/assetexchange/AssetTransferServiceImpl.java
+++ b/src/brs/assetexchange/AssetTransferServiceImpl.java
@@ -3,7 +3,7 @@ package brs.assetexchange;
 import brs.AssetTransfer;
 import brs.AssetTransfer.Event;
 import brs.Transaction;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.sql.EntitySqlTable;
 import brs.db.store.AssetTransferStore;
 import brs.util.Listener;
@@ -17,7 +17,7 @@ class AssetTransferServiceImpl {
 
   private final AssetTransferStore assetTransferStore;
   private final EntitySqlTable<AssetTransfer> assetTransferTable;
-  private final BurstKey.LinkKeyFactory<AssetTransfer> transferDbKeyFactory;
+  private final SignumKey.LinkKeyFactory<AssetTransfer> transferDbKeyFactory;
 
 
   public AssetTransferServiceImpl(AssetTransferStore assetTransferStore) {
@@ -51,7 +51,7 @@ class AssetTransferServiceImpl {
   }
 
   public AssetTransfer addAssetTransfer(Transaction transaction, long assetId, long quantityQNT) {
-    BurstKey dbKey = transferDbKeyFactory.newKey(transaction.getId(), assetId);
+    SignumKey dbKey = transferDbKeyFactory.newKey(transaction.getId(), assetId);
     AssetTransfer assetTransfer = new AssetTransfer(dbKey, transaction, assetId, quantityQNT);
     assetTransferTable.insert(assetTransfer);
     listeners.notify(assetTransfer, Event.ASSET_TRANSFER);

--- a/src/brs/assetexchange/OrderServiceImpl.java
+++ b/src/brs/assetexchange/OrderServiceImpl.java
@@ -6,8 +6,8 @@ import brs.Attachment.ColoredCoinsOrderPlacement;
 import brs.Order.Ask;
 import brs.Order.Bid;
 import brs.Order.OrderJournal;
-import brs.db.BurstKey;
-import brs.db.BurstKey.LongKeyFactory;
+import brs.db.SignumKey;
+import brs.db.SignumKey.LongKeyFactory;
 import brs.db.VersionedEntityTable;
 import brs.db.store.OrderStore;
 import brs.services.AccountService;
@@ -131,14 +131,14 @@ class OrderServiceImpl {
   }
 
   public void addAskOrder(Transaction transaction, Attachment.ColoredCoinsAskOrderPlacement attachment) {
-    BurstKey dbKey = askOrderDbKeyFactory.newKey(transaction.getId());
+    SignumKey dbKey = askOrderDbKeyFactory.newKey(transaction.getId());
     Ask order = new Ask(dbKey, transaction, attachment);
     askOrderTable.insert(order);
     matchOrders(attachment.getAssetId());
   }
 
   public void addBidOrder(Transaction transaction, Attachment.ColoredCoinsBidOrderPlacement attachment) {
-    BurstKey dbKey = bidOrderDbKeyFactory.newKey(transaction.getId());
+    SignumKey dbKey = bidOrderDbKeyFactory.newKey(transaction.getId());
     Bid order = new Bid(dbKey, transaction, attachment);
     bidOrderTable.insert(order);
     matchOrders(attachment.getAssetId());

--- a/src/brs/assetexchange/OrderServiceImpl.java
+++ b/src/brs/assetexchange/OrderServiceImpl.java
@@ -87,7 +87,7 @@ class OrderServiceImpl {
   }
 
   public CollectionWithIndex<OrderJournal> getTradeJournal(final long accountId, final long assetId, int from, int to) {
-    Collection<Transaction> transactions = Burst.getBlockchain().getTransactions(accountId,
+    Collection<Transaction> transactions = Signum.getBlockchain().getTransactions(accountId,
         TransactionType.TYPE_COLORED_COINS.getType(), TransactionType.SUBTYPE_COLORED_COINS_ASK_ORDER_PLACEMENT,
         TransactionType.SUBTYPE_COLORED_COINS_BID_ORDER_PLACEMENT, from, to);
     
@@ -105,7 +105,7 @@ class OrderServiceImpl {
     }
     
     // check the cancellations
-    transactions = Burst.getBlockchain().getTransactions(accountId,
+    transactions = Signum.getBlockchain().getTransactions(accountId,
         TransactionType.TYPE_COLORED_COINS.getType(), TransactionType.SUBTYPE_COLORED_COINS_ASK_ORDER_CANCELLATION,
         TransactionType.SUBTYPE_COLORED_COINS_BID_ORDER_CANCELLATION, -1, -1);
     for(Transaction transaction : transactions) {
@@ -145,11 +145,11 @@ class OrderServiceImpl {
   }
 
   private Ask getNextAskOrder(long assetId) {
-    return Burst.getStores().getOrderStore().getNextOrder(assetId);
+    return Signum.getStores().getOrderStore().getNextOrder(assetId);
   }
 
   private Bid getNextBidOrder(long assetId) {
-    return Burst.getStores().getOrderStore().getNextBid(assetId);
+    return Signum.getStores().getOrderStore().getNextBid(assetId);
   }
 
   private void matchOrders(long assetId) {
@@ -165,7 +165,7 @@ class OrderServiceImpl {
       }
 
 
-      Trade trade = tradeService.addTrade(assetId, Burst.getBlockchain().getLastBlock(), askOrder, bidOrder);
+      Trade trade = tradeService.addTrade(assetId, Signum.getBlockchain().getLastBlock(), askOrder, bidOrder);
 
       askOrderUpdateQuantityQNT(askOrder, Convert.safeSubtract(askOrder.getQuantityQNT(), trade.getQuantityQNT()));
       Account askAccount = accountService.getAccount(askOrder.getAccountId());

--- a/src/brs/assetexchange/TradeServiceImpl.java
+++ b/src/brs/assetexchange/TradeServiceImpl.java
@@ -4,8 +4,8 @@ import brs.Block;
 import brs.Order;
 import brs.Trade;
 import brs.Trade.Event;
-import brs.db.BurstKey;
-import brs.db.BurstKey.LinkKeyFactory;
+import brs.db.SignumKey;
+import brs.db.SignumKey.LinkKeyFactory;
 import brs.db.sql.EntitySqlTable;
 import brs.db.store.TradeStore;
 import brs.util.Listener;
@@ -86,7 +86,7 @@ class TradeServiceImpl {
   }
 
   public Trade addTrade(long assetId, Block block, Order.Ask askOrder, Order.Bid bidOrder) {
-    BurstKey dbKey = tradeDbKeyFactory.newKey(askOrder.getId(), bidOrder.getId());
+    SignumKey dbKey = tradeDbKeyFactory.newKey(askOrder.getId(), bidOrder.getId());
     Trade trade = new Trade(dbKey, assetId, block, askOrder, bidOrder);
     tradeTable.insert(trade);
     listeners.notify(trade, Event.TRADE);

--- a/src/brs/at/AT.java
+++ b/src/brs/at/AT.java
@@ -8,7 +8,7 @@ package brs.at;
 
 
 import brs.*;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.TransactionDb;
 import brs.db.VersionedEntityTable;
 import brs.services.AccountService;
@@ -32,7 +32,7 @@ public class AT extends AtMachineState {
     private static final LinkedHashMap<Long, LinkedHashMap<Long, Long>> pendingFeesMap = new LinkedHashMap<>();
     private static final LinkedHashMap<Long, List<AtTransaction>> pendingTransactionsMap = new LinkedHashMap<>();
     private static final LinkedHashMap<Long, List<AtMapEntry>> pendingEntryUpdatesMap = new LinkedHashMap<>();
-    public final BurstKey dbKey;
+    public final SignumKey dbKey;
     private final String name;
     private final String description;
     private final int nextHeight;
@@ -118,7 +118,7 @@ public class AT extends AtMachineState {
         return false;
     }
 
-    private static BurstKey.LongKeyFactory<AT> atDbKeyFactory() {
+    private static SignumKey.LongKeyFactory<AT> atDbKeyFactory() {
         return Signum.getStores().getAtStore().getAtDbKeyFactory();
     }
 
@@ -126,7 +126,7 @@ public class AT extends AtMachineState {
         return Signum.getStores().getAtStore().getAtTable();
     }
 
-    private static BurstKey.LongKeyFactory<ATState> atStateDbKeyFactory() {
+    private static SignumKey.LongKeyFactory<ATState> atStateDbKeyFactory() {
         return Signum.getStores().getAtStore().getAtStateDbKeyFactory();
     }
 
@@ -300,7 +300,7 @@ public class AT extends AtMachineState {
 
     public static class ATState {
 
-        public final BurstKey dbKey;
+        public final SignumKey dbKey;
         private final long atId;
         private byte[] state;
         private int prevHeight;

--- a/src/brs/at/AT.java
+++ b/src/brs/at/AT.java
@@ -42,7 +42,7 @@ public class AT extends AtMachineState {
         this.name = name;
         this.description = description;
         dbKey = atDbKeyFactory().newKey(AtApiHelper.getLong(atId));
-        this.nextHeight = Burst.getBlockchain().getHeight();
+        this.nextHeight = Signum.getBlockchain().getHeight();
     }
 
     public AT(byte[] atId, byte[] creator, String name, String description, short version,
@@ -119,19 +119,19 @@ public class AT extends AtMachineState {
     }
 
     private static BurstKey.LongKeyFactory<AT> atDbKeyFactory() {
-        return Burst.getStores().getAtStore().getAtDbKeyFactory();
+        return Signum.getStores().getAtStore().getAtDbKeyFactory();
     }
 
     private static VersionedEntityTable<AT> atTable() {
-        return Burst.getStores().getAtStore().getAtTable();
+        return Signum.getStores().getAtStore().getAtTable();
     }
 
     private static BurstKey.LongKeyFactory<ATState> atStateDbKeyFactory() {
-        return Burst.getStores().getAtStore().getAtStateDbKeyFactory();
+        return Signum.getStores().getAtStore().getAtStateDbKeyFactory();
     }
 
     private static VersionedEntityTable<ATState> atStateTable() {
-        return Burst.getStores().getAtStore().getAtStateTable();
+        return Signum.getStores().getAtStore().getAtStateTable();
     }
 
     public static AT getAT(byte[] id) {
@@ -139,7 +139,7 @@ public class AT extends AtMachineState {
     }
 
     public static AT getAT(Long id) {
-        return Burst.getStores().getAtStore().getAT(id, -1);
+        return Signum.getStores().getAtStore().getAT(id, -1);
     }
 
     public static void addAT(Long atId, Long senderAccountId, String name, String description, byte[] creationBytes, int height, long atCodeHashId) {
@@ -173,7 +173,7 @@ public class AT extends AtMachineState {
     }
 
     public static List<Long> getOrderedATs() {
-        return Burst.getStores().getAtStore().getOrderedATs();
+        return Signum.getStores().getAtStore().getOrderedATs();
     }
 
     public static byte[] compressState(byte[] stateBytes) {
@@ -213,7 +213,7 @@ public class AT extends AtMachineState {
     }
 
     public void saveState() {
-        int prevHeight = Burst.getBlockchain().getHeight();
+        int prevHeight = Signum.getBlockchain().getHeight();
         int newNextHeight = prevHeight + getWaitForNumberOfBlocks();
         ATState state = new ATState(AtApiHelper.getLong(this.getId()),
             getState(), newNextHeight, getSleepBetween(),
@@ -227,9 +227,9 @@ public class AT extends AtMachineState {
       long hash = blockHeight+generatorId;
       List<AtMapEntry> updates = pendingEntryUpdatesMap.get(hash);
       if(updates != null) {
-        VersionedEntityTable<AtMapEntry> table = Burst.getStores().getAtStore().getAtMapTable();
+        VersionedEntityTable<AtMapEntry> table = Signum.getStores().getAtStore().getAtMapTable();
         for(AtMapEntry e : updates) {
-          AtMapEntry cacheEntry = Burst.getStores().getAtStore().getMapValueEntry(e.getAtId(), e.getKey1(), e.getKey2());
+          AtMapEntry cacheEntry = Signum.getStores().getAtStore().getMapValueEntry(e.getAtId(), e.getKey1(), e.getKey2());
           if(cacheEntry != null) {
             cacheEntry.setValue(e.getValue());
             e = cacheEntry;

--- a/src/brs/at/AT.java
+++ b/src/brs/at/AT.java
@@ -284,7 +284,7 @@ public class AT extends AtMachineState {
                       atTransaction.apply(accountService, transaction);
                       transactions.add(transaction);
                     }
-                } catch (BurstException.NotValidException e) {
+                } catch (SignumException.NotValidException e) {
                     throw new RuntimeException("Failed to construct AT payment transaction", e);
                 }
               }

--- a/src/brs/at/AtApiHelper.java
+++ b/src/brs/at/AtApiHelper.java
@@ -19,7 +19,7 @@ public class AtApiHelper {
     private AtApiHelper() {
     }
 
-    private static final SignumCrypto burstCrypto = SignumCrypto.getInstance();
+    private static final SignumCrypto signumCrypto = SignumCrypto.getInstance();
 
     public static int longToHeight(long x) {
         return (int) (x >> 32);
@@ -29,11 +29,11 @@ public class AtApiHelper {
         if (bytes.length > 8) {
             throw new BufferOverflowException();
         }
-        return burstCrypto.bytesToLongLE(bytes);
+        return signumCrypto.bytesToLongLE(bytes);
     }
 
     public static byte[] getByteArray(long l) {
-        return burstCrypto.longToBytesLE(l);
+        return signumCrypto.longToBytesLE(l);
     }
 
     public static int longToNumOfTx(long x) {

--- a/src/brs/at/AtApiImpl.java
+++ b/src/brs/at/AtApiImpl.java
@@ -7,7 +7,7 @@
 
 package brs.at;
 
-import brs.Burst;
+import brs.Signum;
 import brs.crypto.Crypto;
 import brs.fluxcapacitor.FluxValues;
 
@@ -533,7 +533,7 @@ public class AtApiImpl implements AtApi {
         mdb.order(ByteOrder.LITTLE_ENDIAN);
 
         state.setB1(AtApiHelper.getByteArray(mdb.getLong(0)));
-        if (Burst.getFluxCapacitor().getValue(FluxValues.SODIUM)) {
+        if (Signum.getFluxCapacitor().getValue(FluxValues.SODIUM)) {
             state.setB2(AtApiHelper.getByteArray(mdb.getLong(8)));
         } else {
             state.setB1(AtApiHelper.getByteArray(mdb.getLong(8)));
@@ -543,7 +543,7 @@ public class AtApiImpl implements AtApi {
 
     @Override
     public long checkMd5AWithB(AtMachineState state) {
-        if (Burst.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_3)) {
+        if (Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_3)) {
             ByteBuffer b = ByteBuffer.allocate(16);
             b.order(ByteOrder.LITTLE_ENDIAN);
 
@@ -582,7 +582,7 @@ public class AtApiImpl implements AtApi {
 
     @Override
     public long checkHash160AWithB(AtMachineState state) {
-        if (Burst.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_3)) {
+        if (Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_3)) {
             ByteBuffer b = ByteBuffer.allocate(32);
             b.order(ByteOrder.LITTLE_ENDIAN);
 
@@ -627,7 +627,7 @@ public class AtApiImpl implements AtApi {
 
     @Override
     public long checkSha256AWithB(AtMachineState state) {
-        if (Burst.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_3)) {
+        if (Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_3)) {
             ByteBuffer b = ByteBuffer.allocate(32);
             b.order(ByteOrder.LITTLE_ENDIAN);
 

--- a/src/brs/at/AtApiPlatformImpl.java
+++ b/src/brs/at/AtApiPlatformImpl.java
@@ -5,7 +5,7 @@ import brs.Appendix;
 import brs.Asset;
 import brs.Attachment;
 import brs.Attachment.ColoredCoinsAssetTransfer;
-import brs.Burst;
+import brs.Signum;
 import brs.Constants;
 import brs.Transaction;
 import brs.TransactionType;
@@ -37,11 +37,11 @@ public class AtApiPlatformImpl extends AtApiImpl {
     }
 
     private static Long findTransaction(int startHeight, int endHeight, Long atID, int numOfTx, long minAmount) {
-        return Burst.getStores().getAtStore().findTransaction(startHeight, endHeight, atID, numOfTx, minAmount);
+        return Signum.getStores().getAtStore().findTransaction(startHeight, endHeight, atID, numOfTx, minAmount);
     }
 
     private static int findTransactionHeight(Long transactionId, int height, Long atID, long minAmount) {
-        return Burst.getStores().getAtStore().findTransactionHeight(transactionId, height, atID, minAmount);
+        return Signum.getStores().getAtStore().findTransactionHeight(transactionId, height, atID, minAmount);
     }
 
     @Override
@@ -66,7 +66,7 @@ public class AtApiPlatformImpl extends AtApiImpl {
         ByteBuffer b = ByteBuffer.allocate(state.getA1().length * 4);
         b.order(ByteOrder.LITTLE_ENDIAN);
 
-        b.put(Burst.getBlockchain().getBlockAtHeight(state.getHeight() - 1).getBlockHash());
+        b.put(Signum.getBlockchain().getBlockAtHeight(state.getHeight() - 1).getBlockHash());
 
         b.clear();
 
@@ -104,7 +104,7 @@ public class AtApiPlatformImpl extends AtApiImpl {
     public long getTypeForTxInA(AtMachineState state) {
         long txid = AtApiHelper.getLong(state.getA1());
 
-        Transaction tx = Burst.getBlockchain().getTransaction(txid);
+        Transaction tx = Signum.getBlockchain().getTransaction(txid);
 
         if (tx == null || (tx.getHeight() >= state.getHeight())) {
             return -1;
@@ -125,7 +125,7 @@ public class AtApiPlatformImpl extends AtApiImpl {
     public long getAmountForTxInA(AtMachineState state) {
         long txId = AtApiHelper.getLong(state.getA1());
 
-        Transaction tx = Burst.getBlockchain().getTransaction(txId);
+        Transaction tx = Signum.getBlockchain().getTransaction(txId);
 
         if (tx == null || (tx.getHeight() >= state.getHeight())) {
             return -1;
@@ -151,7 +151,7 @@ public class AtApiPlatformImpl extends AtApiImpl {
             return 0L;
           }
         }
-        if ((tx.getMessage() == null || Burst.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_2, state.getHeight())) && state.minActivationAmount() <= tx.getAmountNQT()) {
+        if ((tx.getMessage() == null || Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_2, state.getHeight())) && state.minActivationAmount() <= tx.getAmountNQT()) {
             return tx.getAmountNQT() - state.minActivationAmount();
         }
 
@@ -192,7 +192,7 @@ public class AtApiPlatformImpl extends AtApiImpl {
     public long getTimestampForTxInA(AtMachineState state) {
         long txId = AtApiHelper.getLong(state.getA1());
         logger.debug("get timestamp for tx with id {} found", txId);
-        Transaction tx = Burst.getBlockchain().getTransaction(txId);
+        Transaction tx = Signum.getBlockchain().getTransaction(txId);
 
         if (tx == null || (tx.getHeight() >= state.getHeight())) {
             return -1;
@@ -209,7 +209,7 @@ public class AtApiPlatformImpl extends AtApiImpl {
     public long getRandomIdForTxInA(AtMachineState state) {
         long txId = AtApiHelper.getLong(state.getA1());
 
-        Transaction tx = Burst.getBlockchain().getTransaction(txId);
+        Transaction tx = Signum.getBlockchain().getTransaction(txId);
 
         if (tx == null || (tx.getHeight() >= state.getHeight())) {
             return -1;
@@ -229,11 +229,11 @@ public class AtApiPlatformImpl extends AtApiImpl {
 
         byte[] senderPublicKey = tx.getSenderPublicKey();
 
-        ByteBuffer bf = ByteBuffer.allocate((Burst.getFluxCapacitor().getValue(FluxValues.SODIUM)) ?
+        ByteBuffer bf = ByteBuffer.allocate((Signum.getFluxCapacitor().getValue(FluxValues.SODIUM)) ?
         		32 + 8 + senderPublicKey.length :
         		32 + Long.SIZE + senderPublicKey.length);
         bf.order(ByteOrder.LITTLE_ENDIAN);
-        bf.put(Burst.getBlockchain().getBlockAtHeight(blockHeight - 1).getGenerationSignature());
+        bf.put(Signum.getBlockchain().getBlockAtHeight(blockHeight - 1).getGenerationSignature());
         bf.putLong(tx.getId());
         bf.put(senderPublicKey);
 
@@ -247,7 +247,7 @@ public class AtApiPlatformImpl extends AtApiImpl {
     public long checkSignBWithA(AtMachineState state) {
         if (state.getVersion() > 2) {
           long txid = AtApiHelper.getLong(state.getA1());
-          Transaction tx = Burst.getBlockchain().getTransaction(txid);
+          Transaction tx = Signum.getBlockchain().getTransaction(txid);
           if (tx == null || tx.getHeight() >= state.getHeight() || tx.getMessage() == null) {
               return 0L;
           }
@@ -291,7 +291,7 @@ public class AtApiPlatformImpl extends AtApiImpl {
     public void messageFromTxInAToB(AtMachineState state) {
         long txid = AtApiHelper.getLong(state.getA1());
 
-        Transaction tx = Burst.getBlockchain().getTransaction(txid);
+        Transaction tx = Signum.getBlockchain().getTransaction(txid);
         if (tx != null && tx.getHeight() >= state.getHeight()) {
             tx = null;
         }
@@ -340,7 +340,7 @@ public class AtApiPlatformImpl extends AtApiImpl {
 
         clearB(state);
 
-        Transaction tx = Burst.getBlockchain().getTransaction(txId);
+        Transaction tx = Signum.getBlockchain().getTransaction(txId);
         if (tx != null && tx.getHeight() >= state.getHeight()) {
             tx = null;
         }
@@ -356,7 +356,7 @@ public class AtApiPlatformImpl extends AtApiImpl {
 
         clearB(state);
 
-        Transaction tx = Burst.getBlockchain().getTransaction(txId);
+        Transaction tx = Signum.getBlockchain().getTransaction(txId);
         if (tx != null && tx.getHeight() >= state.getHeight()) {
             tx = null;
         }
@@ -393,7 +393,7 @@ public class AtApiPlatformImpl extends AtApiImpl {
         if (atId != 0L) {
           creator = 0L;
           // asking for the creator of the given at_id
-          AT at = Burst.getStores().getAtStore().getAT(atId);
+          AT at = Signum.getStores().getAtStore().getAT(atId);
           if (at != null) {
             creator = AtApiHelper.getLong(at.getCreator());
           }
@@ -414,7 +414,7 @@ public class AtApiPlatformImpl extends AtApiImpl {
       if(atId == 0L){
         atId = AtApiHelper.getLong(state.getId());
       }
-      AT at = Burst.getStores().getAtStore().getAT(atId);
+      AT at = Signum.getStores().getAtStore().getAT(atId);
       if (at != null) {
         return at.getApCodeHashId();
       }
@@ -433,7 +433,7 @@ public class AtApiPlatformImpl extends AtApiImpl {
         atId = AtApiHelper.getLong(state.getId());
       }
       // asking for the creator of the given at_id
-      AT at = Burst.getStores().getAtStore().getAT(atId);
+      AT at = Signum.getStores().getAtStore().getAT(atId);
       if (at != null) {
         return at.minActivationAmount();
       }
@@ -445,7 +445,7 @@ public class AtApiPlatformImpl extends AtApiImpl {
         ByteBuffer b = ByteBuffer.allocate(state.getA1().length * 4);
         b.order(ByteOrder.LITTLE_ENDIAN);
 
-        b.put(Burst.getBlockchain().getBlockAtHeight(state.getHeight() - 1).getGenerationSignature());
+        b.put(Signum.getBlockchain().getBlockAtHeight(state.getHeight() - 1).getGenerationSignature());
 
         b.clear();
 
@@ -466,7 +466,7 @@ public class AtApiPlatformImpl extends AtApiImpl {
 
     @Override
     public long getCurrentBalance(AtMachineState state) {
-        if (!Burst.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_2, state.getHeight())) {
+        if (!Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_2, state.getHeight())) {
             return 0;
         }
 
@@ -480,7 +480,7 @@ public class AtApiPlatformImpl extends AtApiImpl {
 
     @Override
     public long getAccountBalance(AtMachineState state) {
-        if (!Burst.getFluxCapacitor().getValue(FluxValues.PK_FREEZE2, state.getHeight())) {
+        if (!Signum.getFluxCapacitor().getValue(FluxValues.PK_FREEZE2, state.getHeight())) {
             return 0;
         }
 
@@ -498,7 +498,7 @@ public class AtApiPlatformImpl extends AtApiImpl {
 
     @Override
     public long getPreviousBalance(AtMachineState state) {
-        if (!Burst.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_2, state.getHeight())) {
+        if (!Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_2, state.getHeight())) {
             return 0;
         }
 
@@ -559,14 +559,14 @@ public class AtApiPlatformImpl extends AtApiImpl {
       long accountId = AtApiHelper.getLong(state.getId());
       long quantity = AtApiHelper.getLong(state.getB1());
 
-      Asset asset = Burst.getStores().getAssetStore().getAsset(assetId);
+      Asset asset = Signum.getStores().getAssetStore().getAsset(assetId);
       if (asset == null || asset.getAccountId() != accountId || quantity <= 0L) {
         // only assets that we have created internally and no burning by mint
         return;
       }
 
-      boolean unconfirmed = !Burst.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, state.getHeight());
-      long circulatingSupply = Burst.getAssetExchange().getAssetCirculatingSupply(asset, false, unconfirmed);
+      boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, state.getHeight());
+      long circulatingSupply = Signum.getAssetExchange().getAssetCirculatingSupply(asset, false, unconfirmed);
       long newSupply = circulatingSupply + quantity;
       if (newSupply > Constants.MAX_ASSET_QUANTITY_QNT) {
         // do not mint extra to keep the limit
@@ -593,15 +593,15 @@ public class AtApiPlatformImpl extends AtApiImpl {
       long assetToDistribute = AtApiHelper.getLong(state.getA3());
       long quantityToDistribute = 0L;
 
-      Asset asset = Burst.getStores().getAssetStore().getAsset(assetId);
+      Asset asset = Signum.getStores().getAssetStore().getAsset(assetId);
       if (asset == null) {
         // asset not found, do nothing
         return;
       }
 
-      int maxIndirects = Burst.getPropertyService().getInt(Props.MAX_INDIRECTS_PER_BLOCK);
-      boolean unconfirmed = !Burst.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, state.getHeight());
-      int holdersCount = Burst.getAssetExchange().getAssetAccountsCount(asset, minHolding, true, unconfirmed);
+      int maxIndirects = Signum.getPropertyService().getInt(Props.MAX_INDIRECTS_PER_BLOCK);
+      boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, state.getHeight());
+      int holdersCount = Signum.getAssetExchange().getAssetAccountsCount(asset, minHolding, true, unconfirmed);
       if(holdersCount == 0 || state.getIndirectsCount() + holdersCount > maxIndirects){
         // no holders to distribute or over the maximum, so do not distribute
         return;
@@ -639,14 +639,14 @@ public class AtApiPlatformImpl extends AtApiImpl {
       long minHolding = AtApiHelper.getLong(state.getB1());
       long assetId = AtApiHelper.getLong(state.getB2());
 
-      Asset asset = Burst.getStores().getAssetStore().getAsset(assetId);
+      Asset asset = Signum.getStores().getAssetStore().getAsset(assetId);
       if (asset == null) {
         // asset not found, no holders
         return 0L;
       }
 
-      boolean unconfirmed = !Burst.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, state.getHeight());
-      return Burst.getAssetExchange().getAssetAccountsCount(asset, minHolding, true, unconfirmed);
+      boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, state.getHeight());
+      return Signum.getAssetExchange().getAssetAccountsCount(asset, minHolding, true, unconfirmed);
     }
 
     @Override
@@ -657,14 +657,14 @@ public class AtApiPlatformImpl extends AtApiImpl {
 
       long assetId = AtApiHelper.getLong(state.getB2());
 
-      Asset asset = Burst.getStores().getAssetStore().getAsset(assetId);
+      Asset asset = Signum.getStores().getAssetStore().getAsset(assetId);
       if (asset == null) {
         // asset not found, no supply
         return 0L;
       }
 
-      boolean unconfirmed = !Burst.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, state.getHeight());
-      return Burst.getAssetExchange().getAssetCirculatingSupply(asset, true, unconfirmed);
+      boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, state.getHeight());
+      return Signum.getAssetExchange().getAssetCirculatingSupply(asset, true, unconfirmed);
     }
 
     @Override

--- a/src/brs/at/AtConstants.java
+++ b/src/brs/at/AtConstants.java
@@ -1,6 +1,6 @@
 package brs.at;
 
-import brs.Burst;
+import brs.Signum;
 import brs.Constants;
 import brs.fluxcapacitor.FluxValues;
 
@@ -99,7 +99,7 @@ public class AtConstants {
     }
 
     public short atVersion(int blockHeight) {
-        return Burst.getFluxCapacitor().getValue(FluxValues.AT_VERSION, blockHeight);
+        return Signum.getFluxCapacitor().getValue(FluxValues.AT_VERSION, blockHeight);
     }
 
     public long stepFee(short version) {
@@ -107,7 +107,7 @@ public class AtConstants {
     }
 
     public long maxSteps(int height) {
-        if(Burst.getFluxCapacitor().getValue(FluxValues.SIGNUM, height)) {
+        if(Signum.getFluxCapacitor().getValue(FluxValues.SIGNUM, height)) {
             return 1_000_000L;
         }
         return MAX_STEPS.get(atVersion(height));

--- a/src/brs/at/AtController.java
+++ b/src/brs/at/AtController.java
@@ -1,7 +1,7 @@
 package brs.at;
 
 import brs.Account;
-import brs.Burst;
+import brs.Signum;
 import brs.crypto.Crypto;
 import brs.fluxcapacitor.FluxValues;
 import brs.props.Props;
@@ -22,7 +22,7 @@ public abstract class AtController {
 
     private static final Logger logger = LoggerFactory.getLogger(AtController.class);
 
-    private static final Logger debugLogger = Burst.getPropertyService().getBoolean(Props.ENABLE_AT_DEBUG_LOG) ? logger : NOPLogger.NOP_LOGGER;
+    private static final Logger debugLogger = Signum.getPropertyService().getBoolean(Props.ENABLE_AT_DEBUG_LOG) ? logger : NOPLogger.NOP_LOGGER;
 
     private static int runSteps(AtMachineState state) {
         state.getMachineState().running = true;
@@ -31,7 +31,7 @@ public abstract class AtController {
         state.getMachineState().dead = false;
         state.getMachineState().steps = 0;
 
-        AtMachineProcessor processor = new AtMachineProcessor(state, Burst.getPropertyService().getBoolean(Props.ENABLE_AT_DEBUG_LOG));
+        AtMachineProcessor processor = new AtMachineProcessor(state, Signum.getPropertyService().getBoolean(Props.ENABLE_AT_DEBUG_LOG));
 
         state.setFreeze(false);
 
@@ -93,7 +93,7 @@ public abstract class AtController {
     //       intended to be used in production
     private static void listCode(AtMachineState state, boolean disassembly, boolean determineJumps) {
 
-        AtMachineProcessor machineProcessor = new AtMachineProcessor(state, Burst.getPropertyService().getBoolean(Props.ENABLE_AT_DEBUG_LOG));
+        AtMachineProcessor machineProcessor = new AtMachineProcessor(state, Signum.getPropertyService().getBoolean(Props.ENABLE_AT_DEBUG_LOG));
 
         int opc = state.getMachineState().pc;
         int osteps = state.getMachineState().steps;
@@ -256,7 +256,7 @@ public abstract class AtController {
                     at.setpBalance(at.getgBalance());
 
                     long amount = makeTransactions(at, blockHeight, generatorId);
-                    if (!Burst.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_4, blockHeight)) {
+                    if (!Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_4, blockHeight)) {
                         totalAmount = amount;
                     } else {
                         totalAmount += amount;
@@ -334,7 +334,7 @@ public abstract class AtController {
                 }
                 at.setpBalance(at.getgBalance());
 
-                if (!Burst.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_4, blockHeight)) {
+                if (!Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_4, blockHeight)) {
                     totalAmount = makeTransactions(at, blockHeight, generatorId);
                 } else {
                     totalAmount += makeTransactions(at, blockHeight, generatorId);
@@ -423,7 +423,7 @@ public abstract class AtController {
     //platform based
     private static long makeTransactions(AT at, int blockHeight, long generatorId) throws AtException {
         long totalAmount = 0;
-        if (!Burst.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_4, at.getHeight())) {
+        if (!Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_4, at.getHeight())) {
             for (AtTransaction tx : at.getTransactions()) {
                 if (AT.findPendingTransaction(tx.getRecipientId(), blockHeight, generatorId)) {
                     throw new AtException("Conflicting transaction found");

--- a/src/brs/at/AtMachineProcessor.java
+++ b/src/brs/at/AtMachineProcessor.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.helpers.NOPLogger;
 
 import brs.Asset;
-import brs.Burst;
+import brs.Signum;
 import brs.TransactionType;
 import brs.fluxcapacitor.FluxValues;
 import brs.props.Props;
@@ -59,13 +59,13 @@ class AtMachineProcessor {
 
                 long minHolding = AtApiHelper.getLong(machineData.getB1());
                 long assetId = AtApiHelper.getLong(machineData.getB2());
-                Asset asset = Burst.getAssetExchange().getAsset(assetId);
-                int maxIndirects = Burst.getPropertyService().getInt(Props.MAX_INDIRECTS_PER_BLOCK);
+                Asset asset = Signum.getAssetExchange().getAsset(assetId);
+                int maxIndirects = Signum.getPropertyService().getInt(Props.MAX_INDIRECTS_PER_BLOCK);
                 int holdersCount = 0;
 
                 if(asset != null) {
-                  boolean unconfirmed = !Burst.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, height);
-                  holdersCount = Burst.getAssetExchange().getAssetAccountsCount(asset, minHolding, true, unconfirmed);
+                  boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, height);
+                  holdersCount = Signum.getAssetExchange().getAssetAccountsCount(asset, minHolding, true, unconfirmed);
                   if(indirectsCount + holdersCount <= maxIndirects){
                     // distribution actually takes place only if we are not over the limit
                     steps += holdersCount;
@@ -441,7 +441,7 @@ class AtMachineProcessor {
                 }
             }
         } else if (op == OpCode.E_OP_CODE_SET_IDX) {
-          if (Burst.getFluxCapacitor().getValue(FluxValues.SIGNUM, machineData.getCreationBlockHeight())) {
+          if (Signum.getFluxCapacitor().getValue(FluxValues.SIGNUM, machineData.getCreationBlockHeight())) {
             rc = get3Addrs();
             if (rc == 0 || disassemble) {
                 rc = 13;
@@ -453,7 +453,7 @@ class AtMachineProcessor {
                 } else {
                       int addr = (int) ( machineData.getApData().getLong(fun.addr2 * 8)
                                          + machineData.getApData().getLong(fun.addr3 * 8) );
-                      if (Burst.getFluxCapacitor().getValue(FluxValues.SMART_ATS, machineData.getCreationBlockHeight()) && !validAddr(addr, false)) {
+                      if (Signum.getFluxCapacitor().getValue(FluxValues.SMART_ATS, machineData.getCreationBlockHeight()) && !validAddr(addr, false)) {
                         rc = -1;
                       }
                       else {
@@ -595,7 +595,7 @@ class AtMachineProcessor {
                 }
             }
         } else if (op == OpCode.E_OP_CODE_IDX_DAT) {
-          if (Burst.getFluxCapacitor().getValue(FluxValues.SIGNUM, machineData.getCreationBlockHeight())) {
+          if (Signum.getFluxCapacitor().getValue(FluxValues.SIGNUM, machineData.getCreationBlockHeight())) {
             rc = get3Addrs();
             if (rc == 0 || disassemble) {
                 rc=13;
@@ -607,7 +607,7 @@ class AtMachineProcessor {
                 } else {
                       int addr = (int) (machineData.getApData().getLong(fun.addr1 * 8)
                                         + machineData.getApData().getLong(fun.addr2 * 8));
-                      if (Burst.getFluxCapacitor().getValue(FluxValues.SMART_ATS, machineData.getCreationBlockHeight()) && !validAddr(addr, false)) {
+                      if (Signum.getFluxCapacitor().getValue(FluxValues.SMART_ATS, machineData.getCreationBlockHeight()) && !validAddr(addr, false)) {
                         rc = -1;
                       }
                       else {
@@ -923,7 +923,7 @@ class AtMachineProcessor {
             } else {
                 machineData.getMachineState().pc += rc;
                 machineData.getMachineState().stopped = true;
-                if (Burst.getFluxCapacitor().getValue(FluxValues.SMART_ATS, machineData.getCreationBlockHeight())) {
+                if (Signum.getFluxCapacitor().getValue(FluxValues.SMART_ATS, machineData.getCreationBlockHeight())) {
                   machineData.setWaitForNumberOfBlocks(0);
                 }
                 else {

--- a/src/brs/at/AtMachineState.java
+++ b/src/brs/at/AtMachineState.java
@@ -7,7 +7,7 @@
 
 package brs.at;
 
-import brs.Burst;
+import brs.Signum;
 import brs.Constants;
 import brs.Account.AccountAsset;
 import brs.crypto.Crypto;
@@ -300,7 +300,7 @@ public class AtMachineState {
         }
       }
 
-      return Burst.getStores().getAtStore().getMapValue(atId, key1, key2);
+      return Signum.getStores().getAtStore().getMapValue(atId, key1, key2);
     }
 
     protected void clearLists() {
@@ -395,7 +395,7 @@ public class AtMachineState {
       Long balance = gBalanceAsset.get(assetId);
       if(balance == null) {
         balance = 0L;
-        AccountAsset asset = Burst.getStores().getAccountStore().getAccountAsset(AtApiHelper.getLong(getId()), assetId);
+        AccountAsset asset = Signum.getStores().getAccountStore().getAccountAsset(AtApiHelper.getLong(getId()), assetId);
         if(asset != null) {
           balance = asset.getQuantityQNT();
         }
@@ -481,7 +481,7 @@ public class AtMachineState {
 
     private byte[] getTransactionBytes() {
         int txLength = creator.length + 8;
-        if(Burst.getFluxCapacitor().getValue(FluxValues.SMART_ATS, height)) {
+        if(Signum.getFluxCapacitor().getValue(FluxValues.SMART_ATS, height)) {
           txLength += 8;
         }
         ByteBuffer b = ByteBuffer.allocate(txLength * transactions.size());
@@ -492,7 +492,7 @@ public class AtMachineState {
             else
               b.put(tx.getRecipientId());
             b.putLong(tx.getAmount());
-            if(Burst.getFluxCapacitor().getValue(FluxValues.SMART_ATS, height)) {
+            if(Signum.getFluxCapacitor().getValue(FluxValues.SMART_ATS, height)) {
               b.putLong(tx.getAssetId());
             }
         }
@@ -628,7 +628,7 @@ public class AtMachineState {
             ByteBuffer bytes = ByteBuffer.allocate(getSize());
             bytes.order(ByteOrder.LITTLE_ENDIAN);
 
-            if (Burst.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_2)) {
+            if (Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_2)) {
                 flags[0] = (byte) ((running ? 1 : 0)
                         | (stopped ? 1 : 0) << 1
                         | (finished ? 1 : 0) << 2

--- a/src/brs/at/AtTransaction.java
+++ b/src/brs/at/AtTransaction.java
@@ -18,7 +18,7 @@ import brs.Appendix;
 import brs.Asset;
 import brs.Attachment;
 import brs.Block;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException.NotValidException;
 import brs.Constants;
 import brs.Genesis;
@@ -126,7 +126,7 @@ public class AtTransaction {
 
       byte[] message = getMessage();
       if (message != null) {
-          builder.message(new Appendix.Message(message, Burst.getBlockchain().getHeight()));
+          builder.message(new Appendix.Message(message, Signum.getBlockchain().getHeight()));
       }
 
       return builder.build();
@@ -142,18 +142,18 @@ public class AtTransaction {
         accountService.addToAssetAndUnconfirmedAssetBalanceQNT(recipientAccount, getAssetId(), quantity);
 
         ColoredCoinsAssetTransfer assetTransferAttachment = (ColoredCoinsAssetTransfer) attachment;
-        Burst.getAssetExchange().addAssetTransfer(transaction, assetTransferAttachment.getAssetId(), assetTransferAttachment.getQuantityQNT());
+        Signum.getAssetExchange().addAssetTransfer(transaction, assetTransferAttachment.getAssetId(), assetTransferAttachment.getQuantityQNT());
 
         // we also have coins to send besides the asset
-        if(getAmount() > 0L && Burst.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_5, transaction.getHeight())) {
+        if(getAmount() > 0L && Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_5, transaction.getHeight())) {
           accountService.addToBalanceAndUnconfirmedBalanceNQT(senderAccount, -getAmount());
           accountService.addToBalanceAndUnconfirmedBalanceNQT(recipientAccount, getAmount());
         }
       }
       else if (getType() == TransactionType.ColoredCoins.ASSET_ISSUANCE) {
-        Asset asset = Burst.getAssetExchange().getAsset(assetId);
+        Asset asset = Signum.getAssetExchange().getAsset(assetId);
         if(asset == null && assetId != 0L) {
-          Burst.getAssetExchange().addAsset(assetId, senderAccount.getId(), (ColoredCoinsAssetIssuance) attachment);
+          Signum.getAssetExchange().addAsset(assetId, senderAccount.getId(), (ColoredCoinsAssetIssuance) attachment);
         }
       }
       else if (getType() == TransactionType.ColoredCoins.ASSET_MINT) {
@@ -184,7 +184,7 @@ public class AtTransaction {
               accountService.addToAssetAndUnconfirmedAssetBalanceQNT(indirecRecipient, assetIdToDistribute, incoming.getQuantity());
             }
           }
-          Burst.getStores().getIndirectIncomingStore().addIndirectIncomings(indirects);
+          Signum.getStores().getIndirectIncomingStore().addIndirectIncomings(indirects);
         }
       }
       else {

--- a/src/brs/at/AtTransaction.java
+++ b/src/brs/at/AtTransaction.java
@@ -19,7 +19,7 @@ import brs.Asset;
 import brs.Attachment;
 import brs.Block;
 import brs.Signum;
-import brs.BurstException.NotValidException;
+import brs.SignumException.NotValidException;
 import brs.Constants;
 import brs.Genesis;
 import brs.IndirectIncoming;

--- a/src/brs/crypto/Crypto.java
+++ b/src/brs/crypto/Crypto.java
@@ -9,21 +9,21 @@ import signumj.crypto.SignumCrypto;
 import signumj.entity.SignumID;
 
 public final class Crypto {
-  static final SignumCrypto burstCrypto = SignumCrypto.getInstance();
+  static final SignumCrypto signumCrypto = SignumCrypto.getInstance();
 
   private Crypto() {
   } //never
 
   public static MessageDigest sha256() {
-    return burstCrypto.getSha256();
+    return signumCrypto.getSha256();
   }
 
   public static MessageDigest shabal256() {
-    return burstCrypto.getShabal256();
+    return signumCrypto.getShabal256();
   }
 
   public static MessageDigest ripemd160() {
-    return burstCrypto.getRipeMD160();
+    return signumCrypto.getRipeMD160();
   }
 
   public static MessageDigest md5() {// TODO unit test
@@ -35,46 +35,46 @@ public final class Crypto {
   }
 
   public static byte[] getPublicKey(String secretPhrase) {
-    return burstCrypto.getPublicKey(secretPhrase);
+    return signumCrypto.getPublicKey(secretPhrase);
   }
 
   public static byte[] getPrivateKey(String secretPhrase) {
-    return burstCrypto.getPrivateKey(secretPhrase);
+    return signumCrypto.getPrivateKey(secretPhrase);
   }
 
   public static byte[] sign(byte[] message, String secretPhrase) {
-      return burstCrypto.sign(message, secretPhrase);
+      return signumCrypto.sign(message, secretPhrase);
   }
 
   public static boolean verify(byte[] signature, byte[] message, byte[] publicKey, boolean enforceCanonical) {
-      return burstCrypto.verify(signature, message, publicKey, enforceCanonical);
+      return signumCrypto.verify(signature, message, publicKey, enforceCanonical);
   }
 
   public static byte[] aesEncrypt(byte[] plaintext, byte[] myPrivateKey, byte[] theirPublicKey) {
-    return burstCrypto.aesSharedEncrypt(plaintext, myPrivateKey, theirPublicKey);
+    return signumCrypto.aesSharedEncrypt(plaintext, myPrivateKey, theirPublicKey);
   }
 
   public static byte[] aesEncrypt(byte[] plaintext, byte[] myPrivateKey, byte[] theirPublicKey, byte[] nonce) {
-    return burstCrypto.aesSharedEncrypt(plaintext, myPrivateKey, theirPublicKey, nonce);
+    return signumCrypto.aesSharedEncrypt(plaintext, myPrivateKey, theirPublicKey, nonce);
   }
 
   public static byte[] aesDecrypt(byte[] ivCiphertext, byte[] myPrivateKey, byte[] theirPublicKey) {
-    return burstCrypto.aesSharedDecrypt(ivCiphertext, myPrivateKey, theirPublicKey);
+    return signumCrypto.aesSharedDecrypt(ivCiphertext, myPrivateKey, theirPublicKey);
   }
 
   public static byte[] aesDecrypt(byte[] ivCiphertext, byte[] myPrivateKey, byte[] theirPublicKey, byte[] nonce) {
-    return burstCrypto.aesSharedDecrypt(ivCiphertext, myPrivateKey, theirPublicKey, nonce);
+    return signumCrypto.aesSharedDecrypt(ivCiphertext, myPrivateKey, theirPublicKey, nonce);
   }
 
   public static byte[] getSharedSecret(byte[] myPrivateKey, byte[] theirPublicKey) {
-    return burstCrypto.getSharedSecret(myPrivateKey, theirPublicKey);
+    return signumCrypto.getSharedSecret(myPrivateKey, theirPublicKey);
   }
 
   public static String rsEncode(long id) {
-    return burstCrypto.rsEncode(SignumID.fromLong(id));
+    return signumCrypto.rsEncode(SignumID.fromLong(id));
   }
 
   public static long rsDecode(String rsString) {
-    return burstCrypto.rsDecode(rsString).getSignedLongId();
+    return signumCrypto.rsDecode(rsString).getSignedLongId();
   }
 }

--- a/src/brs/crypto/EncryptedData.java
+++ b/src/brs/crypto/EncryptedData.java
@@ -1,6 +1,6 @@
 package brs.crypto;
 
-import brs.BurstException;
+import brs.SignumException;
 import signumj.entity.EncryptedMessage;
 
 import java.nio.ByteBuffer;
@@ -18,12 +18,12 @@ public class EncryptedData {
   }
 
   public static EncryptedData readEncryptedData(ByteBuffer buffer, int length, int maxLength)
-    throws BurstException.NotValidException {
+    throws SignumException.NotValidException {
     if (length == 0) {
       return EMPTY_DATA;
     }
     if (length > maxLength) {
-      throw new BurstException.NotValidException("Max encrypted data length exceeded: " + length);
+      throw new SignumException.NotValidException("Max encrypted data length exceeded: " + length);
     }
     byte[] noteBytes = new byte[length];
     buffer.get(noteBytes);

--- a/src/brs/crypto/EncryptedData.java
+++ b/src/brs/crypto/EncryptedData.java
@@ -13,7 +13,7 @@ public class EncryptedData {
     if (plaintext.length == 0) {
       return EMPTY_DATA;
     }
-    EncryptedMessage message = Crypto.burstCrypto.encryptBytesMessage(plaintext, myPrivateKey, theirPublicKey);
+    EncryptedMessage message = Crypto.signumCrypto.encryptBytesMessage(plaintext, myPrivateKey, theirPublicKey);
     return new EncryptedData(message.getData(), message.getNonce());
   }
 
@@ -44,7 +44,7 @@ public class EncryptedData {
     if (data.length == 0) {
       return data;
     }
-    return Crypto.burstCrypto.decryptMessage(new EncryptedMessage(data, nonce, false), myPrivateKey, theirPublicKey);
+    return Crypto.signumCrypto.decryptMessage(new EncryptedMessage(data, nonce, false), myPrivateKey, theirPublicKey);
   }
 
   public byte[] getData() {

--- a/src/brs/db/BlockDb.java
+++ b/src/brs/db/BlockDb.java
@@ -1,7 +1,7 @@
 package brs.db;
 
 import brs.Block;
-import brs.BurstException;
+import brs.SignumException;
 import brs.schema.tables.records.BlockRecord;
 import org.jooq.DSLContext;
 
@@ -18,7 +18,7 @@ public interface BlockDb extends Table {
 
   Block findLastBlock(int timestamp);
 
-  Block loadBlock(BlockRecord r) throws BurstException.ValidationException;
+  Block loadBlock(BlockRecord r) throws SignumException.ValidationException;
 
   void saveBlock(DSLContext ctx, Block block);
 

--- a/src/brs/db/EntityTable.java
+++ b/src/brs/db/EntityTable.java
@@ -9,9 +9,9 @@ import java.util.List;
 public interface EntityTable<T> extends DerivedTable {
   void checkAvailable(int height);
 
-  T get(BurstKey dbKey);
+  T get(SignumKey dbKey);
 
-  T get(BurstKey dbKey, int height);
+  T get(SignumKey dbKey, int height);
 
   T getBy(Condition condition);
 

--- a/src/brs/db/SignumKey.java
+++ b/src/brs/db/SignumKey.java
@@ -2,29 +2,29 @@ package brs.db;
 
 import org.jooq.Record;
 
-public interface BurstKey {
+public interface SignumKey {
 
   interface Factory<T> {
-    BurstKey newKey(T t);
+    SignumKey newKey(T t);
 
-    BurstKey newKey(Record rs);
+    SignumKey newKey(Record rs);
   }
 
   long[] getPKValues();
 
   interface LongKeyFactory<T> extends Factory<T> {
     @Override
-    BurstKey newKey(Record rs);
+    SignumKey newKey(Record rs);
 
-    BurstKey newKey(long id);
+    SignumKey newKey(long id);
 
   }
 
   interface LinkKeyFactory<T> extends Factory<T> {
-    BurstKey newKey(long idA, long idB);
+    SignumKey newKey(long idA, long idB);
   }
   
   interface LinkKey3Factory<T> extends Factory<T> {
-    BurstKey newKey(long idA, long idB, long idC);
+    SignumKey newKey(long idA, long idB, long idC);
   }
 }

--- a/src/brs/db/TransactionDb.java
+++ b/src/brs/db/TransactionDb.java
@@ -1,6 +1,6 @@
 package brs.db;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.Transaction;
 import brs.schema.tables.records.TransactionRecord;
 
@@ -15,7 +15,7 @@ public interface TransactionDb extends Table {
 
   boolean hasTransactionByFullHash(String fullHash); // TODO add byte[] method
 
-  Transaction loadTransaction(TransactionRecord transactionRecord) throws BurstException.ValidationException;
+  Transaction loadTransaction(TransactionRecord transactionRecord) throws SignumException.ValidationException;
 
   List<Transaction> findBlockTransactions(long blockId, boolean onlySigned);
 

--- a/src/brs/db/ValuesTable.java
+++ b/src/brs/db/ValuesTable.java
@@ -3,7 +3,7 @@ package brs.db;
 import java.util.List;
 
 public interface ValuesTable<T, V> extends DerivedTable {
-  List<V> get(BurstKey dbKey);
+  List<V> get(SignumKey dbKey);
 
   void insert(T t, List<V> values);
 

--- a/src/brs/db/VersionedBatchEntityTable.java
+++ b/src/brs/db/VersionedBatchEntityTable.java
@@ -12,7 +12,7 @@ public interface VersionedBatchEntityTable<T> extends DerivedTable, EntityTable<
   boolean delete(T t);
 
   @Override
-  T get(BurstKey dbKey);
+  T get(SignumKey dbKey);
 
   @Override
   void insert(T t);
@@ -21,7 +21,7 @@ public interface VersionedBatchEntityTable<T> extends DerivedTable, EntityTable<
   void finish();
 
   @Override
-  T get(BurstKey dbKey, int height);
+  T get(SignumKey dbKey, int height);
 
   @Override
   T getBy(Condition condition);
@@ -65,7 +65,7 @@ public interface VersionedBatchEntityTable<T> extends DerivedTable, EntityTable<
   @Override
   void truncate();
 
-  Map<BurstKey, T> getBatch();
+  Map<SignumKey, T> getBatch();
 
   Cache getCache();
 

--- a/src/brs/db/cache/DBCacheManagerImpl.java
+++ b/src/brs/db/cache/DBCacheManagerImpl.java
@@ -1,7 +1,7 @@
 package brs.db.cache;
 
 import brs.Account;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.statistics.StatisticsManagerImpl;
 import org.ehcache.Cache;
 import org.ehcache.CacheManager;
@@ -22,19 +22,19 @@ public class DBCacheManagerImpl {
 
   private final boolean statisticsEnabled;
 
-  private final HashMap<String, CacheConfiguration<BurstKey, ?>> caches = new HashMap<>();
+  private final HashMap<String, CacheConfiguration<SignumKey, ?>> caches = new HashMap<>();
 
   public DBCacheManagerImpl(StatisticsManagerImpl statisticsManager) {
     this.statisticsManager = statisticsManager;
     statisticsEnabled = true;
 
-    caches.put("account", CacheConfigurationBuilder.newCacheConfigurationBuilder(BurstKey.class, Account.class,
+    caches.put("account", CacheConfigurationBuilder.newCacheConfigurationBuilder(SignumKey.class, Account.class,
         ResourcePoolsBuilder.heap(8192*4)).build());
-    caches.put("account_balance", CacheConfigurationBuilder.newCacheConfigurationBuilder(BurstKey.class, Account.Balance.class,
+    caches.put("account_balance", CacheConfigurationBuilder.newCacheConfigurationBuilder(SignumKey.class, Account.Balance.class,
         ResourcePoolsBuilder.heap(8192*4)).build());
 
     CacheManagerBuilder<CacheManager> cacheBuilder = CacheManagerBuilder.newCacheManagerBuilder();
-    for (Map.Entry<String, CacheConfiguration<BurstKey, ?>> cache : caches.entrySet()) {
+    for (Map.Entry<String, CacheConfiguration<SignumKey, ?>> cache : caches.entrySet()) {
       cacheBuilder = cacheBuilder.withCache(cache.getKey(), cache.getValue());
     }
     cacheManager = cacheBuilder.build(true);
@@ -46,17 +46,17 @@ public class DBCacheManagerImpl {
     }
   }
 
-  private <V> Cache<BurstKey, V> getEHCache(String name, Class<V> valueClass) {
-    return cacheManager.getCache(name, BurstKey.class, valueClass);
+  private <V> Cache<SignumKey, V> getEHCache(String name, Class<V> valueClass) {
+    return cacheManager.getCache(name, SignumKey.class, valueClass);
   }
 
-  public <V> Cache<BurstKey, V> getCache(String name, Class<V> valueClass) {
-    Cache<BurstKey, V> cache = getEHCache(name, valueClass);
+  public <V> Cache<SignumKey, V> getCache(String name, Class<V> valueClass) {
+    Cache<SignumKey, V> cache = getEHCache(name, valueClass);
     return statisticsEnabled ? new StatisticsCache<>(cache, name, statisticsManager) : cache;
   }
 
   public void flushCache() {
-    for (Map.Entry<String, CacheConfiguration<BurstKey, ?>> cacheEntry : caches.entrySet()) {
+    for (Map.Entry<String, CacheConfiguration<SignumKey, ?>> cacheEntry : caches.entrySet()) {
       Cache<?,?> cache = getEHCache(cacheEntry.getKey(), cacheEntry.getValue().getValueType());
       if ( cache != null )
         cache.clear();

--- a/src/brs/db/sql/Db.java
+++ b/src/brs/db/sql/Db.java
@@ -1,7 +1,7 @@
 package brs.db.sql;
 
 import brs.Signum;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.cache.DBCacheManagerImpl;
 import brs.db.store.Dbs;
 import brs.props.PropertyService;
@@ -36,8 +36,8 @@ public final class Db {
   private static HikariDataSource cp;
   private static SQLDialect dialect;
   private static final ThreadLocal<Connection> localConnection = new ThreadLocal<>();
-  private static final ThreadLocal<Map<String, Map<BurstKey, Object>>> transactionCaches = new ThreadLocal<>();
-  private static final ThreadLocal<Map<String, Map<BurstKey, Object>>> transactionBatches = new ThreadLocal<>();
+  private static final ThreadLocal<Map<String, Map<SignumKey, Object>>> transactionCaches = new ThreadLocal<>();
+  private static final ThreadLocal<Map<String, Map<SignumKey, Object>>> transactionBatches = new ThreadLocal<>();
 
   private static DBCacheManagerImpl dbCacheManager;
 
@@ -229,20 +229,20 @@ public final class Db {
     }
   }
 
-  static <V> Map<BurstKey, V> getCache(String tableName) {
+  static <V> Map<SignumKey, V> getCache(String tableName) {
     if (!isInTransaction()) {
       throw new IllegalStateException("Not in transaction");
     }
     //noinspection unchecked
-    return (Map<BurstKey, V>) transactionCaches.get().computeIfAbsent(tableName, k -> new HashMap<>());
+    return (Map<SignumKey, V>) transactionCaches.get().computeIfAbsent(tableName, k -> new HashMap<>());
   }
 
-  static <V> Map<BurstKey, V> getBatch(String tableName) {
+  static <V> Map<SignumKey, V> getBatch(String tableName) {
     if (!isInTransaction()) {
       throw new IllegalStateException("Not in transaction");
     }
     //noinspection unchecked
-    return (Map<BurstKey, V>) transactionBatches.get().computeIfAbsent(tableName, k -> new HashMap<>());
+    return (Map<SignumKey, V>) transactionBatches.get().computeIfAbsent(tableName, k -> new HashMap<>());
   }
 
   public static boolean isInTransaction() {

--- a/src/brs/db/sql/Db.java
+++ b/src/brs/db/sql/Db.java
@@ -1,6 +1,6 @@
 package brs.db.sql;
 
-import brs.Burst;
+import brs.Signum;
 import brs.db.BurstKey;
 import brs.db.cache.DBCacheManagerImpl;
 import brs.db.store.Dbs;
@@ -159,7 +159,7 @@ public final class Db {
         Connection con = cp.getConnection();
         Statement stmt = con.createStatement();
         // COMPACT is not giving good result.
-        if (Burst.getPropertyService().getBoolean(Props.DB_H2_DEFRAG_ON_SHUTDOWN)) {
+        if (Signum.getPropertyService().getBoolean(Props.DB_H2_DEFRAG_ON_SHUTDOWN)) {
           logger.info("H2 defragmentation started, this can take a while");
           stmt.execute("SHUTDOWN DEFRAG");
         } else {

--- a/src/brs/db/sql/DbKey.java
+++ b/src/brs/db/sql/DbKey.java
@@ -1,6 +1,6 @@
 package brs.db.sql;
 
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.util.StringUtils;
 import org.jooq.*;
 import org.jooq.Record;
@@ -8,9 +8,9 @@ import org.jooq.Record;
 import java.util.ArrayList;
 import java.util.Collection;
 
-public interface DbKey extends BurstKey {
+public interface DbKey extends SignumKey {
 
-  abstract class Factory<T> implements BurstKey.Factory<T> {
+  abstract class Factory<T> implements SignumKey.Factory<T> {
 
     private final String pkClause;
     private final String[] pkColumns;
@@ -49,7 +49,7 @@ public interface DbKey extends BurstKey {
 
   long[] getPKValues();
 
-  abstract class LongKeyFactory<T> extends Factory<T> implements BurstKey.LongKeyFactory<T> {
+  abstract class LongKeyFactory<T> extends Factory<T> implements SignumKey.LongKeyFactory<T> {
 
     private final Field<Long> idColumn;
 
@@ -61,12 +61,12 @@ public interface DbKey extends BurstKey {
     }
 
     @Override
-    public BurstKey newKey(Record record) {
+    public SignumKey newKey(Record record) {
       Long result = record.get(idColumn);
       return new LongKey(result, idColumn.getName());
     }
 
-    public BurstKey newKey(long id) {
+    public SignumKey newKey(long id) {
       return new LongKey(id, idColumn.getName());
     }
 
@@ -80,7 +80,7 @@ public interface DbKey extends BurstKey {
     }
   }
 
-  abstract class LinkKeyFactory<T> extends Factory<T> implements BurstKey.LinkKeyFactory<T> {
+  abstract class LinkKeyFactory<T> extends Factory<T> implements SignumKey.LinkKeyFactory<T> {
 
     private final String idColumnA;
     private final String idColumnB;
@@ -117,7 +117,7 @@ public interface DbKey extends BurstKey {
     }
   }
 
-  abstract class LinkKey3Factory<T> extends Factory<T> implements BurstKey.LinkKey3Factory<T> {
+  abstract class LinkKey3Factory<T> extends Factory<T> implements SignumKey.LinkKey3Factory<T> {
 
     private final String idColumnA;
     private final String idColumnB;

--- a/src/brs/db/sql/EntitySqlTable.java
+++ b/src/brs/db/sql/EntitySqlTable.java
@@ -1,7 +1,7 @@
 package brs.db.sql;
 
 import brs.Signum;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.EntityTable;
 import brs.db.store.DerivedTableManager;
 import org.jooq.*;
@@ -22,11 +22,11 @@ public abstract class EntitySqlTable<T> extends DerivedSqlTable implements Entit
   final Field<Integer> heightField;
   final Field<Boolean> latestField;
 
-  EntitySqlTable(String table, TableImpl<?> tableClass, BurstKey.Factory<T> dbKeyFactory, DerivedTableManager derivedTableManager) {
+  EntitySqlTable(String table, TableImpl<?> tableClass, SignumKey.Factory<T> dbKeyFactory, DerivedTableManager derivedTableManager) {
     this(table, tableClass, dbKeyFactory, false, derivedTableManager);
   }
 
-  EntitySqlTable(String table, TableImpl<?> tableClass, BurstKey.Factory<T> dbKeyFactory, boolean multiversion, DerivedTableManager derivedTableManager) {
+  EntitySqlTable(String table, TableImpl<?> tableClass, SignumKey.Factory<T> dbKeyFactory, boolean multiversion, DerivedTableManager derivedTableManager) {
     super(table, tableClass, derivedTableManager);
     this.dbKeyFactory = (DbKey.Factory<T>) dbKeyFactory;
     this.multiversion = multiversion;
@@ -41,7 +41,7 @@ public abstract class EntitySqlTable<T> extends DerivedSqlTable implements Entit
     defaultSort.add(heightField.desc());
   }
 
-  private Map<BurstKey, T> getCache() {
+  private Map<SignumKey, T> getCache() {
     return Db.getCache(table);
   }
 
@@ -68,7 +68,7 @@ public abstract class EntitySqlTable<T> extends DerivedSqlTable implements Entit
   }
 
   @Override
-  public T get(BurstKey nxtKey) {
+  public T get(SignumKey nxtKey) {
     DbKey dbKey = (DbKey) nxtKey;
     if (Db.isInTransaction()) {
       T t = getCache().get(dbKey);
@@ -90,7 +90,7 @@ public abstract class EntitySqlTable<T> extends DerivedSqlTable implements Entit
   }
 
   @Override
-  public T get(BurstKey nxtKey, int height) {
+  public T get(SignumKey nxtKey, int height) {
     DbKey dbKey = (DbKey) nxtKey;
 
     return Db.useDSLContext(ctx -> {

--- a/src/brs/db/sql/EntitySqlTable.java
+++ b/src/brs/db/sql/EntitySqlTable.java
@@ -1,6 +1,6 @@
 package brs.db.sql;
 
-import brs.Burst;
+import brs.Signum;
 import brs.db.BurstKey;
 import brs.db.EntityTable;
 import brs.db.store.DerivedTableManager;
@@ -62,7 +62,7 @@ public abstract class EntitySqlTable<T> extends DerivedSqlTable implements Entit
 
   @Override
   public final void checkAvailable(int height) {
-    if (multiversion && height < Burst.getBlockchainProcessor().getMinRollbackHeight()) {
+    if (multiversion && height < Signum.getBlockchainProcessor().getMinRollbackHeight()) {
       throw new IllegalArgumentException("Historical data as of height " + height + " not available, set DB.trimDerivedTables=false and re-scan");
     }
   }

--- a/src/brs/db/sql/SqlATStore.java
+++ b/src/brs/db/sql/SqlATStore.java
@@ -1,7 +1,7 @@
 package brs.db.sql;
 
 import brs.Attachment;
-import brs.Burst;
+import brs.Signum;
 import brs.Transaction;
 import brs.at.AT;
 import brs.at.AT.AtMapEntry;
@@ -123,13 +123,13 @@ public class SqlATStore implements ATStore {
     ctx.insertInto( // .mergeInto(
       AT_STATE, AT_STATE.AT_ID, AT_STATE.STATE, AT_STATE.PREV_HEIGHT, AT_STATE.NEXT_HEIGHT, AT_STATE.SLEEP_BETWEEN, AT_STATE.PREV_BALANCE, AT_STATE.FREEZE_WHEN_SAME_BALANCE, AT_STATE.MIN_ACTIVATE_AMOUNT, AT_STATE.HEIGHT, AT_STATE.LATEST)
             //.key(AT_STATE.AT_ID, AT_STATE.HEIGHT)
-            .values(atState.getATId(), brs.at.AT.compressState(atState.getState()), atState.getPrevHeight(), atState.getNextHeight(), atState.getSleepBetween(), atState.getPrevBalance(), atState.getFreezeWhenSameBalance(), atState.getMinActivationAmount(), Burst.getBlockchain().getHeight(), true)
+            .values(atState.getATId(), brs.at.AT.compressState(atState.getState()), atState.getPrevHeight(), atState.getNextHeight(), atState.getSleepBetween(), atState.getPrevBalance(), atState.getFreezeWhenSameBalance(), atState.getMinActivationAmount(), Signum.getBlockchain().getHeight(), true)
             .execute();
   }
 
   private void saveATMapEntry(DSLContext ctx, brs.at.AT.AtMapEntry atEntry) {
     ctx.insertInto(AT_MAP, AT_MAP.AT_ID, AT_MAP.KEY1, AT_MAP.KEY2, AT_MAP.VALUE, AT_STATE.HEIGHT, AT_STATE.LATEST)
-            .values(atEntry.getAtId(), atEntry.getKey1(), atEntry.getKey2(), atEntry.getValue(), Burst.getBlockchain().getHeight(), true)
+            .values(atEntry.getAtId(), atEntry.getKey1(), atEntry.getKey2(), atEntry.getValue(), Signum.getBlockchain().getHeight(), true)
             .execute();
   }
 
@@ -144,7 +144,7 @@ public class SqlATStore implements ATStore {
       AtApiHelper.getLong(at.getId()), AtApiHelper.getLong(at.getCreator()), at.getName(), at.getDescription(),
       at.getVersion(), at.getcSize(), at.getdSize(), at.getcUserStackBytes(),
       at.getcCallStackBytes(), at.getCreationBlockHeight(),
-      brs.at.AT.compressState(at.getApCodeBytes()), Burst.getBlockchain().getHeight(), at.getApCodeHashId()
+      brs.at.AT.compressState(at.getApCodeBytes()), Signum.getBlockchain().getHeight(), at.getApCodeHashId()
     ).execute();
   }
 
@@ -168,11 +168,11 @@ public class SqlATStore implements ATStore {
       ).and(
               ACCOUNT_BALANCE.LATEST.isTrue()
       ).and(
-              AT_STATE.NEXT_HEIGHT.lessOrEqual(Burst.getBlockchain().getHeight() + 1)
+              AT_STATE.NEXT_HEIGHT.lessOrEqual(Signum.getBlockchain().getHeight() + 1)
       ).and(
         ACCOUNT_BALANCE.BALANCE.greaterOrEqual(
-                atConstants.stepFee(atConstants.atVersion(Burst.getBlockchain().getHeight()))
-                              * atConstants.apiStepMultiplier(atConstants.atVersion(Burst.getBlockchain().getHeight()))
+                atConstants.stepFee(atConstants.atVersion(Signum.getBlockchain().getHeight()))
+                              * atConstants.apiStepMultiplier(atConstants.atVersion(Signum.getBlockchain().getHeight()))
               )
       ).and(
               AT_STATE.FREEZE_WHEN_SAME_BALANCE.isFalse().or(
@@ -253,8 +253,8 @@ public class SqlATStore implements ATStore {
     int codeSize = at.getCsize();
     if(code == null) {
       // Check the creation transaction for the reference code
-      Transaction atCreationTransaction = Burst.getBlockchain().getTransaction(at.getId());
-      Transaction transaction = Burst.getBlockchain().getTransactionByFullHash(atCreationTransaction.getReferencedTransactionFullHash());
+      Transaction atCreationTransaction = Signum.getBlockchain().getTransaction(at.getId());
+      Transaction transaction = Signum.getBlockchain().getTransactionByFullHash(atCreationTransaction.getReferencedTransactionFullHash());
       if(transaction!=null && transaction.getAttachment() instanceof Attachment.AutomatedTransactionsCreation) {
         Attachment.AutomatedTransactionsCreation atCreationAttachment = (Attachment.AutomatedTransactionsCreation)transaction.getAttachment();
         AtMachineState atCreation = new AtMachineState(null, null, atCreationAttachment.getCreationBytes(), 0);

--- a/src/brs/db/sql/SqlATStore.java
+++ b/src/brs/db/sql/SqlATStore.java
@@ -8,7 +8,7 @@ import brs.at.AT.AtMapEntry;
 import brs.at.AtApiHelper;
 import brs.at.AtConstants;
 import brs.at.AtMachineState;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.VersionedEntityTable;
 import brs.db.store.ATStore;
 import brs.db.store.DerivedTableManager;
@@ -29,17 +29,17 @@ import static brs.schema.Tables.*;
 
 public class SqlATStore implements ATStore {
 
-  private final BurstKey.LongKeyFactory<brs.at.AT> atDbKeyFactory = new DbKey.LongKeyFactory<brs.at.AT>(AT.ID) {
+  private final SignumKey.LongKeyFactory<brs.at.AT> atDbKeyFactory = new DbKey.LongKeyFactory<brs.at.AT>(AT.ID) {
       @Override
-      public BurstKey newKey(brs.at.AT at) {
+      public SignumKey newKey(brs.at.AT at) {
         return at.dbKey;
       }
     };
   private final VersionedEntityTable<brs.at.AT> atTable;
 
-  private final BurstKey.LongKeyFactory<brs.at.AT.ATState> atStateDbKeyFactory = new DbKey.LongKeyFactory<brs.at.AT.ATState>(AT_STATE.AT_ID) {
+  private final SignumKey.LongKeyFactory<brs.at.AT.ATState> atStateDbKeyFactory = new DbKey.LongKeyFactory<brs.at.AT.ATState>(AT_STATE.AT_ID) {
       @Override
-      public BurstKey newKey(brs.at.AT.ATState atState) {
+      public SignumKey newKey(brs.at.AT.ATState atState) {
         return atState.dbKey;
       }
     };
@@ -49,7 +49,7 @@ public class SqlATStore implements ATStore {
 
   private final DbKey.LinkKey3Factory<brs.at.AT.AtMapEntry> atMapKeyFactory = new DbKey.LinkKey3Factory<brs.at.AT.AtMapEntry>("at_id", "key1", "key2"){
     @Override
-    public BurstKey newKey(brs.at.AT.AtMapEntry atDb) {
+    public SignumKey newKey(brs.at.AT.AtMapEntry atDb) {
       return newKey(atDb.getAtId(), atDb.getKey1(), atDb.getKey2());
     }
   };
@@ -297,7 +297,7 @@ public class SqlATStore implements ATStore {
   }
 
   @Override
-  public BurstKey.LongKeyFactory<brs.at.AT> getAtDbKeyFactory() {
+  public SignumKey.LongKeyFactory<brs.at.AT> getAtDbKeyFactory() {
     return atDbKeyFactory;
   }
 
@@ -312,7 +312,7 @@ public class SqlATStore implements ATStore {
   }
 
   @Override
-  public BurstKey.LongKeyFactory<brs.at.AT.ATState> getAtStateDbKeyFactory() {
+  public SignumKey.LongKeyFactory<brs.at.AT.ATState> getAtStateDbKeyFactory() {
     return atStateDbKeyFactory;
   }
 

--- a/src/brs/db/sql/SqlAccountStore.java
+++ b/src/brs/db/sql/SqlAccountStore.java
@@ -44,7 +44,7 @@ public class SqlAccountStore implements AccountStore {
     = new DbKey.LongKeyFactory<Account.RewardRecipientAssignment>(REWARD_RECIP_ASSIGN.ACCOUNT_ID) {
     @Override
     public DbKey newKey(Account.RewardRecipientAssignment assignment) {
-      return (DbKey) assignment.burstKey;
+      return (DbKey) assignment.signumKey;
     }
   };
   private static final org.slf4j.Logger logger = LoggerFactory.getLogger(SqlAccountStore.class);
@@ -52,7 +52,7 @@ public class SqlAccountStore implements AccountStore {
     = new DbKey.LinkKeyFactory<Account.AccountAsset>("account_id", "asset_id") {
     @Override
     public DbKey newKey(Account.AccountAsset accountAsset) {
-      return (DbKey) accountAsset.burstKey;
+      return (DbKey) accountAsset.signumKey;
     }
   };
 

--- a/src/brs/db/sql/SqlAliasStore.java
+++ b/src/brs/db/sql/SqlAliasStore.java
@@ -1,7 +1,7 @@
 package brs.db.sql;
 
 import brs.Alias;
-import brs.Burst;
+import brs.Signum;
 import brs.db.BurstKey;
 import brs.db.VersionedEntityTable;
 import brs.db.store.AliasStore;
@@ -96,7 +96,7 @@ public class SqlAliasStore implements AliasStore {
   private void saveOffer(Alias.Offer offer) {
     Db.useDSLContext(ctx -> {
       ctx.insertInto(ALIAS_OFFER, ALIAS_OFFER.ID, ALIAS_OFFER.PRICE, ALIAS_OFFER.BUYER_ID, ALIAS_OFFER.HEIGHT)
-              .values(offer.getId(), offer.getPriceNQT(), (offer.getBuyerId() == 0 ? null : offer.getBuyerId()), Burst.getBlockchain().getHeight())
+              .values(offer.getId(), offer.getPriceNQT(), (offer.getBuyerId() == 0 ? null : offer.getBuyerId()), Signum.getBlockchain().getHeight())
               .execute();
     });
   }
@@ -131,7 +131,7 @@ public class SqlAliasStore implements AliasStore {
       set(ALIAS.ALIAS_NAME_LOWER, alias.getAliasName().toLowerCase(Locale.ENGLISH)).
       set(ALIAS.ALIAS_URI, alias.getAliasURI()).
       set(ALIAS.TIMESTAMP, alias.getTimestamp()).
-      set(ALIAS.HEIGHT, Burst.getBlockchain().getHeight()).execute();
+      set(ALIAS.HEIGHT, Signum.getBlockchain().getHeight()).execute();
   }
 
   private final VersionedEntityTable<Alias> aliasTable;

--- a/src/brs/db/sql/SqlAliasStore.java
+++ b/src/brs/db/sql/SqlAliasStore.java
@@ -2,7 +2,7 @@ package brs.db.sql;
 
 import brs.Alias;
 import brs.Signum;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.VersionedEntityTable;
 import brs.db.store.AliasStore;
 import brs.db.store.DerivedTableManager;
@@ -26,7 +26,7 @@ public class SqlAliasStore implements AliasStore {
 
   private static final DbKey.LongKeyFactory<Alias.Offer> offerDbKeyFactory = new DbKey.LongKeyFactory<Alias.Offer>(ALIAS_OFFER.ID) {
       @Override
-      public BurstKey newKey(Alias.Offer offer) {
+      public SignumKey newKey(Alias.Offer offer) {
         return offer.dbKey;
       }
     };
@@ -65,20 +65,20 @@ public class SqlAliasStore implements AliasStore {
   }
 
   @Override
-  public BurstKey.LongKeyFactory<Alias.Offer> getOfferDbKeyFactory() {
+  public SignumKey.LongKeyFactory<Alias.Offer> getOfferDbKeyFactory() {
     return offerDbKeyFactory;
   }
 
-  private static final BurstKey.LongKeyFactory<Alias> aliasDbKeyFactory = new DbKey.LongKeyFactory<Alias>(ALIAS.ID) {
+  private static final SignumKey.LongKeyFactory<Alias> aliasDbKeyFactory = new DbKey.LongKeyFactory<Alias>(ALIAS.ID) {
 
       @Override
-      public BurstKey newKey(Alias alias) {
+      public SignumKey newKey(Alias alias) {
         return alias.dbKey;
       }
     };
 
   @Override
-  public BurstKey.LongKeyFactory<Alias> getAliasDbKeyFactory() {
+  public SignumKey.LongKeyFactory<Alias> getAliasDbKeyFactory() {
     return aliasDbKeyFactory;
   }
 

--- a/src/brs/db/sql/SqlAssetStore.java
+++ b/src/brs/db/sql/SqlAssetStore.java
@@ -2,7 +2,7 @@ package brs.db.sql;
 
 import brs.Asset;
 import brs.Signum;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.store.AssetStore;
 import brs.db.store.DerivedTableManager;
 import brs.schema.tables.records.AssetRecord;
@@ -18,10 +18,10 @@ import static brs.schema.Tables.ASSET;
 
 public class SqlAssetStore implements AssetStore {
 
-  private final BurstKey.LongKeyFactory<Asset> assetDbKeyFactory = new DbKey.LongKeyFactory<Asset>(ASSET.ID) {
+  private final SignumKey.LongKeyFactory<Asset> assetDbKeyFactory = new DbKey.LongKeyFactory<Asset>(ASSET.ID) {
 
       @Override
-      public BurstKey newKey(Asset asset) {
+      public SignumKey newKey(Asset asset) {
         return asset.dbKey;
       }
 
@@ -56,7 +56,7 @@ public class SqlAssetStore implements AssetStore {
   }
 
   @Override
-  public BurstKey.LongKeyFactory<Asset> getAssetDbKeyFactory() {
+  public SignumKey.LongKeyFactory<Asset> getAssetDbKeyFactory() {
     return assetDbKeyFactory;
   }
 

--- a/src/brs/db/sql/SqlAssetStore.java
+++ b/src/brs/db/sql/SqlAssetStore.java
@@ -1,7 +1,7 @@
 package brs.db.sql;
 
 import brs.Asset;
-import brs.Burst;
+import brs.Signum;
 import brs.db.BurstKey;
 import brs.db.store.AssetStore;
 import brs.db.store.DerivedTableManager;
@@ -52,7 +52,7 @@ public class SqlAssetStore implements AssetStore {
       set(ASSET.QUANTITY, asset.getQuantityQNT()).
       set(ASSET.DECIMALS, asset.getDecimals()).
       set(ASSET.MINTABLE, asset.getMintable()).
-      set(ASSET.HEIGHT, Burst.getBlockchain().getHeight()).execute();
+      set(ASSET.HEIGHT, Signum.getBlockchain().getHeight()).execute();
   }
 
   @Override

--- a/src/brs/db/sql/SqlAssetTransferStore.java
+++ b/src/brs/db/sql/SqlAssetTransferStore.java
@@ -1,7 +1,7 @@
 package brs.db.sql;
 
 import brs.AssetTransfer;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.store.AssetTransferStore;
 import brs.db.store.DerivedTableManager;
 import brs.schema.tables.records.AssetTransferRecord;
@@ -15,10 +15,10 @@ import static brs.schema.Tables.ASSET_TRANSFER;
 
 public class SqlAssetTransferStore implements AssetTransferStore {
 
-  private static final BurstKey.LinkKeyFactory<AssetTransfer> transferDbKeyFactory = new DbKey.LinkKeyFactory<AssetTransfer>("asset_transfer.id", "asset_transfer.asset_id") {
+  private static final SignumKey.LinkKeyFactory<AssetTransfer> transferDbKeyFactory = new DbKey.LinkKeyFactory<AssetTransfer>("asset_transfer.id", "asset_transfer.asset_id") {
 
       @Override
-      public BurstKey newKey(AssetTransfer assetTransfer) {
+      public SignumKey newKey(AssetTransfer assetTransfer) {
         return assetTransfer.getDbKey();
       }
     };
@@ -59,7 +59,7 @@ public class SqlAssetTransferStore implements AssetTransferStore {
   }
 
   @Override
-  public BurstKey.LinkKeyFactory<AssetTransfer> getTransferDbKeyFactory() {
+  public SignumKey.LinkKeyFactory<AssetTransfer> getTransferDbKeyFactory() {
     return transferDbKeyFactory;
   }
   @Override

--- a/src/brs/db/sql/SqlBlockDb.java
+++ b/src/brs/db/sql/SqlBlockDb.java
@@ -2,7 +2,7 @@ package brs.db.sql;
 
 import brs.Block;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.db.BlockDb;
 import brs.schema.tables.records.BlockRecord;
 import org.jooq.*;
@@ -25,7 +25,7 @@ public class SqlBlockDb implements BlockDb {
       try {
         BlockRecord r = ctx.selectFrom(BLOCK).where(BLOCK.ID.eq(blockId)).fetchAny();
         return r == null ? null : loadBlock(r);
-      } catch (BurstException.ValidationException e) {
+      } catch (SignumException.ValidationException e) {
         throw new RuntimeException("Block already in database, id = " + blockId + ", does not pass validation!", e);
       }
     });
@@ -55,7 +55,7 @@ public class SqlBlockDb implements BlockDb {
           throw new RuntimeException("Block at height " + height + " not found in database!");
         }
         return block;
-      } catch (BurstException.ValidationException e) {
+      } catch (SignumException.ValidationException e) {
         throw new RuntimeException(e.toString(), e);
       }
     });
@@ -74,7 +74,7 @@ public class SqlBlockDb implements BlockDb {
         return loadBlock(query.fetchAny());
         // old statement
         // return loadBlock(ctx.selectFrom(BLOCK).orderBy(BLOCK.DB_ID.desc()).limit(1).fetchAny());
-      } catch (BurstException.ValidationException e) {
+      } catch (SignumException.ValidationException e) {
         throw new RuntimeException("Last block already in database does not pass validation!", e);
       }
     });
@@ -84,13 +84,13 @@ public class SqlBlockDb implements BlockDb {
     return Db.useDSLContext(ctx -> {
       try {
         return loadBlock(ctx.selectFrom(BLOCK).where(BLOCK.TIMESTAMP.lessOrEqual(timestamp)).orderBy(BLOCK.DB_ID.desc()).limit(1).fetchAny());
-      } catch (BurstException.ValidationException e) {
+      } catch (SignumException.ValidationException e) {
         throw new RuntimeException("Block already in database at timestamp " + timestamp + " does not pass validation!", e);
       }
     });
   }
 
-  public Block loadBlock(BlockRecord r) throws BurstException.ValidationException {
+  public Block loadBlock(BlockRecord r) throws SignumException.ValidationException {
     int version = r.getVersion();
     int timestamp = r.getTimestamp();
     long previousBlockId = Optional.ofNullable(r.getPreviousBlockId()).orElse(0L);

--- a/src/brs/db/sql/SqlBlockDb.java
+++ b/src/brs/db/sql/SqlBlockDb.java
@@ -1,7 +1,7 @@
 package brs.db.sql;
 
 import brs.Block;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.db.BlockDb;
 import brs.schema.tables.records.BlockRecord;
@@ -137,7 +137,7 @@ public class SqlBlockDb implements BlockDb {
         block.getGeneratorId(), block.getNonce(), block.getBlockATs())
       .execute();
 
-    Burst.getDbs().getTransactionDb().saveTransactions(block.getTransactions());
+    Signum.getDbs().getTransactionDb().saveTransactions(block.getTransactions());
 
     if (block.getPreviousBlockId() != 0) {
       ctx.update(BLOCK)

--- a/src/brs/db/sql/SqlBlockchainStore.java
+++ b/src/brs/db/sql/SqlBlockchainStore.java
@@ -397,16 +397,16 @@ public class SqlBlockchainStore implements BlockchainStore {
     int commitmentHeight = Math.min(height - commitmentWait, endHeight);
 
     Collection<byte[]> commitmmentAddBytes = Db.useDSLContext(ctx -> {
-      SelectConditionStep<Record1<byte[]>> select = ctx.select(TRANSACTION.ATTACHMENT_BYTES).from(TRANSACTION).where(TRANSACTION.TYPE.eq(TransactionType.TYPE_BURST_MINING.getType()))
-        .and(TRANSACTION.SUBTYPE.eq(TransactionType.SUBTYPE_BURST_MINING_COMMITMENT_ADD))
+      SelectConditionStep<Record1<byte[]>> select = ctx.select(TRANSACTION.ATTACHMENT_BYTES).from(TRANSACTION).where(TRANSACTION.TYPE.eq(TransactionType.TYPE_SIGNA_MINING.getType()))
+        .and(TRANSACTION.SUBTYPE.eq(TransactionType.SUBTYPE_SIGNA_MINING_COMMITMENT_ADD))
         .and(TRANSACTION.HEIGHT.le(commitmentHeight));
       if (accountId != 0L)
         select = select.and(TRANSACTION.SENDER_ID.equal(accountId));
       return select.fetch().getValues(TRANSACTION.ATTACHMENT_BYTES);
     });
     Collection<byte[]> commitmmentRemoveBytes = Db.useDSLContext(ctx -> {
-      SelectConditionStep<Record1<byte[]>> select = ctx.select(TRANSACTION.ATTACHMENT_BYTES).from(TRANSACTION).where(TRANSACTION.TYPE.eq(TransactionType.TYPE_BURST_MINING.getType()))
-        .and(TRANSACTION.SUBTYPE.eq(TransactionType.SUBTYPE_BURST_MINING_COMMITMENT_REMOVE))
+      SelectConditionStep<Record1<byte[]>> select = ctx.select(TRANSACTION.ATTACHMENT_BYTES).from(TRANSACTION).where(TRANSACTION.TYPE.eq(TransactionType.TYPE_SIGNA_MINING.getType()))
+        .and(TRANSACTION.SUBTYPE.eq(TransactionType.SUBTYPE_SIGNA_MINING_COMMITMENT_REMOVE))
         .and(TRANSACTION.HEIGHT.le(endHeight));
       if (accountId != 0L)
         select = select.and(TRANSACTION.SENDER_ID.equal(accountId));

--- a/src/brs/db/sql/SqlBlockchainStore.java
+++ b/src/brs/db/sql/SqlBlockchainStore.java
@@ -82,7 +82,7 @@ public class SqlBlockchainStore implements BlockchainStore {
     return blockRecords.map(blockRecord -> {
       try {
         return blockDb.loadBlock(blockRecord);
-      } catch (BurstException.ValidationException e) {
+      } catch (SignumException.ValidationException e) {
         throw new RuntimeException(e);
       }
     });
@@ -117,7 +117,7 @@ public class SqlBlockchainStore implements BlockchainStore {
         .fetch(result -> {
           try {
             return blockDb.loadBlock(result);
-          } catch (BurstException.ValidationException e) {
+          } catch (SignumException.ValidationException e) {
             throw new RuntimeException(e.toString(), e);
           }
         });
@@ -364,7 +364,7 @@ public class SqlBlockchainStore implements BlockchainStore {
     return rs.map(r -> {
       try {
         return transactionDb.loadTransaction(r);
-      } catch (BurstException.ValidationException e) {
+      } catch (SignumException.ValidationException e) {
         throw new RuntimeException(e);
       }
     });

--- a/src/brs/db/sql/SqlBlockchainStore.java
+++ b/src/brs/db/sql/SqlBlockchainStore.java
@@ -32,8 +32,8 @@ public class SqlBlockchainStore implements BlockchainStore {
 
   private final Logger logger = LoggerFactory.getLogger(SqlBlockchainStore.class);
 
-  private final TransactionDb transactionDb = Burst.getDbs().getTransactionDb();
-  private final BlockDb blockDb = Burst.getDbs().getBlockDb();
+  private final TransactionDb transactionDb = Signum.getDbs().getTransactionDb();
+  private final BlockDb blockDb = Signum.getDbs().getBlockDb();
 
   public SqlBlockchainStore() {
   }
@@ -41,7 +41,7 @@ public class SqlBlockchainStore implements BlockchainStore {
   @Override
   public Collection<Block> getBlocks(int from, int to) {
     return Db.useDSLContext(ctx -> {
-      int blockchainHeight = Burst.getBlockchain().getHeight();
+      int blockchainHeight = Signum.getBlockchain().getHeight();
       return
         getBlocks(ctx.selectFrom(BLOCK)
           .where(BLOCK.HEIGHT.between(blockchainHeight - Math.max(to, 0)).and(blockchainHeight - Math.max(from, 0)))
@@ -198,9 +198,9 @@ public class SqlBlockchainStore implements BlockchainStore {
   }
 
   private static int getHeightForNumberOfConfirmations(int numberOfConfirmations) {
-    int height = numberOfConfirmations > 0 ? Burst.getBlockchain().getHeight() - numberOfConfirmations : Integer.MAX_VALUE;
+    int height = numberOfConfirmations > 0 ? Signum.getBlockchain().getHeight() - numberOfConfirmations : Integer.MAX_VALUE;
     if (height < 0) {
-      throw new IllegalArgumentException("Number of confirmations required " + numberOfConfirmations + " exceeds current blockchain height " + Burst.getBlockchain().getHeight());
+      throw new IllegalArgumentException("Number of confirmations required " + numberOfConfirmations + " exceeds current blockchain height " + Signum.getBlockchain().getHeight());
     }
     return height;
   }
@@ -334,7 +334,7 @@ public class SqlBlockchainStore implements BlockchainStore {
       ArrayList<Condition> conditions = new ArrayList<>();
 
       // must be confirmed already
-      int height = Burst.getBlockchain().getHeight() - numberOfConfirmations;
+      int height = Signum.getBlockchain().getHeight() - numberOfConfirmations;
       conditions.add(TRANSACTION.HEIGHT.le(height));
       if (type >= 0) {
         conditions.add(TRANSACTION.TYPE.eq(type));
@@ -393,7 +393,7 @@ public class SqlBlockchainStore implements BlockchainStore {
 
   @Override
   public long getCommittedAmount(long accountId, int height, int endHeight, Transaction skipTransaction) {
-    int commitmentWait = Burst.getFluxCapacitor().getValue(FluxValues.COMMITMENT_WAIT, height);
+    int commitmentWait = Signum.getFluxCapacitor().getValue(FluxValues.COMMITMENT_WAIT, height);
     int commitmentHeight = Math.min(height - commitmentWait, endHeight);
 
     Collection<byte[]> commitmmentAddBytes = Db.useDSLContext(ctx -> {

--- a/src/brs/db/sql/SqlBlockchainStore.java
+++ b/src/brs/db/sql/SqlBlockchainStore.java
@@ -420,7 +420,7 @@ public class SqlBlockchainStore implements BlockchainStore {
       try {
         ByteBuffer buffer = ByteBuffer.wrap(bytes);
         buffer.order(ByteOrder.LITTLE_ENDIAN);
-        CommitmentAdd txAttachment = (CommitmentAdd) TransactionType.BurstMining.COMMITMENT_ADD.parseAttachment(buffer, (byte) 1);
+        CommitmentAdd txAttachment = (CommitmentAdd) TransactionType.SignaMining.COMMITMENT_ADD.parseAttachment(buffer, (byte) 1);
         amountCommitted = amountCommitted.add(BigInteger.valueOf(txAttachment.getAmountNQT()));
       } catch (Exception e) {
         logger.error(e.getMessage());
@@ -430,7 +430,7 @@ public class SqlBlockchainStore implements BlockchainStore {
       try {
         ByteBuffer buffer = ByteBuffer.wrap(bytes);
         buffer.order(ByteOrder.LITTLE_ENDIAN);
-        CommitmentRemove txAttachment = (CommitmentRemove) TransactionType.BurstMining.COMMITMENT_REMOVE.parseAttachment(buffer, (byte) 1);
+        CommitmentRemove txAttachment = (CommitmentRemove) TransactionType.SignaMining.COMMITMENT_REMOVE.parseAttachment(buffer, (byte) 1);
         amountCommitted = amountCommitted.subtract(BigInteger.valueOf(txAttachment.getAmountNQT()));
       } catch (Exception e) {
         logger.error(e.getMessage());

--- a/src/brs/db/sql/SqlDigitalGoodsStoreStore.java
+++ b/src/brs/db/sql/SqlDigitalGoodsStoreStore.java
@@ -1,6 +1,6 @@
 package brs.db.sql;
 
-import brs.Burst;
+import brs.Signum;
 import brs.DigitalGoodsStore;
 import brs.crypto.EncryptedData;
 import brs.db.BurstKey;
@@ -107,7 +107,7 @@ public class SqlDigitalGoodsStoreStore implements DigitalGoodsStoreStore {
         ).values(
             purchase.getId(),
             data, nonce,
-            brs.Burst.getBlockchain().getHeight(), true
+            brs.Signum.getBlockchain().getHeight(), true
         ).execute();
       }
     };
@@ -124,7 +124,7 @@ public class SqlDigitalGoodsStoreStore implements DigitalGoodsStoreStore {
       protected void save(DSLContext ctx, DigitalGoodsStore.Purchase purchase, String publicFeedback) {
         ctx.mergeInto(PURCHASE_PUBLIC_FEEDBACK, PURCHASE_PUBLIC_FEEDBACK.ID, PURCHASE_PUBLIC_FEEDBACK.PUBLIC_FEEDBACK, PURCHASE_PUBLIC_FEEDBACK.HEIGHT, PURCHASE_PUBLIC_FEEDBACK.LATEST)
                 .key(PURCHASE_PUBLIC_FEEDBACK.ID, PURCHASE_PUBLIC_FEEDBACK.HEIGHT)
-                .values(purchase.getId(), publicFeedback, Burst.getBlockchain().getHeight(), true)
+                .values(purchase.getId(), publicFeedback, Signum.getBlockchain().getHeight(), true)
                 .execute();
       }
     };
@@ -206,7 +206,7 @@ public class SqlDigitalGoodsStoreStore implements DigitalGoodsStoreStore {
   private void saveGoods(DSLContext ctx, DigitalGoodsStore.Goods goods) {
     ctx.mergeInto(GOODS, GOODS.ID, GOODS.SELLER_ID, GOODS.NAME, GOODS.DESCRIPTION, GOODS.TAGS, GOODS.TIMESTAMP, GOODS.QUANTITY, GOODS.PRICE, GOODS.DELISTED, GOODS.HEIGHT, GOODS.LATEST)
             .key(GOODS.ID, GOODS.HEIGHT)
-            .values(goods.getId(), goods.getSellerId(), goods.getName(), goods.getDescription(), goods.getTags(), goods.getTimestamp(), goods.getQuantity(), goods.getPriceNQT(), goods.isDelisted(), Burst.getBlockchain().getHeight(), true)
+            .values(goods.getId(), goods.getSellerId(), goods.getName(), goods.getDescription(), goods.getTags(), goods.getTimestamp(), goods.getQuantity(), goods.getPriceNQT(), goods.isDelisted(), Signum.getBlockchain().getHeight(), true)
             .execute();
   }
 
@@ -231,7 +231,7 @@ public class SqlDigitalGoodsStoreStore implements DigitalGoodsStoreStore {
     }
     ctx.mergeInto(PURCHASE, PURCHASE.ID, PURCHASE.BUYER_ID, PURCHASE.GOODS_ID, PURCHASE.SELLER_ID, PURCHASE.QUANTITY, PURCHASE.PRICE, PURCHASE.DEADLINE, PURCHASE.NOTE, PURCHASE.NONCE, PURCHASE.TIMESTAMP, PURCHASE.PENDING, PURCHASE.GOODS, PURCHASE.GOODS_NONCE, PURCHASE.REFUND_NOTE, PURCHASE.REFUND_NONCE, PURCHASE.HAS_FEEDBACK_NOTES, PURCHASE.HAS_PUBLIC_FEEDBACKS, PURCHASE.DISCOUNT, PURCHASE.REFUND, PURCHASE.HEIGHT, PURCHASE.LATEST)
             .key(PURCHASE.ID, PURCHASE.HEIGHT)
-            .values(purchase.getId(), purchase.getBuyerId(), purchase.getGoodsId(), purchase.getSellerId(), purchase.getQuantity(), purchase.getPriceNQT(), purchase.getDeliveryDeadlineTimestamp(), note, nonce, purchase.getTimestamp(), purchase.isPending(), goods, goodsNonce, refundNote, refundNonce, purchase.getFeedbackNotes() != null && !purchase.getFeedbackNotes().isEmpty(), !purchase.getPublicFeedback().isEmpty(), purchase.getDiscountNQT(), purchase.getRefundNQT(), Burst.getBlockchain().getHeight(), true)
+            .values(purchase.getId(), purchase.getBuyerId(), purchase.getGoodsId(), purchase.getSellerId(), purchase.getQuantity(), purchase.getPriceNQT(), purchase.getDeliveryDeadlineTimestamp(), note, nonce, purchase.getTimestamp(), purchase.isPending(), goods, goodsNonce, refundNote, refundNonce, purchase.getFeedbackNotes() != null && !purchase.getFeedbackNotes().isEmpty(), !purchase.getPublicFeedback().isEmpty(), purchase.getDiscountNQT(), purchase.getRefundNQT(), Signum.getBlockchain().getHeight(), true)
             .execute();
   }
 

--- a/src/brs/db/sql/SqlDigitalGoodsStoreStore.java
+++ b/src/brs/db/sql/SqlDigitalGoodsStoreStore.java
@@ -3,7 +3,7 @@ package brs.db.sql;
 import brs.Signum;
 import brs.DigitalGoodsStore;
 import brs.crypto.EncryptedData;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.VersionedEntityTable;
 import brs.db.VersionedValuesTable;
 import brs.db.store.DerivedTableManager;
@@ -24,15 +24,15 @@ public class SqlDigitalGoodsStoreStore implements DigitalGoodsStoreStore {
   private static final DbKey.LongKeyFactory<DigitalGoodsStore.Purchase> feedbackDbKeyFactory
     = new DbKey.LongKeyFactory<DigitalGoodsStore.Purchase>(PURCHASE.ID) {
         @Override
-        public BurstKey newKey(DigitalGoodsStore.Purchase purchase) {
+        public SignumKey newKey(DigitalGoodsStore.Purchase purchase) {
           return purchase.dbKey;
         }
       };
 
-  private final BurstKey.LongKeyFactory<DigitalGoodsStore.Purchase> purchaseDbKeyFactory
+  private final SignumKey.LongKeyFactory<DigitalGoodsStore.Purchase> purchaseDbKeyFactory
     = new DbKey.LongKeyFactory<DigitalGoodsStore.Purchase>(PURCHASE.ID) {
         @Override
-        public BurstKey newKey(DigitalGoodsStore.Purchase purchase) {
+        public SignumKey newKey(DigitalGoodsStore.Purchase purchase) {
           return purchase.dbKey;
         }
       };
@@ -45,16 +45,16 @@ public class SqlDigitalGoodsStoreStore implements DigitalGoodsStoreStore {
   private final DbKey.LongKeyFactory<DigitalGoodsStore.Purchase> publicFeedbackDbKeyFactory
     = new DbKey.LongKeyFactory<DigitalGoodsStore.Purchase>(PURCHASE.ID) {
         @Override
-        public BurstKey newKey(DigitalGoodsStore.Purchase purchase) {
+        public SignumKey newKey(DigitalGoodsStore.Purchase purchase) {
           return purchase.dbKey;
         }
       };
 
   private final VersionedValuesTable<DigitalGoodsStore.Purchase, String> publicFeedbackTable;
 
-  private final BurstKey.LongKeyFactory<DigitalGoodsStore.Goods> goodsDbKeyFactory = new DbKey.LongKeyFactory<DigitalGoodsStore.Goods>(GOODS.ID) {
+  private final SignumKey.LongKeyFactory<DigitalGoodsStore.Goods> goodsDbKeyFactory = new DbKey.LongKeyFactory<DigitalGoodsStore.Goods>(GOODS.ID) {
       @Override
-      public BurstKey newKey(DigitalGoodsStore.Goods goods) {
+      public SignumKey newKey(DigitalGoodsStore.Goods goods) {
         return goods.dbKey;
       }
     };
@@ -165,12 +165,12 @@ public class SqlDigitalGoodsStoreStore implements DigitalGoodsStoreStore {
   }
 
   @Override
-  public BurstKey.LongKeyFactory<DigitalGoodsStore.Purchase> getFeedbackDbKeyFactory() {
+  public SignumKey.LongKeyFactory<DigitalGoodsStore.Purchase> getFeedbackDbKeyFactory() {
     return feedbackDbKeyFactory;
   }
 
   @Override
-  public BurstKey.LongKeyFactory<DigitalGoodsStore.Purchase> getPurchaseDbKeyFactory() {
+  public SignumKey.LongKeyFactory<DigitalGoodsStore.Purchase> getPurchaseDbKeyFactory() {
     return purchaseDbKeyFactory;
   }
 
@@ -194,7 +194,7 @@ public class SqlDigitalGoodsStoreStore implements DigitalGoodsStoreStore {
   }
 
   @Override
-  public BurstKey.LongKeyFactory<DigitalGoodsStore.Goods> getGoodsDbKeyFactory() {
+  public SignumKey.LongKeyFactory<DigitalGoodsStore.Goods> getGoodsDbKeyFactory() {
     return goodsDbKeyFactory;
   }
 

--- a/src/brs/db/sql/SqlEscrowStore.java
+++ b/src/brs/db/sql/SqlEscrowStore.java
@@ -3,7 +3,7 @@ package brs.db.sql;
 import brs.Signum;
 import brs.Escrow;
 import brs.Transaction;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.VersionedEntityTable;
 import brs.db.store.DerivedTableManager;
 import brs.db.store.EscrowStore;
@@ -18,9 +18,9 @@ import static brs.schema.Tables.ESCROW;
 import static brs.schema.Tables.ESCROW_DECISION;
 
 public class SqlEscrowStore implements EscrowStore {
-  private final BurstKey.LongKeyFactory<Escrow> escrowDbKeyFactory = new DbKey.LongKeyFactory<Escrow>(ESCROW.ID) {
+  private final SignumKey.LongKeyFactory<Escrow> escrowDbKeyFactory = new DbKey.LongKeyFactory<Escrow>(ESCROW.ID) {
       @Override
-      public BurstKey newKey(Escrow escrow) {
+      public SignumKey newKey(Escrow escrow) {
         return escrow.dbKey;
       }
     };
@@ -29,7 +29,7 @@ public class SqlEscrowStore implements EscrowStore {
   private final DbKey.LinkKeyFactory<Escrow.Decision> decisionDbKeyFactory =
       new DbKey.LinkKeyFactory<Escrow.Decision>("escrow_id", "account_id") {
         @Override
-        public BurstKey newKey(Escrow.Decision decision) {
+        public SignumKey newKey(Escrow.Decision decision) {
           return decision.dbKey;
         }
       };
@@ -71,7 +71,7 @@ public class SqlEscrowStore implements EscrowStore {
   }
 
   @Override
-  public BurstKey.LongKeyFactory<Escrow> getEscrowDbKeyFactory() {
+  public SignumKey.LongKeyFactory<Escrow> getEscrowDbKeyFactory() {
     return escrowDbKeyFactory;
   }
 

--- a/src/brs/db/sql/SqlEscrowStore.java
+++ b/src/brs/db/sql/SqlEscrowStore.java
@@ -1,6 +1,6 @@
 package brs.db.sql;
 
-import brs.Burst;
+import brs.Signum;
 import brs.Escrow;
 import brs.Transaction;
 import brs.db.BurstKey;
@@ -66,7 +66,7 @@ public class SqlEscrowStore implements EscrowStore {
   private void saveDecision(DSLContext ctx, Escrow.Decision decision) {
     ctx.mergeInto(ESCROW_DECISION, ESCROW_DECISION.ESCROW_ID, ESCROW_DECISION.ACCOUNT_ID, ESCROW_DECISION.DECISION, ESCROW_DECISION.HEIGHT, ESCROW_DECISION.LATEST)
             .key(ESCROW_DECISION.ESCROW_ID, ESCROW_DECISION.ACCOUNT_ID, ESCROW_DECISION.HEIGHT)
-            .values(decision.escrowId, decision.accountId, (int) Escrow.decisionToByte(decision.getDecision()), Burst.getBlockchain().getHeight(), true)
+            .values(decision.escrowId, decision.accountId, (int) Escrow.decisionToByte(decision.getDecision()), Signum.getBlockchain().getHeight(), true)
             .execute();
   }
 
@@ -110,7 +110,7 @@ public class SqlEscrowStore implements EscrowStore {
   private void saveEscrow(DSLContext ctx, Escrow escrow) {
     ctx.mergeInto(ESCROW, ESCROW.ID, ESCROW.SENDER_ID, ESCROW.RECIPIENT_ID, ESCROW.AMOUNT, ESCROW.REQUIRED_SIGNERS, ESCROW.DEADLINE, ESCROW.DEADLINE_ACTION, ESCROW.HEIGHT, ESCROW.LATEST)
             .key(ESCROW.ID, ESCROW.HEIGHT)
-            .values(escrow.id, escrow.senderId, escrow.recipientId, escrow.amountNQT, escrow.requiredSigners, escrow.deadline, (int) Escrow.decisionToByte(escrow.deadlineAction), Burst.getBlockchain().getHeight(), true)
+            .values(escrow.id, escrow.senderId, escrow.recipientId, escrow.amountNQT, escrow.requiredSigners, escrow.deadline, (int) Escrow.decisionToByte(escrow.deadlineAction), Signum.getBlockchain().getHeight(), true)
             .execute();
   }
 

--- a/src/brs/db/sql/SqlIndirectIncomingStore.java
+++ b/src/brs/db/sql/SqlIndirectIncomingStore.java
@@ -1,7 +1,7 @@
 package brs.db.sql;
 
 import brs.IndirectIncoming;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.store.DerivedTableManager;
 import brs.db.store.IndirectIncomingStore;
 import org.jooq.BatchBindStep;
@@ -19,12 +19,12 @@ import static brs.schema.Tables.INDIRECT_INCOMING;
 public class SqlIndirectIncomingStore implements IndirectIncomingStore {
 
   private final EntitySqlTable<IndirectIncoming> indirectIncomingTable;
-  private final BurstKey.LinkKeyFactory<IndirectIncoming> indirectIncomingDbKeyFactory;
+  private final SignumKey.LinkKeyFactory<IndirectIncoming> indirectIncomingDbKeyFactory;
 
   public SqlIndirectIncomingStore(DerivedTableManager derivedTableManager) {
     indirectIncomingDbKeyFactory = new DbKey.LinkKeyFactory<IndirectIncoming>("account_id", "transaction_id") {
       @Override
-      public BurstKey newKey(IndirectIncoming indirectIncoming) {
+      public SignumKey newKey(IndirectIncoming indirectIncoming) {
         return newKey(indirectIncoming.getAccountId(), indirectIncoming.getTransactionId());
       }
     };

--- a/src/brs/db/sql/SqlOrderStore.java
+++ b/src/brs/db/sql/SqlOrderStore.java
@@ -2,7 +2,7 @@ package brs.db.sql;
 
 import brs.Signum;
 import brs.Order;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.VersionedEntityTable;
 import brs.db.store.DerivedTableManager;
 import brs.db.store.OrderStore;
@@ -25,7 +25,7 @@ public class SqlOrderStore implements OrderStore {
   private final DbKey.LongKeyFactory<Order.Ask> askOrderDbKeyFactory = new DbKey.LongKeyFactory<Order.Ask>(ASK_ORDER.ID) {
 
     @Override
-    public BurstKey newKey(Order.Ask ask) {
+    public SignumKey newKey(Order.Ask ask) {
       return ask.dbKey;
     }
 
@@ -34,7 +34,7 @@ public class SqlOrderStore implements OrderStore {
   private final DbKey.LongKeyFactory<Order.Bid> bidOrderDbKeyFactory = new DbKey.LongKeyFactory<Order.Bid>(BID_ORDER.ID) {
 
     @Override
-    public BurstKey newKey(Order.Bid bid) {
+    public SignumKey newKey(Order.Bid bid) {
       return bid.dbKey;
     }
 

--- a/src/brs/db/sql/SqlOrderStore.java
+++ b/src/brs/db/sql/SqlOrderStore.java
@@ -1,6 +1,6 @@
 package brs.db.sql;
 
-import brs.Burst;
+import brs.Signum;
 import brs.Order;
 import brs.db.BurstKey;
 import brs.db.VersionedEntityTable;
@@ -142,7 +142,7 @@ public class SqlOrderStore implements OrderStore {
   private void saveAsk(DSLContext ctx, Order.Ask ask) {
     ctx.mergeInto(ASK_ORDER, ASK_ORDER.ID, ASK_ORDER.ACCOUNT_ID, ASK_ORDER.ASSET_ID, ASK_ORDER.PRICE, ASK_ORDER.QUANTITY, ASK_ORDER.CREATION_HEIGHT, ASK_ORDER.HEIGHT, ASK_ORDER.LATEST)
             .key(ASK_ORDER.ID, ASK_ORDER.HEIGHT)
-            .values(ask.getId(), ask.getAccountId(), ask.getAssetId(), ask.getPriceNQT(), ask.getQuantityQNT(), ask.getHeight(), Burst.getBlockchain().getHeight(), true)
+            .values(ask.getId(), ask.getAccountId(), ask.getAssetId(), ask.getPriceNQT(), ask.getQuantityQNT(), ask.getHeight(), Signum.getBlockchain().getHeight(), true)
             .execute();
   }
 
@@ -210,7 +210,7 @@ public class SqlOrderStore implements OrderStore {
   private void saveBid(DSLContext ctx, Order.Bid bid) {
     ctx.mergeInto(BID_ORDER, BID_ORDER.ID, BID_ORDER.ACCOUNT_ID, BID_ORDER.ASSET_ID, BID_ORDER.PRICE, BID_ORDER.QUANTITY, BID_ORDER.CREATION_HEIGHT, BID_ORDER.HEIGHT, BID_ORDER.LATEST)
             .key(BID_ORDER.ID, BID_ORDER.HEIGHT)
-            .values(bid.getId(), bid.getAccountId(), bid.getAssetId(), bid.getPriceNQT(), bid.getQuantityQNT(), bid.getHeight(), Burst.getBlockchain().getHeight(), true)
+            .values(bid.getId(), bid.getAccountId(), bid.getAssetId(), bid.getPriceNQT(), bid.getQuantityQNT(), bid.getHeight(), Signum.getBlockchain().getHeight(), true)
             .execute();
   }
 

--- a/src/brs/db/sql/SqlSubscriptionStore.java
+++ b/src/brs/db/sql/SqlSubscriptionStore.java
@@ -2,7 +2,7 @@ package brs.db.sql;
 
 import brs.Signum;
 import brs.Subscription;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.VersionedEntityTable;
 import brs.db.store.DerivedTableManager;
 import brs.db.store.SubscriptionStore;
@@ -18,9 +18,9 @@ import static brs.schema.Tables.SUBSCRIPTION;
 
 public class SqlSubscriptionStore implements SubscriptionStore {
 
-  private final BurstKey.LongKeyFactory<Subscription> subscriptionDbKeyFactory = new DbKey.LongKeyFactory<Subscription>(SUBSCRIPTION.ID) {
+  private final SignumKey.LongKeyFactory<Subscription> subscriptionDbKeyFactory = new DbKey.LongKeyFactory<Subscription>(SUBSCRIPTION.ID) {
       @Override
-      public BurstKey newKey(Subscription subscription) {
+      public SignumKey newKey(Subscription subscription) {
         return subscription.dbKey;
       }
     };
@@ -58,7 +58,7 @@ public class SqlSubscriptionStore implements SubscriptionStore {
   }
 
   @Override
-  public BurstKey.LongKeyFactory<Subscription> getSubscriptionDbKeyFactory() {
+  public SignumKey.LongKeyFactory<Subscription> getSubscriptionDbKeyFactory() {
     return subscriptionDbKeyFactory;
   }
 

--- a/src/brs/db/sql/SqlSubscriptionStore.java
+++ b/src/brs/db/sql/SqlSubscriptionStore.java
@@ -1,6 +1,6 @@
 package brs.db.sql;
 
-import brs.Burst;
+import brs.Signum;
 import brs.Subscription;
 import brs.db.BurstKey;
 import brs.db.VersionedEntityTable;
@@ -89,7 +89,7 @@ public class SqlSubscriptionStore implements SubscriptionStore {
 
   private Query insertSubscription(DSLContext ctx, Subscription subscription) {
     return ctx.insertInto(SUBSCRIPTION, SUBSCRIPTION.ID, SUBSCRIPTION.SENDER_ID, SUBSCRIPTION.RECIPIENT_ID, SUBSCRIPTION.AMOUNT, SUBSCRIPTION.FREQUENCY, SUBSCRIPTION.TIME_NEXT, SUBSCRIPTION.HEIGHT, SUBSCRIPTION.LATEST)
-            .values(subscription.id, subscription.senderId, subscription.recipientId, subscription.amountNQT, subscription.frequency, subscription.getTimeNext(), Burst.getBlockchain().getHeight(), true);
+            .values(subscription.id, subscription.senderId, subscription.recipientId, subscription.amountNQT, subscription.frequency, subscription.getTimeNext(), Signum.getBlockchain().getHeight(), true);
   }
 
   private class SqlSubscription extends Subscription {
@@ -127,7 +127,7 @@ public class SqlSubscriptionStore implements SubscriptionStore {
         for (Subscription subscription : subscriptions) {
           insertBatch.bind(
             subscription.id, subscription.senderId, subscription.recipientId, subscription.amountNQT, subscription.frequency,
-            subscription.getTimeNext(), Burst.getBlockchain().getHeight(), true
+            subscription.getTimeNext(), Signum.getBlockchain().getHeight(), true
           );
         }
         insertBatch.execute();

--- a/src/brs/db/sql/SqlTradeStore.java
+++ b/src/brs/db/sql/SqlTradeStore.java
@@ -1,7 +1,7 @@
 package brs.db.sql;
 
 import brs.Trade;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.store.DerivedTableManager;
 import brs.db.store.TradeStore;
 import brs.schema.tables.records.TradeRecord;
@@ -18,7 +18,7 @@ public class SqlTradeStore implements TradeStore {
   private final DbKey.LinkKeyFactory<Trade> tradeDbKeyFactory = new DbKey.LinkKeyFactory<Trade>("ask_order_id", "bid_order_id") {
 
       @Override
-      public BurstKey newKey(Trade trade) {
+      public SignumKey newKey(Trade trade) {
         return trade.dbKey;
       }
 

--- a/src/brs/db/sql/SqlTransactionDb.java
+++ b/src/brs/db/sql/SqlTransactionDb.java
@@ -1,7 +1,7 @@
 package brs.db.sql;
 
 import brs.Appendix;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Transaction;
 import brs.TransactionType;
 import brs.db.TransactionDb;
@@ -26,7 +26,7 @@ public class SqlTransactionDb implements TransactionDb {
       try {
         TransactionRecord transactionRecord = ctx.selectFrom(TRANSACTION).where(TRANSACTION.ID.eq(transactionId)).fetchOne();
         return loadTransaction(transactionRecord);
-      } catch (BurstException.ValidationException e) {
+      } catch (SignumException.ValidationException e) {
         throw new RuntimeException("Transaction already in database, id = " + transactionId + ", does not pass validation!", e);
       }
     });
@@ -38,7 +38,7 @@ public class SqlTransactionDb implements TransactionDb {
       try {
         TransactionRecord transactionRecord = ctx.selectFrom(TRANSACTION).where(TRANSACTION.FULL_HASH.eq(Convert.parseHexString(fullHash))).fetchOne();
         return loadTransaction(transactionRecord);
-      } catch (BurstException.ValidationException e) {
+      } catch (SignumException.ValidationException e) {
         throw new RuntimeException("Transaction already in database, full_hash = " + fullHash + ", does not pass validation!", e);
       }
     });
@@ -59,7 +59,7 @@ public class SqlTransactionDb implements TransactionDb {
   }
 
   @Override
-  public Transaction loadTransaction(TransactionRecord tr) throws BurstException.ValidationException {
+  public Transaction loadTransaction(TransactionRecord tr) throws SignumException.ValidationException {
     if (tr == null) {
       return null;
     }
@@ -119,7 +119,7 @@ public class SqlTransactionDb implements TransactionDb {
       return select.fetch(record -> {
                 try {
                   return loadTransaction(record);
-                } catch (BurstException.ValidationException e) {
+                } catch (SignumException.ValidationException e) {
                   e.printStackTrace();
                   throw new RuntimeException("Invalid transaction :" + e.getMessage(), e);
                 }

--- a/src/brs/db/sql/ValuesSqlTable.java
+++ b/src/brs/db/sql/ValuesSqlTable.java
@@ -1,6 +1,6 @@
 package brs.db.sql;
 
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.ValuesTable;
 import brs.db.store.DerivedTableManager;
 import org.jooq.DSLContext;
@@ -33,7 +33,7 @@ public abstract class ValuesSqlTable<T,V> extends DerivedSqlTable implements Val
 
   @SuppressWarnings("unchecked")
   @Override
-  public final List<V> get(BurstKey nxtKey) {
+  public final List<V> get(SignumKey nxtKey) {
     return Db.useDSLContext(ctx -> {
       DbKey dbKey = (DbKey) nxtKey;
       List<V> values;

--- a/src/brs/db/sql/VersionedBatchEntitySqlTable.java
+++ b/src/brs/db/sql/VersionedBatchEntitySqlTable.java
@@ -1,6 +1,6 @@
 package brs.db.sql;
 
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.VersionedBatchEntityTable;
 import brs.db.cache.DBCacheManagerImpl;
 import brs.db.store.DerivedTableManager;
@@ -46,7 +46,7 @@ public abstract class VersionedBatchEntitySqlTable<T> extends VersionedEntitySql
   }
 
   @Override
-  public T get(BurstKey dbKey) {
+  public T get(SignumKey dbKey) {
     if (getCache().containsKey(dbKey)) {
       return getCache().get(dbKey);
     }
@@ -63,7 +63,7 @@ public abstract class VersionedBatchEntitySqlTable<T> extends VersionedEntitySql
   @Override
   public void insert(T t) {
     assertNotInTransaction();
-    BurstKey key = dbKeyFactory.newKey(t);
+    SignumKey key = dbKeyFactory.newKey(t);
     getBatch().put(key, t);
     getCache().put(key, t);
   }
@@ -71,7 +71,7 @@ public abstract class VersionedBatchEntitySqlTable<T> extends VersionedEntitySql
   @Override
   public void finish() {
     assertNotInTransaction();
-    Set<BurstKey> keySet = getBatch().keySet();
+    Set<SignumKey> keySet = getBatch().keySet();
     if (keySet.isEmpty()) {
       return;
     }
@@ -85,7 +85,7 @@ public abstract class VersionedBatchEntitySqlTable<T> extends VersionedEntitySql
       updateQuery.addConditions(latestField.isTrue());
 
       BatchBindStep updateBatch = ctx.batch(updateQuery);
-      for (BurstKey dbKey : keySet) {
+      for (SignumKey dbKey : keySet) {
         List<Object> bindArgs = new ArrayList<>();
         bindArgs.add(false);
         for (long pkValue : dbKey.getPKValues()) {
@@ -101,7 +101,7 @@ public abstract class VersionedBatchEntitySqlTable<T> extends VersionedEntitySql
   }
 
   @Override
-  public T get(BurstKey dbKey, int height) {
+  public T get(SignumKey dbKey, int height) {
     assertInTransaction();
     return super.get(dbKey, height);
   }
@@ -197,12 +197,12 @@ public abstract class VersionedBatchEntitySqlTable<T> extends VersionedEntitySql
   }
 
   @Override
-  public Map<BurstKey, T> getBatch() {
+  public Map<SignumKey, T> getBatch() {
     return Db.getBatch(table);
   }
 
   @Override
-  public Cache<BurstKey, T> getCache() {
+  public Cache<SignumKey, T> getCache() {
     return dbCacheManager.getCache(table, tClass);
   }
 

--- a/src/brs/db/sql/VersionedEntitySqlTable.java
+++ b/src/brs/db/sql/VersionedEntitySqlTable.java
@@ -1,6 +1,6 @@
 package brs.db.sql;
 
-import brs.Burst;
+import brs.Signum;
 import brs.db.BurstKey;
 import brs.db.VersionedEntityTable;
 import brs.db.store.DerivedTableManager;
@@ -135,7 +135,7 @@ public abstract class VersionedEntitySqlTable<T> extends EntitySqlTable<T> imple
         SelectQuery<Record> countQuery = ctx.selectQuery();
         countQuery.addFrom(tableClass);
         countQuery.addConditions(dbKey.getPKConditions(tableClass));
-        countQuery.addConditions(heightField.lt(Burst.getBlockchain().getHeight()));
+        countQuery.addConditions(heightField.lt(Signum.getBlockchain().getHeight()));
         if (ctx.fetchCount(countQuery) > 0) {
           UpdateQuery updateQuery = ctx.updateQuery(tableClass);
           updateQuery.addValue(

--- a/src/brs/db/sql/VersionedEntitySqlTable.java
+++ b/src/brs/db/sql/VersionedEntitySqlTable.java
@@ -1,7 +1,7 @@
 package brs.db.sql;
 
 import brs.Signum;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.VersionedEntityTable;
 import brs.db.store.DerivedTableManager;
 import org.jooq.*;
@@ -18,7 +18,7 @@ public abstract class VersionedEntitySqlTable<T> extends EntitySqlTable<T> imple
     
   private static final Logger logger = LoggerFactory.getLogger(VersionedEntitySqlTable.class);
 
-  VersionedEntitySqlTable(String table, TableImpl<?> tableClass, BurstKey.Factory<T> dbKeyFactory, DerivedTableManager derivedTableManager) {
+  VersionedEntitySqlTable(String table, TableImpl<?> tableClass, SignumKey.Factory<T> dbKeyFactory, DerivedTableManager derivedTableManager) {
     super(table, tableClass, dbKeyFactory, true, derivedTableManager);
   }
 

--- a/src/brs/db/store/ATStore.java
+++ b/src/brs/db/store/ATStore.java
@@ -2,7 +2,7 @@ package brs.db.store;
 
 import brs.at.AT;
 import brs.at.AT.AtMapEntry;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.VersionedEntityTable;
 import brs.util.CollectionWithIndex;
 
@@ -23,11 +23,11 @@ public interface ATStore {
 
   Collection<Long> getAllATIds(Long codeHashId);
 
-  BurstKey.LongKeyFactory<AT> getAtDbKeyFactory();
+  SignumKey.LongKeyFactory<AT> getAtDbKeyFactory();
 
   VersionedEntityTable<AT> getAtTable();
 
-  BurstKey.LongKeyFactory<AT.ATState> getAtStateDbKeyFactory();
+  SignumKey.LongKeyFactory<AT.ATState> getAtStateDbKeyFactory();
 
   VersionedEntityTable<AT.ATState> getAtStateTable();
 

--- a/src/brs/db/store/AccountStore.java
+++ b/src/brs/db/store/AccountStore.java
@@ -2,7 +2,7 @@ package brs.db.store;
 
 import brs.Account;
 import brs.Asset;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.VersionedBatchEntityTable;
 import brs.db.VersionedEntityTable;
 
@@ -21,9 +21,9 @@ public interface AccountStore {
 
   VersionedEntityTable<Account.RewardRecipientAssignment> getRewardRecipientAssignmentTable();
 
-  BurstKey.LongKeyFactory<Account.RewardRecipientAssignment> getRewardRecipientAssignmentKeyFactory();
+  SignumKey.LongKeyFactory<Account.RewardRecipientAssignment> getRewardRecipientAssignmentKeyFactory();
 
-  BurstKey.LinkKeyFactory<Account.AccountAsset> getAccountAssetKeyFactory();
+  SignumKey.LinkKeyFactory<Account.AccountAsset> getAccountAssetKeyFactory();
 
   VersionedEntityTable<Account.AccountAsset> getAccountAssetTable();
 
@@ -31,9 +31,9 @@ public interface AccountStore {
 
   long getAssetCirculatingSupply(Asset asset, boolean ignoreTreasury, boolean unconfirmed);
 
-  BurstKey.LongKeyFactory<Account> getAccountKeyFactory();
+  SignumKey.LongKeyFactory<Account> getAccountKeyFactory();
 
-  BurstKey.LongKeyFactory<Account.Balance> getAccountBalanceKeyFactory();
+  SignumKey.LongKeyFactory<Account.Balance> getAccountBalanceKeyFactory();
 
   Collection<Account.RewardRecipientAssignment> getAccountsWithRewardRecipient(Long recipientId);
 

--- a/src/brs/db/store/AliasStore.java
+++ b/src/brs/db/store/AliasStore.java
@@ -1,14 +1,14 @@
 package brs.db.store;
 
 import brs.Alias;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.VersionedEntityTable;
 
 import java.util.Collection;
 
 public interface AliasStore {
-  BurstKey.LongKeyFactory<Alias> getAliasDbKeyFactory();
-  BurstKey.LongKeyFactory<Alias.Offer> getOfferDbKeyFactory();
+  SignumKey.LongKeyFactory<Alias> getAliasDbKeyFactory();
+  SignumKey.LongKeyFactory<Alias.Offer> getOfferDbKeyFactory();
 
   VersionedEntityTable<Alias> getAliasTable();
 

--- a/src/brs/db/store/AssetStore.java
+++ b/src/brs/db/store/AssetStore.java
@@ -1,13 +1,13 @@
 package brs.db.store;
 
 import brs.Asset;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.sql.EntitySqlTable;
 
 import java.util.Collection;
 
 public interface AssetStore {
-  BurstKey.LongKeyFactory<Asset> getAssetDbKeyFactory();
+  SignumKey.LongKeyFactory<Asset> getAssetDbKeyFactory();
 
   EntitySqlTable<Asset> getAssetTable();
 

--- a/src/brs/db/store/AssetTransferStore.java
+++ b/src/brs/db/store/AssetTransferStore.java
@@ -1,13 +1,13 @@
 package brs.db.store;
 
 import brs.AssetTransfer;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.sql.EntitySqlTable;
 
 import java.util.Collection;
 
 public interface AssetTransferStore {
-  BurstKey.LinkKeyFactory<AssetTransfer> getTransferDbKeyFactory();
+  SignumKey.LinkKeyFactory<AssetTransfer> getTransferDbKeyFactory();
 
   EntitySqlTable<AssetTransfer> getAssetTransferTable();
 

--- a/src/brs/db/store/DigitalGoodsStoreStore.java
+++ b/src/brs/db/store/DigitalGoodsStoreStore.java
@@ -2,7 +2,7 @@ package brs.db.store;
 
 import brs.DigitalGoodsStore;
 import brs.crypto.EncryptedData;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.VersionedEntityTable;
 import brs.db.VersionedValuesTable;
 
@@ -10,19 +10,19 @@ import java.util.Collection;
 
 public interface DigitalGoodsStoreStore {
 
-  BurstKey.LongKeyFactory<DigitalGoodsStore.Purchase> getFeedbackDbKeyFactory();
+  SignumKey.LongKeyFactory<DigitalGoodsStore.Purchase> getFeedbackDbKeyFactory();
 
-  BurstKey.LongKeyFactory<DigitalGoodsStore.Purchase> getPurchaseDbKeyFactory();
+  SignumKey.LongKeyFactory<DigitalGoodsStore.Purchase> getPurchaseDbKeyFactory();
 
   VersionedEntityTable<DigitalGoodsStore.Purchase> getPurchaseTable();
 
   VersionedValuesTable<DigitalGoodsStore.Purchase, EncryptedData> getFeedbackTable();
 
-  BurstKey.LongKeyFactory<DigitalGoodsStore.Purchase> getPublicFeedbackDbKeyFactory();
+  SignumKey.LongKeyFactory<DigitalGoodsStore.Purchase> getPublicFeedbackDbKeyFactory();
 
   VersionedValuesTable<DigitalGoodsStore.Purchase, String> getPublicFeedbackTable();
 
-  BurstKey.LongKeyFactory<DigitalGoodsStore.Goods> getGoodsDbKeyFactory();
+  SignumKey.LongKeyFactory<DigitalGoodsStore.Goods> getGoodsDbKeyFactory();
 
   VersionedEntityTable<DigitalGoodsStore.Goods> getGoodsTable();
 

--- a/src/brs/db/store/EscrowStore.java
+++ b/src/brs/db/store/EscrowStore.java
@@ -2,7 +2,7 @@ package brs.db.store;
 
 import brs.Escrow;
 import brs.Transaction;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.VersionedEntityTable;
 import brs.db.sql.DbKey;
 
@@ -11,7 +11,7 @@ import java.util.List;
 
 public interface EscrowStore {
 
-  BurstKey.LongKeyFactory<Escrow> getEscrowDbKeyFactory();
+  SignumKey.LongKeyFactory<Escrow> getEscrowDbKeyFactory();
 
   VersionedEntityTable<Escrow> getEscrowTable();
 

--- a/src/brs/db/store/OrderStore.java
+++ b/src/brs/db/store/OrderStore.java
@@ -1,7 +1,7 @@
 package brs.db.store;
 
 import brs.Order;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.VersionedEntityTable;
 
 import java.util.Collection;
@@ -21,11 +21,11 @@ public interface OrderStore {
 
   Collection<Order.Ask> getAskOrdersByAsset(long assetId, int from, int to);
 
-  BurstKey.LongKeyFactory<Order.Ask> getAskOrderDbKeyFactory();
+  SignumKey.LongKeyFactory<Order.Ask> getAskOrderDbKeyFactory();
 
   VersionedEntityTable<Order.Ask> getAskOrderTable();
 
-  BurstKey.LongKeyFactory<Order.Bid> getBidOrderDbKeyFactory();
+  SignumKey.LongKeyFactory<Order.Bid> getBidOrderDbKeyFactory();
 
   Collection<Order.Bid> getBidOrdersByAccount(long accountId, int from, int to);
 

--- a/src/brs/db/store/SubscriptionStore.java
+++ b/src/brs/db/store/SubscriptionStore.java
@@ -1,14 +1,14 @@
 package brs.db.store;
 
 import brs.Subscription;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.VersionedEntityTable;
 
 import java.util.Collection;
 
 public interface SubscriptionStore {
 
-  BurstKey.LongKeyFactory<Subscription> getSubscriptionDbKeyFactory();
+  SignumKey.LongKeyFactory<Subscription> getSubscriptionDbKeyFactory();
 
   VersionedEntityTable<Subscription> getSubscriptionTable();
 

--- a/src/brs/db/store/TradeStore.java
+++ b/src/brs/db/store/TradeStore.java
@@ -1,7 +1,7 @@
 package brs.db.store;
 
 import brs.Trade;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.sql.EntitySqlTable;
 
 import java.util.Collection;
@@ -29,7 +29,7 @@ public interface TradeStore {
 
   int getTradeCount(long assetId);
 
-  BurstKey.LinkKeyFactory<Trade> getTradeDbKeyFactory();
+  SignumKey.LinkKeyFactory<Trade> getTradeDbKeyFactory();
 
   EntitySqlTable<Trade> getTradeTable();
 }

--- a/src/brs/db/store/TransactionProcessorStore.java
+++ b/src/brs/db/store/TransactionProcessorStore.java
@@ -1,7 +1,7 @@
 package brs.db.store;
 
 import brs.Transaction;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.sql.EntitySqlTable;
 
 import java.util.Collection;
@@ -12,7 +12,7 @@ public interface TransactionProcessorStore {
   // WATCH: BUSINESS-LOGIC
   void processLater(Collection<Transaction> transactions);
 
-  BurstKey.LongKeyFactory<Transaction> getUnconfirmedTransactionDbKeyFactory();
+  SignumKey.LongKeyFactory<Transaction> getUnconfirmedTransactionDbKeyFactory();
 
   Set<Transaction> getLostTransactions();
 

--- a/src/brs/deeplink/DeeplinkQRCodeGenerator.java
+++ b/src/brs/deeplink/DeeplinkQRCodeGenerator.java
@@ -23,7 +23,7 @@ public class DeeplinkQRCodeGenerator {
     hints.put(EncodeHintType.ERROR_CORRECTION, ErrorCorrectionLevel.L);
   }
 
-  public BufferedImage generateRequestBurstDeepLinkQRCode(String receiverId, long amountNQT, FeeSuggestionType feeSuggestionType, Long feeNQT, String message, boolean immutable)
+  public BufferedImage generateRequestSignumDeepLinkQRCode(String receiverId, long amountNQT, FeeSuggestionType feeSuggestionType, Long feeNQT, String message, boolean immutable)
       throws WriterException {
     final StringBuilder deeplinkBuilder = new StringBuilder("burst://requestBurst");
 
@@ -42,10 +42,10 @@ public class DeeplinkQRCodeGenerator {
 
     deeplinkBuilder.append("&immutable=").append(immutable);
 
-    return generateBurstQRCode(deeplinkBuilder.toString());
+    return generateSignumQRCode(deeplinkBuilder.toString());
   }
 
-  private BufferedImage generateBurstQRCode(String url) throws WriterException {
+  private BufferedImage generateSignumQRCode(String url) throws WriterException {
     return MatrixToImageWriter.toBufferedImage(qrCodeWriter.encode(url, BarcodeFormat.QR_CODE, 350, 350, hints), new MatrixToImageConfig());
   }
 }

--- a/src/brs/feesuggestions/FeeSuggestionCalculator.java
+++ b/src/brs/feesuggestions/FeeSuggestionCalculator.java
@@ -2,7 +2,7 @@ package brs.feesuggestions;
 
 import brs.Block;
 import brs.BlockchainProcessor;
-import brs.Burst;
+import brs.Signum;
 import brs.fluxcapacitor.FluxValues;
 import brs.BlockchainProcessor.Event;
 import brs.unconfirmedtransactions.UnconfirmedTransactionStore;
@@ -23,15 +23,15 @@ public class FeeSuggestionCalculator {
     long cheap = 1;
     long standard = 1;
     long priority = 3;
-    if(Burst.getBlockchain() != null) {
-      Block lastBlock = Burst.getBlockchain().getLastBlock();
+    if(Signum.getBlockchain() != null) {
+      Block lastBlock = Signum.getBlockchain().getLastBlock();
       if(lastBlock != null) {
         standard = Math.max(1, lastBlock.getTransactions().size()-2);
         priority = lastBlock.getTransactions().size()+2;
       }
     }
     
-    long FEE_QUANT = Burst.getFluxCapacitor().getValue(FluxValues.FEE_QUANT);
+    long FEE_QUANT = Signum.getFluxCapacitor().getValue(FluxValues.FEE_QUANT);
     feeSuggestion.set(new FeeSuggestion(cheap * FEE_QUANT, standard * FEE_QUANT, priority * FEE_QUANT));
   }
 
@@ -55,7 +55,7 @@ public class FeeSuggestionCalculator {
       priority = standard + 1;
     }
 
-    long FEE_QUANT = Burst.getFluxCapacitor().getValue(FluxValues.FEE_QUANT);
+    long FEE_QUANT = Signum.getFluxCapacitor().getValue(FluxValues.FEE_QUANT);
     long cheapFee = cheap * FEE_QUANT;
     long standardFee = standard * FEE_QUANT;
     long priorityFee = priority * FEE_QUANT;

--- a/src/brs/fluxcapacitor/FluxValues.java
+++ b/src/brs/fluxcapacitor/FluxValues.java
@@ -31,7 +31,7 @@ public class FluxValues {
 
     public static final FluxValue<Integer> BLOCK_TIME = new FluxValue<>(240);
     public static final FluxValue<Long> FEE_QUANT = new FluxValue<>(
-        Constants.ONE_BURST,
+        Constants.ONE_SIGNA,
         new FluxValue.ValueChange<>(HistoricalMoments.PRE_POC2, Constants.FEE_QUANT_SIP3),
         new FluxValue.ValueChange<>(HistoricalMoments.SMART_FEES, Constants.FEE_QUANT_SIP34)
         );

--- a/src/brs/peer/PeerImpl.java
+++ b/src/brs/peer/PeerImpl.java
@@ -232,7 +232,7 @@ final class PeerImpl implements Peer {
 
   @Override
   public void blacklist(Exception cause, String description) {
-    if (cause instanceof BurstException.NotCurrentlyValidException || cause instanceof BlockchainProcessor.BlockOutOfOrderException
+    if (cause instanceof SignumException.NotCurrentlyValidException || cause instanceof BlockchainProcessor.BlockOutOfOrderException
         || cause instanceof SQLException || cause.getCause() instanceof SQLException) {
       // don't blacklist peers just because a feature is not yet enabled, or because of database timeouts
       // prevents erroneous blacklisting during loading of blockchain from scratch

--- a/src/brs/peer/PeerImpl.java
+++ b/src/brs/peer/PeerImpl.java
@@ -135,16 +135,16 @@ final class PeerImpl implements Peer {
   }
 
   public boolean isAtLeastMyVersion() {
-    return isHigherOrEqualVersionThan(Burst.VERSION);
+    return isHigherOrEqualVersionThan(Signum.VERSION);
   }
   
   void setVersion(String version) {
     this.version.set(Version.EMPTY);
     isOldVersion.set(false);
-    if (Burst.getPropertyService().getString(Props.APPLICATION).equals(getApplication()) && version != null) {
+    if (Signum.getPropertyService().getString(Props.APPLICATION).equals(getApplication()) && version != null) {
       try {
         this.version.set(Version.parse(version));
-        isOldVersion.set(Burst.getFluxCapacitor().getValue(FluxValues.MIN_PEER_VERSION).isGreaterThan(this.version.get()));
+        isOldVersion.set(Signum.getFluxCapacitor().getValue(FluxValues.MIN_PEER_VERSION).isGreaterThan(this.version.get()));
       } catch (IllegalArgumentException e) {
         isOldVersion.set(true);
       }
@@ -319,7 +319,7 @@ final class PeerImpl implements Peer {
       buf.append(address);
       if (port.get() <= 0) {
         buf.append(':');
-        buf.append(Burst.getPropertyService().getInt(Props.P2P_PORT));
+        buf.append(Signum.getPropertyService().getInt(Props.P2P_PORT));
       }
       buf.append("/burst");
       URL url = new URL(buf.toString());
@@ -335,7 +335,7 @@ final class PeerImpl implements Peer {
       connection.setDoOutput(true);
       connection.setConnectTimeout(Peers.connectTimeout);
       connection.setReadTimeout(Peers.readTimeout);
-      connection.addRequestProperty("User-Agent", "BRS/" + Burst.VERSION.toString());
+      connection.addRequestProperty("User-Agent", "BRS/" + Signum.VERSION.toString());
       connection.setRequestProperty("Accept-Encoding", "gzip");
       connection.setRequestProperty("Connection", "close");
 
@@ -439,7 +439,7 @@ final class PeerImpl implements Peer {
       String newAnnouncedAddress = Convert.emptyToNull(JSON.getAsString(response.get("announcedAddress")));
       int port = this.port.get();
       if(port < 0)
-        port = Burst.getPropertyService().getInt(Props.P2P_PORT);
+        port = Signum.getPropertyService().getInt(Props.P2P_PORT);
       if (newAnnouncedAddress != null && ! newAnnouncedAddress.equals(announcedAddress.get())
           && !newAnnouncedAddress.equals(announcedAddress.get() + ":" + port)) {
         // force verification of changed announced address

--- a/src/brs/peer/ProcessBlock.java
+++ b/src/brs/peer/ProcessBlock.java
@@ -2,7 +2,7 @@ package brs.peer;
 
 import brs.Blockchain;
 import brs.BlockchainProcessor;
-import brs.BurstException;
+import brs.SignumException;
 import brs.util.JSON;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -44,7 +44,7 @@ public final class ProcessBlock implements PeerServlet.PeerRequestHandler {
       blockchainProcessor.processPeerBlock(request, peer);
       return ACCEPTED;
 
-    } catch (BurstException|RuntimeException e) {
+    } catch (SignumException|RuntimeException e) {
       if (peer != null) {
         peer.blacklist(e, "received invalid data via requestType=processBlock");
       }

--- a/src/brs/peer/ProcessTransactions.java
+++ b/src/brs/peer/ProcessTransactions.java
@@ -1,6 +1,6 @@
 package brs.peer;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.TransactionProcessor;
 import brs.util.JSON;
 import com.google.gson.JsonElement;
@@ -21,7 +21,7 @@ final class ProcessTransactions implements PeerServlet.PeerRequestHandler {
     try {
       transactionProcessor.processPeerTransactions(request, peer);
       return JSON.emptyJSON;
-    } catch (RuntimeException | BurstException.ValidationException e) {
+    } catch (RuntimeException | SignumException.ValidationException e) {
       peer.blacklist(e, "received invalid data via requestType=processTransactions");
       JsonObject response = new JsonObject();
       response.addProperty("error", e.toString());

--- a/src/brs/props/PropertyServiceImpl.java
+++ b/src/brs/props/PropertyServiceImpl.java
@@ -1,6 +1,6 @@
 package brs.props;
 
-import brs.Burst;
+import brs.Signum;
 import signum.net.NetworkParameters;
 
 import org.slf4j.Logger;
@@ -10,7 +10,7 @@ import java.util.*;
 
 public class PropertyServiceImpl implements PropertyService {
 
-  private final Logger logger = LoggerFactory.getLogger(Burst.class);
+  private final Logger logger = LoggerFactory.getLogger(Signum.class);
   private static final String LOG_UNDEF_NAME_DEFAULT = "{} using default: >{}<";
 
   private final Properties properties;

--- a/src/brs/props/Props.java
+++ b/src/brs/props/Props.java
@@ -1,14 +1,14 @@
 package brs.props;
 
-import brs.Burst;
+import brs.Signum;
 import brs.Constants;
 import brs.Genesis;
 import brs.util.Convert;
 
 public class Props {
 
-  public static final Prop<String> APPLICATION = new Prop<>("node.application", Burst.APPLICATION);
-  public static final Prop<String> VERSION = new Prop<>("node.version", Burst.VERSION.toString());
+  public static final Prop<String> APPLICATION = new Prop<>("node.application", Signum.APPLICATION);
+  public static final Prop<String> VERSION = new Prop<>("node.version", Signum.VERSION.toString());
 
   // Structural parameters
   public static final Prop<Integer> BLOCK_TIME = new Prop<>("node.blockTime", 240);

--- a/src/brs/services/ParameterService.java
+++ b/src/brs/services/ParameterService.java
@@ -10,9 +10,9 @@ import java.util.List;
 
 public interface ParameterService {
 
-  Account getAccount(HttpServletRequest req) throws BurstException;
+  Account getAccount(HttpServletRequest req) throws SignumException;
 
-  Account getAccount(HttpServletRequest req, boolean checkPresent) throws BurstException;
+  Account getAccount(HttpServletRequest req, boolean checkPresent) throws SignumException;
 
   List<Account> getAccounts(HttpServletRequest req) throws ParameterException;
 

--- a/src/brs/services/TransactionService.java
+++ b/src/brs/services/TransactionService.java
@@ -1,13 +1,13 @@
 package brs.services;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.Transaction;
 
 public interface TransactionService {
 
   boolean verifyPublicKey(Transaction transaction);
 
-  void validate(Transaction transaction) throws BurstException.ValidationException;
+  void validate(Transaction transaction) throws SignumException.ValidationException;
   
   void startNewBlock();
 

--- a/src/brs/services/impl/AccountServiceImpl.java
+++ b/src/brs/services/impl/AccountServiceImpl.java
@@ -8,9 +8,9 @@ import brs.AssetTransfer;
 import brs.Signum;
 import brs.Constants;
 import brs.crypto.Crypto;
-import brs.db.BurstKey;
-import brs.db.BurstKey.LinkKeyFactory;
-import brs.db.BurstKey.LongKeyFactory;
+import brs.db.SignumKey;
+import brs.db.SignumKey.LinkKeyFactory;
+import brs.db.SignumKey.LongKeyFactory;
 import brs.db.VersionedBatchEntityTable;
 import brs.db.VersionedEntityTable;
 import brs.db.store.AccountStore;
@@ -190,7 +190,7 @@ public class AccountServiceImpl implements AccountService {
     }
     AccountAsset accountAsset;
 
-    BurstKey newKey = accountAssetKeyFactory.newKey(account.getId(), assetId);
+    SignumKey newKey = accountAssetKeyFactory.newKey(account.getId(), assetId);
     accountAsset = accountAssetTable.get(newKey);
     long assetBalance = accountAsset == null ? 0 : accountAsset.getQuantityQNT();
     assetBalance = Convert.safeAdd(assetBalance, quantityQNT);
@@ -210,7 +210,7 @@ public class AccountServiceImpl implements AccountService {
       return;
     }
     AccountAsset accountAsset;
-    BurstKey newKey = accountAssetKeyFactory.newKey(account.getId(), assetId);
+    SignumKey newKey = accountAssetKeyFactory.newKey(account.getId(), assetId);
     accountAsset = accountAssetTable.get(newKey);
     long unconfirmedAssetBalance = accountAsset == null ? 0 : accountAsset.getUnconfirmedQuantityQNT();
     unconfirmedAssetBalance = Convert.safeAdd(unconfirmedAssetBalance, quantityQNT);
@@ -230,7 +230,7 @@ public class AccountServiceImpl implements AccountService {
       return;
     }
     AccountAsset accountAsset;
-    BurstKey newKey = accountAssetKeyFactory.newKey(account.getId(), assetId);
+    SignumKey newKey = accountAssetKeyFactory.newKey(account.getId(), assetId);
     accountAsset = accountAssetTable.get(newKey);
     long assetBalance = accountAsset == null ? 0 : accountAsset.getQuantityQNT();
     assetBalance = Convert.safeAdd(assetBalance, quantityQNT);
@@ -304,7 +304,7 @@ public class AccountServiceImpl implements AccountService {
     int currentHeight = Signum.getBlockchain().getLastBlock().getHeight();
     RewardRecipientAssignment assignment = getRewardRecipientAssignment(account.getId());
     if (assignment == null) {
-      BurstKey burstKey = rewardRecipientAssignmentKeyFactory.newKey(account.getId());
+      SignumKey burstKey = rewardRecipientAssignmentKeyFactory.newKey(account.getId());
       assignment = new RewardRecipientAssignment(account.getId(), account.getId(), recipient, (int) (currentHeight + Constants.BURST_REWARD_RECIPIENT_ASSIGNMENT_WAIT_TIME), burstKey);
     } else {
       assignment.setRecipient(recipient, (int) (currentHeight + Constants.BURST_REWARD_RECIPIENT_ASSIGNMENT_WAIT_TIME));
@@ -314,7 +314,7 @@ public class AccountServiceImpl implements AccountService {
 
   @Override
   public long getUnconfirmedAssetBalanceQNT(Account account, long assetId) {
-    BurstKey newKey = Signum.getStores().getAccountStore().getAccountAssetKeyFactory().newKey(account.getId(), assetId);
+    SignumKey newKey = Signum.getStores().getAccountStore().getAccountAssetKeyFactory().newKey(account.getId(), assetId);
     AccountAsset accountAsset = accountAssetTable.get(newKey);
     return accountAsset == null ? 0 : accountAsset.getUnconfirmedQuantityQNT();
   }

--- a/src/brs/services/impl/AccountServiceImpl.java
+++ b/src/brs/services/impl/AccountServiceImpl.java
@@ -5,7 +5,7 @@ import brs.Account.AccountAsset;
 import brs.Account.Event;
 import brs.Account.RewardRecipientAssignment;
 import brs.AssetTransfer;
-import brs.Burst;
+import brs.Signum;
 import brs.Constants;
 import brs.crypto.Crypto;
 import brs.db.BurstKey;
@@ -301,7 +301,7 @@ public class AccountServiceImpl implements AccountService {
 
   @Override
   public void setRewardRecipientAssignment(Account account, Long recipient) {
-    int currentHeight = Burst.getBlockchain().getLastBlock().getHeight();
+    int currentHeight = Signum.getBlockchain().getLastBlock().getHeight();
     RewardRecipientAssignment assignment = getRewardRecipientAssignment(account.getId());
     if (assignment == null) {
       BurstKey burstKey = rewardRecipientAssignmentKeyFactory.newKey(account.getId());
@@ -314,7 +314,7 @@ public class AccountServiceImpl implements AccountService {
 
   @Override
   public long getUnconfirmedAssetBalanceQNT(Account account, long assetId) {
-    BurstKey newKey = Burst.getStores().getAccountStore().getAccountAssetKeyFactory().newKey(account.getId(), assetId);
+    BurstKey newKey = Signum.getStores().getAccountStore().getAccountAssetKeyFactory().newKey(account.getId(), assetId);
     AccountAsset accountAsset = accountAssetTable.get(newKey);
     return accountAsset == null ? 0 : accountAsset.getUnconfirmedQuantityQNT();
   }

--- a/src/brs/services/impl/AccountServiceImpl.java
+++ b/src/brs/services/impl/AccountServiceImpl.java
@@ -31,8 +31,8 @@ public class AccountServiceImpl implements AccountService {
   private final AccountStore accountStore;
   private final VersionedBatchEntityTable<Account> accountTable;
   private final VersionedBatchEntityTable<Account.Balance> accountBalanceTable;
-  private final LongKeyFactory<Account> accountBurstKeyFactory;
-  private final LongKeyFactory<Account.Balance> accountBalanceBurstKeyFactory;
+  private final LongKeyFactory<Account> accountSignumKeyFactory;
+  private final LongKeyFactory<Account.Balance> accountBalanceSignumKeyFactory;
   private final VersionedEntityTable<AccountAsset> accountAssetTable;
   private final LinkKeyFactory<AccountAsset> accountAssetKeyFactory;
   private final VersionedEntityTable<RewardRecipientAssignment> rewardRecipientAssignmentTable;
@@ -47,8 +47,8 @@ public class AccountServiceImpl implements AccountService {
     this.accountStore = accountStore;
     this.accountTable = accountStore.getAccountTable();
     this.accountBalanceTable = accountStore.getAccountBalanceTable();
-    this.accountBurstKeyFactory = accountStore.getAccountKeyFactory();
-    this.accountBalanceBurstKeyFactory = accountStore.getAccountBalanceKeyFactory();
+    this.accountSignumKeyFactory = accountStore.getAccountKeyFactory();
+    this.accountBalanceSignumKeyFactory = accountStore.getAccountBalanceKeyFactory();
     this.assetTransferStore = assetTransferStore;
     this.accountAssetTable = accountStore.getAccountAssetTable();
     this.accountAssetKeyFactory = accountStore.getAccountAssetKeyFactory();
@@ -68,12 +68,12 @@ public class AccountServiceImpl implements AccountService {
 
   @Override
   public Account getAccount(long id) {
-    return id == 0 ? null : accountTable.get(accountBurstKeyFactory.newKey(id));
+    return id == 0 ? null : accountTable.get(accountSignumKeyFactory.newKey(id));
   }
 
   @Override
   public Account.Balance getAccountBalance(long id) {
-    Account.Balance account = accountBalanceTable.get(accountBalanceBurstKeyFactory.newKey(id));
+    Account.Balance account = accountBalanceTable.get(accountBalanceSignumKeyFactory.newKey(id));
     if(account == null){
       account = new Account.Balance(id);
     }
@@ -82,17 +82,17 @@ public class AccountServiceImpl implements AccountService {
 
   @Override
   public Account getNullAccount() {
-    return accountTable.get(accountBurstKeyFactory.newKey(0L));
+    return accountTable.get(accountSignumKeyFactory.newKey(0L));
   }
 
   @Override
   public Account getAccount(long id, int height) {
-    return id == 0 ? null : accountTable.get(accountBurstKeyFactory.newKey(id), height);
+    return id == 0 ? null : accountTable.get(accountSignumKeyFactory.newKey(id), height);
   }
 
   @Override
   public Account getAccount(byte[] publicKey) {
-    final Account account = accountTable.get(accountBurstKeyFactory.newKey(getId(publicKey)));
+    final Account account = accountTable.get(accountSignumKeyFactory.newKey(getId(publicKey)));
 
     if (account == null) {
       return null;
@@ -138,7 +138,7 @@ public class AccountServiceImpl implements AccountService {
 
   @Override
   public Account getOrAddAccount(long id) {
-    Account account = accountTable.get(accountBurstKeyFactory.newKey(id));
+    Account account = accountTable.get(accountSignumKeyFactory.newKey(id));
     if (account == null) {
       account = new Account(id);
       accountTable.insert(account);
@@ -304,10 +304,10 @@ public class AccountServiceImpl implements AccountService {
     int currentHeight = Signum.getBlockchain().getLastBlock().getHeight();
     RewardRecipientAssignment assignment = getRewardRecipientAssignment(account.getId());
     if (assignment == null) {
-      SignumKey burstKey = rewardRecipientAssignmentKeyFactory.newKey(account.getId());
-      assignment = new RewardRecipientAssignment(account.getId(), account.getId(), recipient, (int) (currentHeight + Constants.BURST_REWARD_RECIPIENT_ASSIGNMENT_WAIT_TIME), burstKey);
+      SignumKey signumKey = rewardRecipientAssignmentKeyFactory.newKey(account.getId());
+      assignment = new RewardRecipientAssignment(account.getId(), account.getId(), recipient, (int) (currentHeight + Constants.SIGNA_REWARD_RECIPIENT_ASSIGNMENT_WAIT_TIME), signumKey);
     } else {
-      assignment.setRecipient(recipient, (int) (currentHeight + Constants.BURST_REWARD_RECIPIENT_ASSIGNMENT_WAIT_TIME));
+      assignment.setRecipient(recipient, (int) (currentHeight + Constants.SIGNA_REWARD_RECIPIENT_ASSIGNMENT_WAIT_TIME));
     }
     rewardRecipientAssignmentTable.insert(assignment);
   }

--- a/src/brs/services/impl/AliasServiceImpl.java
+++ b/src/brs/services/impl/AliasServiceImpl.java
@@ -16,7 +16,7 @@ import brs.Signum;
 import brs.Subscription;
 import brs.Transaction;
 import brs.TransactionType;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.VersionedEntityTable;
 import brs.db.sql.Db;
 import brs.db.store.AliasStore;
@@ -31,9 +31,9 @@ public class AliasServiceImpl implements AliasService {
 
   private final AliasStore aliasStore;
   private final VersionedEntityTable<Alias> aliasTable;
-  private final BurstKey.LongKeyFactory<Alias> aliasDbKeyFactory;
+  private final SignumKey.LongKeyFactory<Alias> aliasDbKeyFactory;
   private final VersionedEntityTable<Offer> offerTable;
-  private final BurstKey.LongKeyFactory<Offer> offerDbKeyFactory;
+  private final SignumKey.LongKeyFactory<Offer> offerDbKeyFactory;
 
   private static final String MAIN_TLD = "signum";
   private static final String[] DEFAULT_TLDS = {
@@ -165,7 +165,7 @@ public class AliasServiceImpl implements AliasService {
   public void addOrUpdateAlias(Transaction transaction, Attachment.MessagingAliasAssignment attachment) {
     Alias alias = getAlias(attachment.getAliasName(), attachment.getTLD());
     if (alias == null) {
-      BurstKey aliasDBId = aliasDbKeyFactory.newKey(transaction.getId());
+      SignumKey aliasDBId = aliasDbKeyFactory.newKey(transaction.getId());
       alias = new Alias(transaction.getId(), aliasDBId, transaction, attachment);
     } else {
       alias.setAccountId(transaction.getSenderId());
@@ -179,7 +179,7 @@ public class AliasServiceImpl implements AliasService {
 
   @Override
   public void addTLD(long id, Transaction transaction, Attachment.MessagingTLDAssignment attachment) {
-    BurstKey aliasDBId = aliasDbKeyFactory.newKey(id);
+    SignumKey aliasDBId = aliasDbKeyFactory.newKey(id);
     Alias alias = new Alias(id, aliasDBId, transaction, attachment);
     aliasTable.insert(alias);
   }
@@ -192,7 +192,7 @@ public class AliasServiceImpl implements AliasService {
     if (priceNQT > 0) {
       Offer offer = getOffer(alias);
       if (offer == null) {
-        BurstKey dbKey = offerDbKeyFactory.newKey(alias.getId());
+        SignumKey dbKey = offerDbKeyFactory.newKey(alias.getId());
         offerTable.insert(new Offer(dbKey, alias.getId(), priceNQT, buyerId));
       } else {
         offer.setPriceNQT(priceNQT);

--- a/src/brs/services/impl/AliasServiceImpl.java
+++ b/src/brs/services/impl/AliasServiceImpl.java
@@ -12,7 +12,7 @@ import brs.Account;
 import brs.Alias;
 import brs.Alias.Offer;
 import brs.Attachment;
-import brs.Burst;
+import brs.Signum;
 import brs.Subscription;
 import brs.Transaction;
 import brs.TransactionType;
@@ -50,7 +50,7 @@ public class AliasServiceImpl implements AliasService {
 
   public void addDefaultTLDs() {
     try {
-      Burst.getStores().beginTransaction();
+      Signum.getStores().beginTransaction();
 
       // TODO: should be removed prior to the next release
 //      try {
@@ -80,10 +80,10 @@ public class AliasServiceImpl implements AliasService {
         Attachment.MessagingTLDAssignment attachment = new Attachment.MessagingTLDAssignment(tldName, 0);
         addTLD(id, null, attachment);
       }
-      Burst.getStores().commitTransaction();
+      Signum.getStores().commitTransaction();
     }
     finally {
-      Burst.getStores().endTransaction();
+      Signum.getStores().endTransaction();
     }
   }
 
@@ -142,19 +142,19 @@ public class AliasServiceImpl implements AliasService {
   }
 
   private void createSubscription(Alias alias, int timestamp, boolean updateSubscription){
-    if(!Burst.getFluxCapacitor().getValue(FluxValues.SMART_ALIASES)) {
+    if(!Signum.getFluxCapacitor().getValue(FluxValues.SMART_ALIASES)) {
       return;
     }
 
-    SubscriptionService subscriptionService = Burst.getSubscriptionService();
-    int frequency = Burst.getPropertyService().getInt(Props.ALIAS_RENEWAL_FREQUENCY);
-    long fee = Burst.getFluxCapacitor().getValue(FluxValues.FEE_QUANT) * TransactionType.BASELINE_ALIAS_RENEWAL_FACTOR;
+    SubscriptionService subscriptionService = Signum.getSubscriptionService();
+    int frequency = Signum.getPropertyService().getInt(Props.ALIAS_RENEWAL_FREQUENCY);
+    long fee = Signum.getFluxCapacitor().getValue(FluxValues.FEE_QUANT) * TransactionType.BASELINE_ALIAS_RENEWAL_FACTOR;
     Subscription subscription = subscriptionService.getSubscription(alias.getId());
     if(subscription != null && updateSubscription && subscription.getSenderId() != alias.getAccountId()) {
       subscription.setSenderId(alias.getAccountId());
       ArrayList<Subscription> subscriptions = new ArrayList<>();
       subscriptions.add(subscription);
-      Burst.getStores().getSubscriptionStore().saveSubscriptions(subscriptions);
+      Signum.getStores().getSubscriptionStore().saveSubscriptions(subscriptions);
     }
     if(subscription == null) {
       subscriptionService.addSubscription(Account.getAccount(alias.getAccountId()), alias.getId(), alias.getId(), fee, timestamp, frequency);

--- a/src/brs/services/impl/BlockServiceImpl.java
+++ b/src/brs/services/impl/BlockServiceImpl.java
@@ -272,7 +272,7 @@ public class BlockServiceImpl implements BlockService {
     } else if (block.getHeight() < 4) {
       block.setBaseTarget(Constants.INITIAL_BASE_TARGET);
       block.setCumulativeDifficulty(previousBlock.getCumulativeDifficulty().add(Convert.two64.divide(BigInteger.valueOf(Constants.INITIAL_BASE_TARGET))));
-    } else if (block.getHeight() < Constants.BURST_DIFF_ADJUST_CHANGE_BLOCK && !Signum.getFluxCapacitor().getValue(FluxValues.SODIUM)) {
+    } else if (block.getHeight() < Constants.SIGNUM_DIFF_ADJUST_CHANGE_BLOCK && !Signum.getFluxCapacitor().getValue(FluxValues.SODIUM)) {
       Block itBlock = previousBlock;
       BigInteger avgBaseTarget = BigInteger.valueOf(itBlock.getBaseTarget());
       do {

--- a/src/brs/services/impl/BlockServiceImpl.java
+++ b/src/brs/services/impl/BlockServiceImpl.java
@@ -62,8 +62,8 @@ public class BlockServiceImpl implements BlockService {
       byte[] publicKey = block.getGeneratorPublicKey();
       Account account = accountService.getAccount(publicKey);
       if(account != null) {
-        if(Burst.getFluxCapacitor().getValue(FluxValues.PK_FREEZE2) && account.getPublicKey() == null
-          && Burst.getBlockchain().getHeight() - account.getCreationHeight() > Burst.getPropertyService().getInt(Props.PK_BLOCKS_PAST)) {
+        if(Signum.getFluxCapacitor().getValue(FluxValues.PK_FREEZE2) && account.getPublicKey() == null
+          && Signum.getBlockchain().getHeight() - account.getCreationHeight() > Signum.getPropertyService().getInt(Props.PK_BLOCKS_PAST)) {
           logger.error("Setting a new key for an old inactivated account");
           return false;
         }
@@ -148,7 +148,7 @@ public class BlockServiceImpl implements BlockService {
       return;
     }
 
-    int checkPointHeight = Burst.getPropertyService().getInt(Props.BRS_CHECKPOINT_HEIGHT);
+    int checkPointHeight = Signum.getPropertyService().getInt(Props.BRS_CHECKPOINT_HEIGHT);
     try {
       if(block.getHeight() < checkPointHeight) {
         // do not verify the nonce up to the checkpoint block
@@ -156,7 +156,7 @@ public class BlockServiceImpl implements BlockService {
       }
       else {
     	if(block.getHeight() == checkPointHeight) {
-       	    String checkPointHash = Burst.getPropertyService().getString(Props.BRS_CHECKPOINT_HASH);
+       	    String checkPointHash = Signum.getPropertyService().getString(Props.BRS_CHECKPOINT_HASH);
 
        	    String receivedHash = Hex.toHexString(block.getPreviousBlockHash());
     		if(!receivedHash.equals(checkPointHash)) {
@@ -210,14 +210,14 @@ public class BlockServiceImpl implements BlockService {
         }
       }
     }
-    if (!Burst.getFluxCapacitor().getValue(FluxValues.REWARD_RECIPIENT_ENABLE)) {
+    if (!Signum.getFluxCapacitor().getValue(FluxValues.REWARD_RECIPIENT_ENABLE)) {
       accountService.addToBalanceAndUnconfirmedBalanceNQT(generatorAccount, block.getTotalFeeNQT() + blockReward);
       accountService.addToForgedBalanceNQT(generatorAccount, block.getTotalFeeNQT() + blockReward);
     } else {
       Account rewardAccount = getRewardAccount(block);
 
       long rewardFeesNQT = block.getTotalFeeNQT();
-      if (Burst.getFluxCapacitor().getValue(FluxValues.SMART_FEES)) {
+      if (Signum.getFluxCapacitor().getValue(FluxValues.SMART_FEES)) {
         rewardFeesNQT -= block.getTotalFeeCashBackNQT();
         rewardFeesNQT -= block.getTotalFeeBurntNQT();
 
@@ -264,15 +264,15 @@ public class BlockServiceImpl implements BlockService {
 
   @Override
   public void calculateBaseTarget(Block block, Block previousBlock) throws BlockOutOfOrderException {
-    long blockTime = Burst.getFluxCapacitor().getValue(FluxValues.BLOCK_TIME);
+    long blockTime = Signum.getFluxCapacitor().getValue(FluxValues.BLOCK_TIME);
 
-    if (block.getPreviousBlockId() == 0 && block.getId() == Convert.parseUnsignedLong(Burst.getPropertyService().getString(Props.GENESIS_BLOCK_ID)) ) {
+    if (block.getPreviousBlockId() == 0 && block.getId() == Convert.parseUnsignedLong(Signum.getPropertyService().getString(Props.GENESIS_BLOCK_ID)) ) {
       block.setBaseTarget(Constants.INITIAL_BASE_TARGET);
       block.setCumulativeDifficulty(BigInteger.ZERO);
     } else if (block.getHeight() < 4) {
       block.setBaseTarget(Constants.INITIAL_BASE_TARGET);
       block.setCumulativeDifficulty(previousBlock.getCumulativeDifficulty().add(Convert.two64.divide(BigInteger.valueOf(Constants.INITIAL_BASE_TARGET))));
-    } else if (block.getHeight() < Constants.BURST_DIFF_ADJUST_CHANGE_BLOCK && !Burst.getFluxCapacitor().getValue(FluxValues.SODIUM)) {
+    } else if (block.getHeight() < Constants.BURST_DIFF_ADJUST_CHANGE_BLOCK && !Signum.getFluxCapacitor().getValue(FluxValues.SODIUM)) {
       Block itBlock = previousBlock;
       BigInteger avgBaseTarget = BigInteger.valueOf(itBlock.getBaseTarget());
       do {
@@ -356,13 +356,13 @@ public class BlockServiceImpl implements BlockService {
       block.setBaseTarget(newBaseTarget);
       BigInteger difficulty = Convert.two64.divide(BigInteger.valueOf(newBaseTarget));
 
-      if(Burst.getFluxCapacitor().getValue(FluxValues.POC_PLUS, block.getHeight())) {
+      if(Signum.getFluxCapacitor().getValue(FluxValues.POC_PLUS, block.getHeight())) {
         block.setCommitment(generator.estimateCommitment(block.getGeneratorId(), previousBlock));
 
         // update the average commitment based on a moving average filter
         long curCommitment = previousBlock.getAverageCommitment();
 
-        long avgCommitmentWindow = Burst.getFluxCapacitor().getValue(FluxValues.AVERAGE_COMMITMENT_WINDOW, block.getHeight());
+        long avgCommitmentWindow = Signum.getFluxCapacitor().getValue(FluxValues.AVERAGE_COMMITMENT_WINDOW, block.getHeight());
         long newAvgCommitment = (curCommitment*(avgCommitmentWindow - 1L) + block.getCommitment())/avgCommitmentWindow;
 
         // avoid changing more than 20% in a single block
@@ -374,7 +374,7 @@ public class BlockServiceImpl implements BlockService {
         }
 
         // assuming a minimum value of 1 coin
-        newAvgCommitment = Math.max(newAvgCommitment, Burst.getPropertyService().getInt(Props.ONE_COIN_NQT));
+        newAvgCommitment = Math.max(newAvgCommitment, Signum.getPropertyService().getInt(Props.ONE_COIN_NQT));
         block.setBaseTarget(newBaseTarget, newAvgCommitment);
 
         if(block.getPeer()!=null && peerBaseTarget != 0L && peerBaseTarget != block.getBaseTarget()) {
@@ -392,7 +392,7 @@ public class BlockServiceImpl implements BlockService {
         Block pastBlock = blockchain.getBlockAtHeight(pastBlockHeight);
 
         long pastAverageCommitment = pastBlock.getAverageCommitment();
-        if(Burst.getFluxCapacitor().getValue(FluxValues.SPEEDWAY, block.getHeight())) {
+        if(Signum.getFluxCapacitor().getValue(FluxValues.SPEEDWAY, block.getHeight())) {
           // use the average from past and now to get a smoother result
           pastAverageCommitment = (pastAverageCommitment + block.getAverageCommitment())/2;
         }

--- a/src/brs/services/impl/DGSGoodsStoreServiceImpl.java
+++ b/src/brs/services/impl/DGSGoodsStoreServiceImpl.java
@@ -5,8 +5,8 @@ import brs.DigitalGoodsStore.Event;
 import brs.DigitalGoodsStore.Goods;
 import brs.DigitalGoodsStore.Purchase;
 import brs.crypto.EncryptedData;
-import brs.db.BurstKey;
-import brs.db.BurstKey.LongKeyFactory;
+import brs.db.SignumKey;
+import brs.db.SignumKey.LongKeyFactory;
 import brs.db.VersionedEntityTable;
 import brs.db.VersionedValuesTable;
 import brs.db.store.DigitalGoodsStoreStore;
@@ -155,7 +155,7 @@ public class DGSGoodsStoreServiceImpl implements DGSGoodsStoreService {
 
   @Override
   public void listGoods(Transaction transaction, Attachment.DigitalGoodsListing attachment) {
-    BurstKey dbKey = goodsDbKeyFactory.newKey(transaction.getId());
+    SignumKey dbKey = goodsDbKeyFactory.newKey(transaction.getId());
     Goods goods = new Goods(dbKey, transaction, attachment);
     goodsTable.insert(goods);
     goodsListeners.notify(goods, Event.GOODS_LISTED);

--- a/src/brs/services/impl/EscrowServiceImpl.java
+++ b/src/brs/services/impl/EscrowServiceImpl.java
@@ -60,7 +60,7 @@ public class EscrowServiceImpl implements EscrowService {
 
   @Override
   public boolean isEnabled() {
-    if(blockchain.getLastBlock().getHeight() >= Constants.BURST_ESCROW_START_BLOCK) {
+    if(blockchain.getLastBlock().getHeight() >= Constants.SIGNUM_ESCROW_START_BLOCK) {
       return true;
     }
 

--- a/src/brs/services/impl/EscrowServiceImpl.java
+++ b/src/brs/services/impl/EscrowServiceImpl.java
@@ -244,7 +244,7 @@ public class EscrowServiceImpl implements EscrowService {
     try {
       transaction = builder.build();
     }
-    catch(BurstException.NotValidException e) {
+    catch(SignumException.NotValidException e) {
       throw new RuntimeException(e.toString(), e);
     }
 

--- a/src/brs/services/impl/EscrowServiceImpl.java
+++ b/src/brs/services/impl/EscrowServiceImpl.java
@@ -3,8 +3,8 @@ package brs.services.impl;
 import brs.*;
 import brs.Escrow.Decision;
 import brs.Escrow.DecisionType;
-import brs.db.BurstKey;
-import brs.db.BurstKey.LongKeyFactory;
+import brs.db.SignumKey;
+import brs.db.SignumKey.LongKeyFactory;
 import brs.db.VersionedEntityTable;
 import brs.db.sql.DbKey.LinkKeyFactory;
 import brs.db.store.EscrowStore;
@@ -81,17 +81,17 @@ public class EscrowServiceImpl implements EscrowService {
 
   @Override
   public void addEscrowTransaction(Account sender, Account recipient, Long id, Long amountNQT, int requiredSigners, Collection<Long> signers, int deadline, DecisionType deadlineAction) {
-    final BurstKey dbKey = escrowDbKeyFactory.newKey(id);
+    final SignumKey dbKey = escrowDbKeyFactory.newKey(id);
     Escrow newEscrowTransaction = new Escrow(dbKey, sender, recipient, id, amountNQT, requiredSigners, deadline, deadlineAction);
     escrowTable.insert(newEscrowTransaction);
-    BurstKey senderDbKey = decisionDbKeyFactory.newKey(id, sender.getId());
+    SignumKey senderDbKey = decisionDbKeyFactory.newKey(id, sender.getId());
     Decision senderDecision = new Decision(senderDbKey, id, sender.getId(), DecisionType.UNDECIDED);
     decisionTable.insert(senderDecision);
-    BurstKey recipientDbKey = decisionDbKeyFactory.newKey(id, recipient.getId());
+    SignumKey recipientDbKey = decisionDbKeyFactory.newKey(id, recipient.getId());
     Decision recipientDecision = new Decision(recipientDbKey, id, recipient.getId(), DecisionType.UNDECIDED);
     decisionTable.insert(recipientDecision);
     for(Long signer : signers) {
-      BurstKey signerDbKey = decisionDbKeyFactory.newKey(id, signer);
+      SignumKey signerDbKey = decisionDbKeyFactory.newKey(id, signer);
       Decision decision = new Decision(signerDbKey, id, signer, DecisionType.UNDECIDED);
       decisionTable.insert(decision);
     }

--- a/src/brs/services/impl/EscrowServiceImpl.java
+++ b/src/brs/services/impl/EscrowServiceImpl.java
@@ -133,7 +133,7 @@ public class EscrowServiceImpl implements EscrowService {
     int countRefund = 0;
     int countSplit = 0;
 
-    for (Decision decision : Burst.getStores().getEscrowStore().getDecisions(escrow.getId())) {
+    for (Decision decision : Signum.getStores().getEscrowStore().getDecisions(escrow.getId())) {
       if(decision.getAccountId().equals(escrow.getSenderId()) ||
           decision.getAccountId().equals(escrow.getRecipientId())) {
         continue;
@@ -193,7 +193,7 @@ public class EscrowServiceImpl implements EscrowService {
         }
       }
       if (!resultTransactions.isEmpty()) {
-        Burst.getDbs().getTransactionDb().saveTransactions( resultTransactions);
+        Signum.getDbs().getTransactionDb().saveTransactions( resultTransactions);
       }
       updatedEscrowIds.clear();
     }
@@ -248,7 +248,7 @@ public class EscrowServiceImpl implements EscrowService {
       throw new RuntimeException(e.toString(), e);
     }
 
-    if(!Burst.getDbs().getTransactionDb().hasTransaction(transaction.getId())) {
+    if(!Signum.getDbs().getTransactionDb().hasTransaction(transaction.getId())) {
       resultTransactions.add(transaction);
     }
   }

--- a/src/brs/services/impl/ParameterServiceImpl.java
+++ b/src/brs/services/impl/ParameterServiceImpl.java
@@ -53,12 +53,12 @@ public class ParameterServiceImpl implements ParameterService {
   }
 
   @Override
-  public Account getAccount(HttpServletRequest req) throws BurstException {
+  public Account getAccount(HttpServletRequest req) throws SignumException {
     return getAccount(req, true);
   }
 
   @Override
-  public Account getAccount(HttpServletRequest req, boolean checkPresent) throws BurstException {
+  public Account getAccount(HttpServletRequest req, boolean checkPresent) throws SignumException {
     String accountId = Convert.emptyToNull(req.getParameter(ACCOUNT_PARAMETER));
     String heightValue = Convert.emptyToNull(req.getParameter(HEIGHT_PARAMETER));
     if (accountId == null && !checkPresent) {
@@ -362,7 +362,7 @@ public class ParameterServiceImpl implements ParameterService {
       try {
         byte[] bytes = Convert.parseHexString(transactionBytes);
         return transactionProcessor.parseTransaction(bytes);
-      } catch (BurstException.ValidationException | RuntimeException e) {
+      } catch (SignumException.ValidationException | RuntimeException e) {
           logger.debug(e.getMessage(), e); // TODO remove?
         JsonObject response = new JsonObject();
         response.addProperty(ERROR_CODE_RESPONSE, 4);
@@ -373,7 +373,7 @@ public class ParameterServiceImpl implements ParameterService {
       try {
         JsonObject json = JSON.getAsJsonObject(JSON.parse(transactionJSON));
         return transactionProcessor.parseTransaction(json);
-      } catch (BurstException.ValidationException | RuntimeException e) {
+      } catch (SignumException.ValidationException | RuntimeException e) {
         logger.debug(e.getMessage(), e);
         JsonObject response = new JsonObject();
         response.addProperty(ERROR_CODE_RESPONSE, 4);

--- a/src/brs/services/impl/SubscriptionServiceImpl.java
+++ b/src/brs/services/impl/SubscriptionServiceImpl.java
@@ -71,7 +71,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
 
   @Override
   public boolean isEnabled() {
-    if (blockchain.getLastBlock().getHeight() >= Constants.BURST_SUBSCRIPTION_START_BLOCK) {
+    if (blockchain.getLastBlock().getHeight() >= Constants.SIGNUM_SUBSCRIPTION_START_BLOCK) {
       return true;
     }
 
@@ -101,7 +101,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
   private long getFee(int height) {
 	if (Signum.getFluxCapacitor().getValue(FluxValues.SODIUM, height))
 	  return Signum.getFluxCapacitor().getValue(FluxValues.FEE_QUANT, height);
-    return Constants.ONE_BURST;
+    return Constants.ONE_SIGNA;
   }
 
   @Override

--- a/src/brs/services/impl/SubscriptionServiceImpl.java
+++ b/src/brs/services/impl/SubscriptionServiceImpl.java
@@ -99,8 +99,8 @@ public class SubscriptionServiceImpl implements SubscriptionService {
   }
 
   private long getFee(int height) {
-	if (Burst.getFluxCapacitor().getValue(FluxValues.SODIUM, height))
-	  return Burst.getFluxCapacitor().getValue(FluxValues.FEE_QUANT, height);
+	if (Signum.getFluxCapacitor().getValue(FluxValues.SODIUM, height))
+	  return Signum.getFluxCapacitor().getValue(FluxValues.FEE_QUANT, height);
     return Constants.ONE_BURST;
   }
 
@@ -113,9 +113,9 @@ public class SubscriptionServiceImpl implements SubscriptionService {
         if(alias != null && alias.getId() == subscription.getId()) {
           Offer offer = aliasService.getOffer(alias);
           if(offer != null) {
-            Burst.getStores().getAliasStore().getOfferTable().delete(offer);
+            Signum.getStores().getAliasStore().getOfferTable().delete(offer);
           }
-          Burst.getStores().getAliasStore().getAliasTable().delete(alias);
+          Signum.getStores().getAliasStore().getAliasTable().delete(alias);
         }
       }
       subscriptionTable.delete(subscription);
@@ -176,7 +176,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
   }
 
   private Account getRecipient(Subscription subscription) {
-    if(Burst.getFluxCapacitor().getValue(FluxValues.SMART_ALIASES)) {
+    if(Signum.getFluxCapacitor().getValue(FluxValues.SMART_ALIASES)) {
       Alias alias = aliasService.getAlias(subscription.getRecipientId());
       if(alias != null) {
         Alias tld = aliasService.getTLD(alias.getTLD());

--- a/src/brs/services/impl/SubscriptionServiceImpl.java
+++ b/src/brs/services/impl/SubscriptionServiceImpl.java
@@ -3,8 +3,8 @@ package brs.services.impl;
 import brs.*;
 import brs.Alias.Offer;
 import brs.SignumException.NotValidException;
-import brs.db.BurstKey;
-import brs.db.BurstKey.LongKeyFactory;
+import brs.db.SignumKey;
+import brs.db.SignumKey.LongKeyFactory;
 import brs.db.TransactionDb;
 import brs.db.VersionedEntityTable;
 import brs.db.store.SubscriptionStore;
@@ -63,7 +63,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
 
   @Override
   public void addSubscription(Account sender, long recipientId, Long id, Long amountNQT, int startTimestamp, int frequency) {
-    final BurstKey dbKey = subscriptionDbKeyFactory.newKey(id);
+    final SignumKey dbKey = subscriptionDbKeyFactory.newKey(id);
     final Subscription subscription = new Subscription(sender.getId(), recipientId, id, amountNQT, frequency, startTimestamp + frequency, dbKey);
 
     subscriptionTable.insert(subscription);

--- a/src/brs/services/impl/SubscriptionServiceImpl.java
+++ b/src/brs/services/impl/SubscriptionServiceImpl.java
@@ -2,7 +2,7 @@ package brs.services.impl;
 
 import brs.*;
 import brs.Alias.Offer;
-import brs.BurstException.NotValidException;
+import brs.SignumException.NotValidException;
 import brs.db.BurstKey;
 import brs.db.BurstKey.LongKeyFactory;
 import brs.db.TransactionDb;

--- a/src/brs/services/impl/TransactionServiceImpl.java
+++ b/src/brs/services/impl/TransactionServiceImpl.java
@@ -30,13 +30,13 @@ public class TransactionServiceImpl implements TransactionService {
   }
 
   @Override
-  public void validate(Transaction transaction) throws BurstException.ValidationException {
+  public void validate(Transaction transaction) throws SignumException.ValidationException {
     for (Appendix.AbstractAppendix appendage : transaction.getAppendages()) {
       appendage.validate(transaction);
     }
     long minimumFeeNQT = transaction.getType().minimumFeeNQT(blockchain.getHeight(), transaction);
     if (transaction.getFeeNQT() < minimumFeeNQT) {
-      throw new BurstException.NotCurrentlyValidException(String.format("Transaction fee %d less than minimum fee %d at height %d",
+      throw new SignumException.NotCurrentlyValidException(String.format("Transaction fee %d less than minimum fee %d at height %d",
           transaction.getFeeNQT(), minimumFeeNQT, blockchain.getHeight()));
     }
   }

--- a/src/brs/services/impl/TransactionServiceImpl.java
+++ b/src/brs/services/impl/TransactionServiceImpl.java
@@ -48,7 +48,7 @@ public class TransactionServiceImpl implements TransactionService {
 
   @Override
   public boolean applyUnconfirmed(Transaction transaction) {
-    if(transaction.getType() == TransactionType.BurstMining.COMMITMENT_REMOVE) {
+    if(transaction.getType() == TransactionType.SignaMining.COMMITMENT_REMOVE) {
       // we only accept one removal per account per block
       if(accountCommitmentRemovals.get(transaction.getSenderId()) != null)
         return false;

--- a/src/brs/unconfirmedtransactions/ReservedBalanceCache.java
+++ b/src/brs/unconfirmedtransactions/ReservedBalanceCache.java
@@ -2,9 +2,9 @@ package brs.unconfirmedtransactions;
 
 import brs.Account;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Constants;
-import brs.BurstException.ValidationException;
+import brs.SignumException.ValidationException;
 import brs.Transaction;
 import brs.TransactionType;
 import brs.Attachment.CommitmentRemove;
@@ -32,7 +32,7 @@ class ReservedBalanceCache {
     this.reservedBalanceCache = new HashMap<>();
   }
 
-  void reserveBalanceAndPut(Transaction transaction) throws BurstException.ValidationException {
+  void reserveBalanceAndPut(Transaction transaction) throws SignumException.ValidationException {
     Account senderAccount = null;
 
     if (transaction.getSenderId() != 0) {
@@ -50,7 +50,7 @@ class ReservedBalanceCache {
         LOGGER.info(String.format("Transaction %d: Account %d does not exist and has no balance. Required funds: %d", transaction.getId(), transaction.getSenderId(), amountNQT));
       }
 
-      throw new BurstException.NotCurrentlyValidException("Account unknown");
+      throw new SignumException.NotCurrentlyValidException("Account unknown");
     }
 
     if ( amountNQT > senderAccount.getUnconfirmedBalanceNQT() ) {
@@ -58,7 +58,7 @@ class ReservedBalanceCache {
         LOGGER.info("Transaction {} for {}: account {} balance too low. Total required {} > {} balance",
                 Convert.toUnsignedLong(transaction.getId()), thisTransactionAmountNQT, Convert.toUnsignedLong(transaction.getSenderId()), amountNQT, senderAccount.getUnconfirmedBalanceNQT());
       }
-      throw new BurstException.NotCurrentlyValidException("Insufficient funds");
+      throw new SignumException.NotCurrentlyValidException("Insufficient funds");
     }
 
     if(transaction.getType() == TransactionType.BurstMining.COMMITMENT_REMOVE) {
@@ -73,7 +73,7 @@ class ReservedBalanceCache {
           LOGGER.debug("Transaction {}: Account {} commitment remove not allowed. Blocks mined {}, amount commitment {}, amount removing {}",
               transaction.getId(), transaction.getSenderId(), nBlocksMined, amountCommitted, totalAmountNQT);
         }
-        throw new BurstException.NotCurrentlyValidException("Commitment remove not allowed");        
+        throw new SignumException.NotCurrentlyValidException("Commitment remove not allowed");        
       }
     }
 

--- a/src/brs/unconfirmedtransactions/ReservedBalanceCache.java
+++ b/src/brs/unconfirmedtransactions/ReservedBalanceCache.java
@@ -61,7 +61,7 @@ class ReservedBalanceCache {
       throw new SignumException.NotCurrentlyValidException("Insufficient funds");
     }
 
-    if(transaction.getType() == TransactionType.BurstMining.COMMITMENT_REMOVE) {
+    if(transaction.getType() == TransactionType.SignaMining.COMMITMENT_REMOVE) {
       CommitmentRemove commitmentRemove = (CommitmentRemove) transaction.getAttachment();
       long totalAmountNQT = commitmentRemove.getAmountNQT();
 

--- a/src/brs/unconfirmedtransactions/ReservedBalanceCache.java
+++ b/src/brs/unconfirmedtransactions/ReservedBalanceCache.java
@@ -1,7 +1,7 @@
 package brs.unconfirmedtransactions;
 
 import brs.Account;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.Constants;
 import brs.BurstException.ValidationException;
@@ -65,7 +65,7 @@ class ReservedBalanceCache {
       CommitmentRemove commitmentRemove = (CommitmentRemove) transaction.getAttachment();
       long totalAmountNQT = commitmentRemove.getAmountNQT();
 
-      Blockchain blockchain = Burst.getBlockchain();
+      Blockchain blockchain = Signum.getBlockchain();
       int nBlocksMined = blockchain.getBlocksCount(senderAccount.getId(), blockchain.getHeight() - Constants.MAX_ROLLBACK, blockchain.getHeight());
       long amountCommitted = blockchain.getCommittedAmount(senderAccount.getId(), blockchain.getHeight(), blockchain.getHeight(), transaction);
       if (nBlocksMined > 0 || amountCommitted < totalAmountNQT ) {

--- a/src/brs/unconfirmedtransactions/UnconfirmedTransactionStore.java
+++ b/src/brs/unconfirmedtransactions/UnconfirmedTransactionStore.java
@@ -1,6 +1,6 @@
 package brs.unconfirmedtransactions;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.Transaction;
 import brs.peer.Peer;
 
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface UnconfirmedTransactionStore {
 
-  boolean put(Transaction transaction, Peer peer) throws BurstException.ValidationException;
+  boolean put(Transaction transaction, Peer peer) throws SignumException.ValidationException;
 
   Transaction get(Long transactionId);
 

--- a/src/brs/unconfirmedtransactions/UnconfirmedTransactionStoreImpl.java
+++ b/src/brs/unconfirmedtransactions/UnconfirmedTransactionStoreImpl.java
@@ -1,6 +1,6 @@
 package brs.unconfirmedtransactions;
 
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException.ValidationException;
 import brs.Constants;
 import brs.Transaction;
@@ -272,7 +272,7 @@ public class UnconfirmedTransactionStoreImpl implements UnconfirmedTransactionSt
   private boolean tooManyTransactionsForSlotSize(Transaction transaction) {
     final long slotHeight = this.amountSlotForTransaction(transaction);
     long slotUnconfirmedLimit = slotHeight * 360;
-    if(Burst.getFluxCapacitor().getValue(FluxValues.SPEEDWAY, Burst.getBlockchain().getHeight())) {
+    if(Signum.getFluxCapacitor().getValue(FluxValues.SPEEDWAY, Signum.getBlockchain().getHeight())) {
       // Use a higher limit per slot, since most transactions will be on the same slot (first)
       slotUnconfirmedLimit = maxSize/4;
     }
@@ -375,8 +375,8 @@ public class UnconfirmedTransactionStoreImpl implements UnconfirmedTransactionSt
 
 
   private long amountSlotForTransaction(Transaction transaction) {
-    long slot = transaction.getFeeNQT() / Burst.getFluxCapacitor().getValue(FluxValues.FEE_QUANT);
-    if(Burst.getFluxCapacitor().getValue(FluxValues.SPEEDWAY)) {
+    long slot = transaction.getFeeNQT() / Signum.getFluxCapacitor().getValue(FluxValues.FEE_QUANT);
+    if(Signum.getFluxCapacitor().getValue(FluxValues.SPEEDWAY)) {
       // Using the 'slot' now as a priority measure, not exactly as before
       long transactionSize = transaction.getSize() / Constants.ORDINARY_TRANSACTION_BYTES;
       slot /= transactionSize;
@@ -427,9 +427,9 @@ public class UnconfirmedTransactionStoreImpl implements UnconfirmedTransactionSt
     long freeSlot = 1;
 
     long txsPerSlot = 1;
-    if(Burst.getFluxCapacitor().getValue(FluxValues.SPEEDWAY)) {
+    if(Signum.getFluxCapacitor().getValue(FluxValues.SPEEDWAY)) {
       // transactions per slot, we assume transactions can occupy up to 2 times the ordinary size
-      txsPerSlot = Burst.getFluxCapacitor().getValue(FluxValues.MAX_NUMBER_TRANSACTIONS, Burst.getBlockchain().getHeight())/2;
+      txsPerSlot = Signum.getFluxCapacitor().getValue(FluxValues.MAX_NUMBER_TRANSACTIONS, Signum.getBlockchain().getHeight())/2;
     }
 
     synchronized (internalStore) {

--- a/src/brs/unconfirmedtransactions/UnconfirmedTransactionStoreImpl.java
+++ b/src/brs/unconfirmedtransactions/UnconfirmedTransactionStoreImpl.java
@@ -1,7 +1,7 @@
 package brs.unconfirmedtransactions;
 
 import brs.Signum;
-import brs.BurstException.ValidationException;
+import brs.SignumException.ValidationException;
 import brs.Constants;
 import brs.Transaction;
 import brs.db.TransactionDb;

--- a/src/brs/util/BurstLogManager.java
+++ b/src/brs/util/BurstLogManager.java
@@ -6,7 +6,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.LogManager;
 
 /**
- * Java LogManager extension for use with Burst
+ * Java LogManager extension for use with Signum
  */
 class BurstLogManager extends LogManager {
 
@@ -16,7 +16,7 @@ class BurstLogManager extends LogManager {
   private final AtomicBoolean loggingReconfiguration = new AtomicBoolean(false);
 
   /**
-   * Create the Burst log manager
+   * Create the Signum log manager
    *
    * We will let the Java LogManager create its shutdown hook so that the
    * shutdown context will be set up properly.  However, we will intercept
@@ -46,7 +46,7 @@ class BurstLogManager extends LogManager {
    *
    * This method is called to reset the log handlers.  We will forward the
    * call during logging reconfiguration but will ignore it otherwise.
-   * This allows us to continue to use logging facilities during Burst shutdown.
+   * This allows us to continue to use logging facilities during Signum shutdown.
    */
   @Override
   public void reset() {

--- a/src/brs/util/Convert.java
+++ b/src/brs/util/Convert.java
@@ -1,6 +1,6 @@
 package brs.util;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.Constants;
 import signumj.crypto.SignumCrypto;
 import signumj.entity.SignumAddress;
@@ -119,9 +119,9 @@ public final class Convert {
     return (sum == 0);
   }
 
-  public static String readString(ByteBuffer buffer, int numBytes, int maxLength) throws BurstException.NotValidException {
+  public static String readString(ByteBuffer buffer, int numBytes, int maxLength) throws SignumException.NotValidException {
     if (numBytes > 3 * maxLength) {
-      throw new BurstException.NotValidException("Max parameter length exceeded");
+      throw new SignumException.NotValidException("Max parameter length exceeded");
     }
     byte[] bytes = new byte[numBytes];
     buffer.get(bytes);

--- a/src/brs/util/Convert.java
+++ b/src/brs/util/Convert.java
@@ -15,7 +15,7 @@ import java.util.Date;
 
 public final class Convert {
 
-  private static final SignumCrypto burstCrypto = SignumCrypto.getInstance();
+  private static final SignumCrypto signumCrypto = SignumCrypto.getInstance();
 
   private static final long[] multipliers = {1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000};
 
@@ -65,7 +65,7 @@ public final class Convert {
   }
 
   public static long fullHashToId(byte[] hash) {
-    return burstCrypto.hashToId(hash).getSignedLongId();
+    return signumCrypto.hashToId(hash).getSignedLongId();
   }
 
   public static long fullHashToId(String hash) {
@@ -133,7 +133,7 @@ public final class Convert {
   }
 
   public static long parseNXT(String nxt) {
-    return parseStringFraction(nxt, 8, Constants.MAX_BALANCE_BURST);
+    return parseStringFraction(nxt, 8, Constants.MAX_BALANCE_SIGNA);
   }
 
   private static long parseStringFraction(String value, int decimals, long maxValue) {

--- a/src/brs/util/LoggerConfigurator.java
+++ b/src/brs/util/LoggerConfigurator.java
@@ -13,7 +13,7 @@ import java.util.logging.Logger;
 import brs.Signum;
 
 /**
- * Handle logging for the Burst node server
+ * Handle logging for the Signum node server
  */
 
 public final class LoggerConfigurator {

--- a/src/brs/util/LoggerConfigurator.java
+++ b/src/brs/util/LoggerConfigurator.java
@@ -10,7 +10,7 @@ import java.util.Properties;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
-import brs.Burst;
+import brs.Signum;
 
 /**
  * Handle logging for the Burst node server
@@ -46,13 +46,13 @@ public final class LoggerConfigurator {
       try {
         boolean foundProperties = false;
         Properties loggingProperties = new Properties();
-        try (InputStream is = new FileInputStream(new File(Burst.CONF_FOLDER, "logging-default.properties"))) {
+        try (InputStream is = new FileInputStream(new File(Signum.CONF_FOLDER, "logging-default.properties"))) {
           if (is != null) {
             loggingProperties.load(is);
             foundProperties = true;
           }
         }
-        try (InputStream is = new FileInputStream(new File(Burst.CONF_FOLDER, "logging.properties"))) {
+        try (InputStream is = new FileInputStream(new File(Signum.CONF_FOLDER, "logging.properties"))) {
           if (is != null) {
             loggingProperties.load(is);
             foundProperties = true;

--- a/src/brs/util/LoggerConfigurator.java
+++ b/src/brs/util/LoggerConfigurator.java
@@ -37,8 +37,8 @@ public final class LoggerConfigurator {
   public static void init() {
     final String managerPackage = "java.util.logging.manager";
     String oldManager = System.getProperty(managerPackage);
-    System.setProperty(managerPackage, "brs.util.BurstLogManager");
-    if (!(LogManager.getLogManager() instanceof BurstLogManager)) {
+    System.setProperty(managerPackage, "brs.util.SignumLogManager");
+    if (!(LogManager.getLogManager() instanceof SignumLogManager)) {
       System.setProperty(managerPackage,
                          (oldManager != null ? oldManager : "java.util.logging.LogManager"));
     }
@@ -83,8 +83,8 @@ public final class LoggerConfigurator {
    * LoggerConfigurator shutdown
    */
   public static void shutdown() {
-    if (LogManager.getLogManager() instanceof BurstLogManager) {
-      ((BurstLogManager) LogManager.getLogManager()).burstShutdown();
+    if (LogManager.getLogManager() instanceof SignumLogManager) {
+      ((SignumLogManager) LogManager.getLogManager()).signumShutdown();
     }
   }
 }

--- a/src/brs/util/SignumLogManager.java
+++ b/src/brs/util/SignumLogManager.java
@@ -8,7 +8,7 @@ import java.util.logging.LogManager;
 /**
  * Java LogManager extension for use with Signum
  */
-class BurstLogManager extends LogManager {
+class SignumLogManager extends LogManager {
 
   /**
    * Logging reconfiguration in progress
@@ -21,9 +21,9 @@ class BurstLogManager extends LogManager {
    * We will let the Java LogManager create its shutdown hook so that the
    * shutdown context will be set up properly.  However, we will intercept
    * the reset() method so we can delay the actual shutdown until we are
-   * done terminating the Burst processes.
+   * done terminating the Signum processes.
    */
-  public BurstLogManager() {
+  public SignumLogManager() {
     super();
   }
 
@@ -55,10 +55,10 @@ class BurstLogManager extends LogManager {
   }
 
   /**
-   * Burst shutdown is now complete, so call LogManager.reset() to terminate
+   * Signum shutdown is now complete, so call LogManager.reset() to terminate
    * the log handlers.
    */
-  void burstShutdown() {
+  void signumShutdown() {
     super.reset();
   }
 }

--- a/src/brs/web/api/http/ApiServlet.java
+++ b/src/brs/web/api/http/ApiServlet.java
@@ -236,7 +236,7 @@ public final class ApiServlet extends HttpServlet {
         response = processRequest(req);
       } catch (ParameterException e) {
         response = e.getErrorResponse();
-      } catch (BurstException | RuntimeException e) {
+      } catch (SignumException | RuntimeException e) {
         logger.debug("Error processing API request", e);
         response = ERROR_INCORRECT_REQUEST;
       }
@@ -252,7 +252,7 @@ public final class ApiServlet extends HttpServlet {
       writeJsonToResponse(resp, response);
     }
 
-    protected abstract JsonElement processRequest(HttpServletRequest request) throws BurstException;
+    protected abstract JsonElement processRequest(HttpServletRequest request) throws SignumException;
 
   }
 

--- a/src/brs/web/api/http/common/APITransactionManager.java
+++ b/src/brs/web/api/http/common/APITransactionManager.java
@@ -2,13 +2,13 @@ package brs.web.api.http.common;
 
 import brs.Account;
 import brs.Attachment;
-import brs.BurstException;
+import brs.SignumException;
 import com.google.gson.JsonElement;
 
 import javax.servlet.http.HttpServletRequest;
 
 public interface APITransactionManager {
 
-  JsonElement createTransaction(HttpServletRequest req, Account senderAccount, Long recipientId, long amountNQT, Attachment attachment, long minimumFeeNQT) throws BurstException;
+  JsonElement createTransaction(HttpServletRequest req, Account senderAccount, Long recipientId, long amountNQT, Attachment attachment, long minimumFeeNQT) throws SignumException;
 
 }

--- a/src/brs/web/api/http/common/APITransactionManagerImpl.java
+++ b/src/brs/web/api/http/common/APITransactionManagerImpl.java
@@ -45,7 +45,7 @@ public class APITransactionManagerImpl implements APITransactionManager {
   }
 
   @Override
-  public JsonElement createTransaction(HttpServletRequest req, Account senderAccount, Long recipientId, long amountNQT, Attachment attachment, long minimumFeeNQT) throws BurstException {
+  public JsonElement createTransaction(HttpServletRequest req, Account senderAccount, Long recipientId, long amountNQT, Attachment attachment, long minimumFeeNQT) throws SignumException {
     int blockchainHeight = blockchain.getHeight();
     String deadlineValue = req.getParameter(DEADLINE_PARAMETER);
     String referencedTransactionFullHash = Convert.emptyToNull(req.getParameter(REFERENCED_TRANSACTION_FULL_HASH_PARAMETER));
@@ -187,9 +187,9 @@ public class APITransactionManagerImpl implements APITransactionManager {
       response.addProperty(UNSIGNED_TRANSACTION_BYTES_RESPONSE, Convert.toHexString(transaction.getUnsignedBytes()));
       response.add(TRANSACTION_JSON_RESPONSE, JSONData.unconfirmedTransaction(transaction));
 
-    } catch (BurstException.NotYetEnabledException e) {
+    } catch (SignumException.NotYetEnabledException e) {
       return FEATURE_NOT_AVAILABLE;
-    } catch (BurstException.ValidationException e) {
+    } catch (SignumException.ValidationException e) {
       response.addProperty(ERROR_CODE_RESPONSE, 4);
       response.addProperty(ERROR_DESCRIPTION_RESPONSE, e.getMessage());
     }

--- a/src/brs/web/api/http/common/APITransactionManagerImpl.java
+++ b/src/brs/web/api/http/common/APITransactionManagerImpl.java
@@ -55,7 +55,7 @@ public class APITransactionManagerImpl implements APITransactionManager {
     String recipientPublicKeyValue = Convert.emptyToNull(ParameterParser.getRecipientPublicKey(req));
     boolean broadcast = !Parameters.isFalse(req.getParameter(BROADCAST_PARAMETER));
 
-    long cashBackId = Convert.parseUnsignedLong(Burst.getPropertyService().getString(Props.CASH_BACK_ID));
+    long cashBackId = Convert.parseUnsignedLong(Signum.getPropertyService().getString(Props.CASH_BACK_ID));
 
     EncryptedMessage encryptedMessage = null;
 
@@ -74,24 +74,24 @@ public class APITransactionManagerImpl implements APITransactionManager {
     Message message = null;
     String messageValue = Convert.emptyToNull(req.getParameter(MESSAGE_PARAMETER));
     if (messageValue != null) {
-      boolean messageIsText = Burst.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE, blockchainHeight)
+      boolean messageIsText = Signum.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE, blockchainHeight)
           && !Parameters.isFalse(req.getParameter(MESSAGE_IS_TEXT_PARAMETER));
       try {
         message = messageIsText ? new Message(messageValue, blockchainHeight) : new Message(Convert.parseHexString(messageValue), blockchainHeight);
       } catch (RuntimeException e) {
         throw new ParameterException(INCORRECT_ARBITRARY_MESSAGE);
       }
-    } else if (attachment instanceof Attachment.ColoredCoinsAssetTransfer && Burst.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE, blockchainHeight)) {
+    } else if (attachment instanceof Attachment.ColoredCoinsAssetTransfer && Signum.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE, blockchainHeight)) {
       String commentValue = Convert.emptyToNull(req.getParameter(COMMENT_PARAMETER));
       if (commentValue != null) {
         message = new Message(commentValue, blockchainHeight);
       }
-    } else if (attachment == Attachment.ARBITRARY_MESSAGE && ! Burst.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE, blockchainHeight)) {
+    } else if (attachment == Attachment.ARBITRARY_MESSAGE && ! Signum.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE, blockchainHeight)) {
       message = new Message(new byte[0], blockchainHeight);
     }
     PublicKeyAnnouncement publicKeyAnnouncement = null;
     byte []recipientPublicKey = Convert.parseHexString(recipientPublicKeyValue);
-    if (recipientPublicKeyValue != null && Burst.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE, blockchainHeight)) {
+    if (recipientPublicKeyValue != null && Signum.getFluxCapacitor().getValue(FluxValues.DIGITAL_GOODS_STORE, blockchainHeight)) {
       publicKeyAnnouncement = new PublicKeyAnnouncement(recipientPublicKey, blockchainHeight);
     }
 
@@ -138,7 +138,7 @@ public class APITransactionManagerImpl implements APITransactionManager {
       Builder builder = transactionProcessor.newTransactionBuilder(publicKey, amountNQT, feeNQT, deadline, attachment).referencedTransactionFullHash(referencedTransactionFullHash);
       if (attachment.getTransactionType().hasRecipient()) {
         Account recipientAccount = accountService.getAccount(recipientId);
-        if(recipientId!=0L && Burst.getPropertyService().getBoolean(Props.PK_API_BLOCK)) {
+        if(recipientId!=0L && Signum.getPropertyService().getBoolean(Props.PK_API_BLOCK)) {
           long referenceId = Convert.fullHashToId(referencedTransactionFullHash);
           if((referenceId!=recipientId) // allow to send to a fresh new account if we use the reference to a transaction that has that ID (contract creation pending)
                   && (recipientAccount == null || recipientAccount.getPublicKey() == null) && publicKeyAnnouncement == null) {

--- a/src/brs/web/api/http/common/JSONData.java
+++ b/src/brs/web/api/http/common/JSONData.java
@@ -153,7 +153,7 @@ public final class JSONData {
     json.addProperty(TOTAL_FEE_CASH_BACK_NQT_RESPONSE, String.valueOf(block.getTotalFeeCashBackNQT()));
     json.addProperty(TOTAL_FEE_BURNT_NQT_RESPONSE, String.valueOf(block.getTotalFeeBurntNQT()));
     json.addProperty(BLOCK_REWARD_NQT_RESPONSE, Convert.toUnsignedLong(blockReward));
-    json.addProperty(BLOCK_REWARD_RESPONSE, Convert.toUnsignedLong(blockReward / Burst.getPropertyService().getInt(Props.ONE_COIN_NQT)));
+    json.addProperty(BLOCK_REWARD_RESPONSE, Convert.toUnsignedLong(blockReward / Signum.getPropertyService().getInt(Props.ONE_COIN_NQT)));
     json.addProperty(PAYLOAD_LENGTH_RESPONSE, block.getPayloadLength());
     json.addProperty(VERSION_RESPONSE, block.getVersion());
     json.addProperty(BASE_TARGET_RESPONSE, Convert.toUnsignedLong(block.getCapacityBaseTarget()));

--- a/src/brs/web/api/http/common/ParameterException.java
+++ b/src/brs/web/api/http/common/ParameterException.java
@@ -1,9 +1,9 @@
 package brs.web.api.http.common;
 
-import brs.BurstException;
+import brs.SignumException;
 import com.google.gson.JsonElement;
 
-public final class ParameterException extends BurstException {
+public final class ParameterException extends SignumException {
 
   private transient final JsonElement errorResponse;
 

--- a/src/brs/web/api/http/common/ParameterParser.java
+++ b/src/brs/web/api/http/common/ParameterParser.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.common;
 
-import brs.Burst;
+import brs.Signum;
 import brs.Constants;
 import brs.crypto.EncryptedData;
 import brs.fluxcapacitor.FluxValues;
@@ -136,7 +136,7 @@ public final class ParameterParser {
   public static long getRecipientId(HttpServletRequest req) throws ParameterException {
     String recipientValue = Convert.emptyToNull(req.getParameter(RECIPIENT_PARAMETER));
     if (recipientValue == null ||  Parameters.isZero(recipientValue)) {
-      if(Burst.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)){
+      if(Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)){
         return 0L;
       }
       throw new ParameterException(MISSING_RECIPIENT);

--- a/src/brs/web/api/http/common/Parameters.java
+++ b/src/brs/web/api/http/common/Parameters.java
@@ -109,8 +109,8 @@ public final class Parameters {
   public static final String MESSAGE_IS_TEXT_PARAMETER = "messageIsText";
   public static final String MESSAGE_PARAMETER = "message";
   public static final String UNSIGNED_TRANSACTION_JSON_PARAMETER = "unsignedTransactionJSON";
-  public static final String AMOUNT_BURST_PARAMETER = "amountNXT";
-  public static final String FEE_BURST_PARAMETER = "feeNXT";
+  public static final String AMOUNT_SIGNA_PARAMETER = "amountNXT";
+  public static final String FEE_SIGNA_PARAMETER = "feeNXT";
   public static final String IN_STOCK_ONLY_PARAMETER = "inStockOnly";
   public static final String COMPLETED_PARAMETER = "completed";
   public static final String PEER_PARAMETER = "peer";

--- a/src/brs/web/api/http/handler/AddAssetTreasuryAccount.java
+++ b/src/brs/web/api/http/handler/AddAssetTreasuryAccount.java
@@ -29,7 +29,7 @@ public final class AddAssetTreasuryAccount extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     long recipient = ParameterParser.getRecipientId(req);
     Account sender = parameterService.getSenderAccount(req);

--- a/src/brs/web/api/http/handler/AddCommitment.java
+++ b/src/brs/web/api/http/handler/AddCommitment.java
@@ -4,7 +4,7 @@ import brs.Account;
 import brs.Attachment;
 import brs.Blockchain;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.fluxcapacitor.FluxValues;
 import brs.services.AccountService;
 import brs.services.ParameterService;
@@ -34,7 +34,7 @@ public final class AddCommitment extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     final Account account = parameterService.getSenderAccount(req);
     long amountNQT = ParameterParser.getAmountNQT(req);
 

--- a/src/brs/web/api/http/handler/AddCommitment.java
+++ b/src/brs/web/api/http/handler/AddCommitment.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Account;
 import brs.Attachment;
 import brs.Blockchain;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.fluxcapacitor.FluxValues;
 import brs.services.AccountService;
@@ -38,7 +38,7 @@ public final class AddCommitment extends CreateTransaction {
     final Account account = parameterService.getSenderAccount(req);
     long amountNQT = ParameterParser.getAmountNQT(req);
 
-    long minimumFeeNQT = Burst.getFluxCapacitor().getValue(FluxValues.FEE_QUANT);
+    long minimumFeeNQT = Signum.getFluxCapacitor().getValue(FluxValues.FEE_QUANT);
     long feeNQT = ParameterParser.getFeeNQT(req);
     if (feeNQT < minimumFeeNQT) {
       return INCORRECT_FEE;

--- a/src/brs/web/api/http/handler/BroadcastTransaction.java
+++ b/src/brs/web/api/http/handler/BroadcastTransaction.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Transaction;
 import brs.TransactionProcessor;
 import brs.fluxcapacitor.FluxValues;
@@ -41,7 +41,7 @@ public final class BroadcastTransaction extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     String transactionBytes = Convert.emptyToNull(req.getParameter(TRANSACTION_BYTES_PARAMETER));
     if(transactionBytes == null) {
@@ -75,7 +75,7 @@ public final class BroadcastTransaction extends ApiServlet.JsonRequestHandler {
       response.addProperty(NUMBER_PEERS_SENT_TO_RESPONSE, transactionProcessor.broadcast(transaction));
       response.addProperty(TRANSACTION_RESPONSE, transaction.getStringId());
       response.addProperty(FULL_HASH_RESPONSE, transaction.getFullHash());
-    } catch (BurstException.ValidationException | RuntimeException e) {
+    } catch (SignumException.ValidationException | RuntimeException e) {
       logger.log(Level.INFO, e.getMessage(), e);
       response.addProperty(ERROR_CODE_RESPONSE, 4);
       response.addProperty(ERROR_DESCRIPTION_RESPONSE, "Incorrect transaction: " + e.toString());

--- a/src/brs/web/api/http/handler/BroadcastTransaction.java
+++ b/src/brs/web/api/http/handler/BroadcastTransaction.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.Transaction;
 import brs.TransactionProcessor;
@@ -60,9 +60,9 @@ public final class BroadcastTransaction extends ApiServlet.JsonRequestHandler {
     Transaction transaction = parameterService.parseTransaction(transactionBytes, transactionJSON);
 
     long cashBackId = 0L;
-    if(Burst.getPropertyService() != null)
-      cashBackId = Convert.parseUnsignedLong(Burst.getPropertyService().getString(Props.CASH_BACK_ID));
-    if (Burst.getFluxCapacitor().getValue(FluxValues.SMART_FEES) && transaction.getCashBackId() != cashBackId){
+    if(Signum.getPropertyService() != null)
+      cashBackId = Convert.parseUnsignedLong(Signum.getPropertyService().getString(Props.CASH_BACK_ID));
+    if (Signum.getFluxCapacitor().getValue(FluxValues.SMART_FEES) && transaction.getCashBackId() != cashBackId){
       JsonObject response = new JsonObject();
       response.addProperty(ERROR_CODE_RESPONSE, 4);
       response.addProperty(ERROR_DESCRIPTION_RESPONSE, "Incorrect transactionBytes: cash back ID mismatch");

--- a/src/brs/web/api/http/handler/BuyAlias.java
+++ b/src/brs/web/api/http/handler/BuyAlias.java
@@ -28,7 +28,7 @@ public final class BuyAlias extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     Account buyer = parameterService.getSenderAccount(req);
     Alias alias = parameterService.getAlias(req);
     long amountNQT = ParameterParser.getAmountNQT(req);

--- a/src/brs/web/api/http/handler/CancelAskOrder.java
+++ b/src/brs/web/api/http/handler/CancelAskOrder.java
@@ -28,7 +28,7 @@ public final class CancelAskOrder extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     long orderId = ParameterParser.getOrderId(req);
     Account account = parameterService.getSenderAccount(req);
     Order.Ask orderData = assetExchange.getAskOrder(orderId);

--- a/src/brs/web/api/http/handler/CancelBidOrder.java
+++ b/src/brs/web/api/http/handler/CancelBidOrder.java
@@ -28,7 +28,7 @@ public final class CancelBidOrder extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     long orderId = ParameterParser.getOrderId(req);
     Account account = parameterService.getSenderAccount(req);
     Order.Bid orderData = assetExchange.getBidOrder(orderId);

--- a/src/brs/web/api/http/handler/CreateATProgram.java
+++ b/src/brs/web/api/http/handler/CreateATProgram.java
@@ -39,7 +39,7 @@ public final class CreateATProgram extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     String name = req.getParameter(NAME_PARAMETER);
     String description = req.getParameter(DESCRIPTION_PARAMETER);
 

--- a/src/brs/web/api/http/handler/CreateTransaction.java
+++ b/src/brs/web/api/http/handler/CreateTransaction.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Account;
 import brs.Attachment;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.fluxcapacitor.FluxValues;
 import brs.web.api.http.ApiServlet;
 import brs.web.api.http.common.APITransactionManager;
@@ -44,16 +44,16 @@ public abstract class CreateTransaction extends ApiServlet.JsonRequestHandler {
   }
 
   public final JsonElement createTransaction(HttpServletRequest req, Account senderAccount, Attachment attachment)
-    throws BurstException {
+    throws SignumException {
     return createTransaction(req, senderAccount, null, 0, attachment);
   }
 
   public final JsonElement createTransaction(HttpServletRequest req, Account senderAccount, Long recipientId, long amountNQT)
-    throws BurstException {
+    throws SignumException {
     return createTransaction(req, senderAccount, recipientId, amountNQT, Attachment.ORDINARY_PAYMENT);
   }
 
-  public final JsonElement createTransaction(HttpServletRequest req, Account senderAccount, Long recipientId, long amountNQT, Attachment attachment) throws BurstException {
+  public final JsonElement createTransaction(HttpServletRequest req, Account senderAccount, Long recipientId, long amountNQT, Attachment attachment) throws SignumException {
     return apiTransactionManager.createTransaction(req, senderAccount, recipientId, amountNQT, attachment, minimumFeeNQT());
   }
 

--- a/src/brs/web/api/http/handler/CreateTransaction.java
+++ b/src/brs/web/api/http/handler/CreateTransaction.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Account;
 import brs.Attachment;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.fluxcapacitor.FluxValues;
 import brs.web.api.http.ApiServlet;
@@ -62,7 +62,7 @@ public abstract class CreateTransaction extends ApiServlet.JsonRequestHandler {
   }
 
   private long minimumFeeNQT() {
-    return Burst.getFluxCapacitor().getValue(FluxValues.FEE_QUANT);
+    return Signum.getFluxCapacitor().getValue(FluxValues.FEE_QUANT);
   }
 
 }

--- a/src/brs/web/api/http/handler/DGSDelisting.java
+++ b/src/brs/web/api/http/handler/DGSDelisting.java
@@ -24,7 +24,7 @@ public final class DGSDelisting extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     Account account = parameterService.getSenderAccount(req);
     DigitalGoodsStore.Goods goods = parameterService.getGoods(req);
     if (goods.isDelisted() || goods.getSellerId() != account.getId()) {

--- a/src/brs/web/api/http/handler/DGSDelivery.java
+++ b/src/brs/web/api/http/handler/DGSDelivery.java
@@ -32,7 +32,7 @@ public final class DGSDelivery extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     Account sellerAccount = parameterService.getSenderAccount(req);
     DigitalGoodsStore.Purchase purchase = parameterService.getPurchase(req);

--- a/src/brs/web/api/http/handler/DGSFeedback.java
+++ b/src/brs/web/api/http/handler/DGSFeedback.java
@@ -28,7 +28,7 @@ public final class DGSFeedback extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     DigitalGoodsStore.Purchase purchase = parameterService.getPurchase(req);
     Account buyerAccount = parameterService.getSenderAccount(req);
 

--- a/src/brs/web/api/http/handler/DGSListing.java
+++ b/src/brs/web/api/http/handler/DGSListing.java
@@ -26,7 +26,7 @@ public final class DGSListing extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     String name = Convert.emptyToNull(req.getParameter(NAME_PARAMETER));
     String description = Convert.nullToEmpty(req.getParameter(DESCRIPTION_PARAMETER));

--- a/src/brs/web/api/http/handler/DGSPriceChange.java
+++ b/src/brs/web/api/http/handler/DGSPriceChange.java
@@ -26,7 +26,7 @@ public final class DGSPriceChange extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     Account account = parameterService.getSenderAccount(req);
     DigitalGoodsStore.Goods goods = parameterService.getGoods(req);
     long priceNQT = ParameterParser.getPriceNQT(req);

--- a/src/brs/web/api/http/handler/DGSPurchase.java
+++ b/src/brs/web/api/http/handler/DGSPurchase.java
@@ -32,7 +32,7 @@ public final class DGSPurchase extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     DigitalGoodsStore.Goods goods = parameterService.getGoods(req);
     if (goods.isDelisted()) {

--- a/src/brs/web/api/http/handler/DGSQuantityChange.java
+++ b/src/brs/web/api/http/handler/DGSQuantityChange.java
@@ -27,7 +27,7 @@ public final class DGSQuantityChange extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     Account account = parameterService.getSenderAccount(req);
     DigitalGoodsStore.Goods goods = parameterService.getGoods(req);

--- a/src/brs/web/api/http/handler/DGSRefund.java
+++ b/src/brs/web/api/http/handler/DGSRefund.java
@@ -29,7 +29,7 @@ public final class DGSRefund extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     Account sellerAccount = parameterService.getSenderAccount(req);
     DigitalGoodsStore.Purchase purchase = parameterService.getPurchase(req);
 

--- a/src/brs/web/api/http/handler/DecryptFrom.java
+++ b/src/brs/web/api/http/handler/DecryptFrom.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Account;
-import brs.BurstException;
+import brs.SignumException;
 import brs.crypto.EncryptedData;
 import brs.web.api.http.common.LegacyDocTag;
 import brs.web.api.http.common.ParameterParser;
@@ -34,7 +34,7 @@ public final class DecryptFrom extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     Account account = parameterService.getAccount(req);
     if (account.getPublicKey() == null) {
       return INCORRECT_ACCOUNT;

--- a/src/brs/web/api/http/handler/DistributeToAssetHolders.java
+++ b/src/brs/web/api/http/handler/DistributeToAssetHolders.java
@@ -19,7 +19,7 @@ import brs.Account.AccountAsset;
 import brs.Asset;
 import brs.Attachment;
 import brs.Blockchain;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.Constants;
 import brs.assetexchange.AssetExchange;
@@ -66,7 +66,7 @@ public final class DistributeToAssetHolders extends CreateTransaction {
       }
     }
 
-    if(!Burst.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
+    if(!Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
       return JSONResponses.incorrect("asset distribution is not enabled yet");
     }
 
@@ -99,7 +99,7 @@ public final class DistributeToAssetHolders extends CreateTransaction {
       return JSONResponses.incorrect(AMOUNT_NQT_PARAMETER);
     }
 
-    boolean unconfirmed = !Burst.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX);
+    boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX);
     CollectionWithIndex<AccountAsset> holders = assetExchange.getAssetAccounts(asset, false, minimumQuantity, unconfirmed, -1, -1);
     long circulatingSupply = 0;
     for(AccountAsset holder : holders) {

--- a/src/brs/web/api/http/handler/DistributeToAssetHolders.java
+++ b/src/brs/web/api/http/handler/DistributeToAssetHolders.java
@@ -20,7 +20,7 @@ import brs.Asset;
 import brs.Attachment;
 import brs.Blockchain;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Constants;
 import brs.assetexchange.AssetExchange;
 import brs.fluxcapacitor.FluxValues;
@@ -48,7 +48,7 @@ public final class DistributeToAssetHolders extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     Account account = parameterService.getSenderAccount(req);
     Asset asset = parameterService.getAsset(req);

--- a/src/brs/web/api/http/handler/EncryptTo.java
+++ b/src/brs/web/api/http/handler/EncryptTo.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Account;
-import brs.BurstException;
+import brs.SignumException;
 import brs.crypto.EncryptedData;
 import brs.services.AccountService;
 import brs.services.ParameterService;
@@ -29,7 +29,7 @@ public final class EncryptTo extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     long recipientId = ParameterParser.getRecipientId(req);
     Account recipientAccount = accountService.getAccount(recipientId);

--- a/src/brs/web/api/http/handler/EscrowSign.java
+++ b/src/brs/web/api/http/handler/EscrowSign.java
@@ -31,7 +31,7 @@ public final class EscrowSign extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     long escrowId;
     try {
       escrowId = Convert.parseUnsignedLong(Convert.emptyToNull(req.getParameter(ESCROW_PARAMETER)));

--- a/src/brs/web/api/http/handler/GenerateDeeplinkQRCode.java
+++ b/src/brs/web/api/http/handler/GenerateDeeplinkQRCode.java
@@ -97,7 +97,7 @@ public class GenerateDeeplinkQRCode extends HttpRequestHandler {
 
       resp.setContentType("image/jpeg");
 
-      final BufferedImage qrImage = deeplinkQRCodeGenerator.generateRequestBurstDeepLinkQRCode(receiverId, amountNQT, feeSuggestionType, feeNQT, message, immutable);
+      final BufferedImage qrImage = deeplinkQRCodeGenerator.generateRequestSignumDeepLinkQRCode(receiverId, amountNQT, feeSuggestionType, feeNQT, message, immutable);
       ImageIO.write(qrImage, "jpg", resp.getOutputStream());
       resp.getOutputStream().close();
     } catch (WriterException | IOException e) {

--- a/src/brs/web/api/http/handler/GetAT.java
+++ b/src/brs/web/api/http/handler/GetAT.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Attachment;
 import brs.Blockchain;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Transaction;
 import brs.at.AT;
 import brs.at.AtApiHelper;
@@ -32,7 +32,7 @@ public final class GetAT extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     boolean includeDetails = !("false".equalsIgnoreCase(req.getParameter(INCLUDE_DETAILS_PARAMETER)));
 
     AT at = parameterService.getAT(req);

--- a/src/brs/web/api/http/handler/GetATDetails.java
+++ b/src/brs/web/api/http/handler/GetATDetails.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.services.ParameterService;
 import brs.web.api.http.ApiServlet;
 import brs.web.api.http.common.JSONData;
@@ -23,7 +23,7 @@ public class GetATDetails extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     return JSONData.at(parameterService.getAT(req));
   }
 }

--- a/src/brs/web/api/http/handler/GetATMapValue.java
+++ b/src/brs/web/api/http/handler/GetATMapValue.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.Burst;
+import brs.Signum;
 import brs.util.Convert;
 import brs.web.api.http.ApiServlet;
 import brs.web.api.http.common.LegacyDocTag;
@@ -44,7 +44,7 @@ public final class GetATMapValue extends ApiServlet.JsonRequestHandler {
     long k1 = Convert.parseUnsignedLong(key1);
     long k2 = Convert.parseUnsignedLong(key2);
 
-    String value = Convert.toUnsignedLong(Burst.getStores().getAtStore().getMapValue(atId, k1, k2));
+    String value = Convert.toUnsignedLong(Signum.getStores().getAtStore().getMapValue(atId, k1, k2));
 
     JsonObject response = new JsonObject();
     response.addProperty(VALUE_RESPONSE, value);

--- a/src/brs/web/api/http/handler/GetATMapValues.java
+++ b/src/brs/web/api/http/handler/GetATMapValues.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.Burst;
+import brs.Signum;
 import brs.at.AT.AtMapEntry;
 import brs.util.CollectionWithIndex;
 import brs.util.Convert;
@@ -62,7 +62,7 @@ public final class GetATMapValues extends ApiServlet.JsonRequestHandler {
       throw new IllegalArgumentException("lastIndex must be greater or equal to firstIndex");
     }
 
-    CollectionWithIndex<AtMapEntry> atMapEntries = Burst.getStores().getAtStore().getMapValues(atId, k1, value, firstIndex, lastIndex);
+    CollectionWithIndex<AtMapEntry> atMapEntries = Signum.getStores().getAtStore().getMapValues(atId, k1, value, firstIndex, lastIndex);
 
     JsonArray mapValues = new JsonArray();
     for (AtMapEntry entry : atMapEntries) {

--- a/src/brs/web/api/http/handler/GetATs.java
+++ b/src/brs/web/api/http/handler/GetATs.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Attachment;
 import brs.Blockchain;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Transaction;
 import brs.at.AT;
 import brs.at.AtApiHelper;
@@ -38,7 +38,7 @@ public final class GetATs extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     int firstIndex = ParameterParser.getFirstIndex(req);
     int lastIndex  = ParameterParser.getLastIndex(req);

--- a/src/brs/web/api/http/handler/GetATs.java
+++ b/src/brs/web/api/http/handler/GetATs.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Attachment;
 import brs.Blockchain;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.Transaction;
 import brs.at.AT;
@@ -59,7 +59,7 @@ public final class GetATs extends ApiServlet.JsonRequestHandler {
       }
     }
 
-    Blockchain blockchain = Burst.getBlockchain();
+    Blockchain blockchain = Signum.getBlockchain();
     CollectionWithIndex<Long> atIds = atService.getATsIssuedBy(null, codeHashId, firstIndex, lastIndex);
     JsonArray ats = new JsonArray();
     for(long atId : atIds) {

--- a/src/brs/web/api/http/handler/GetAccount.java
+++ b/src/brs/web/api/http/handler/GetAccount.java
@@ -15,7 +15,7 @@ import brs.Account;
 import brs.Block;
 import brs.Blockchain;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Constants;
 import brs.Generator;
 import brs.services.AccountService;
@@ -40,7 +40,7 @@ public final class GetAccount extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     Account account = parameterService.getAccount(req);
 

--- a/src/brs/web/api/http/handler/GetAccount.java
+++ b/src/brs/web/api/http/handler/GetAccount.java
@@ -14,7 +14,7 @@ import com.google.gson.JsonObject;
 import brs.Account;
 import brs.Block;
 import brs.Blockchain;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.Constants;
 import brs.Generator;
@@ -52,7 +52,7 @@ public final class GetAccount extends ApiServlet.JsonRequestHandler {
     }
 
     if(parameterService.getAmountCommitted(req)) {
-      long committedAmount = Burst.getBlockchain().getCommittedAmount(account.getId(), height+Constants.COMMITMENT_WAIT, height, null);
+      long committedAmount = Signum.getBlockchain().getCommittedAmount(account.getId(), height+Constants.COMMITMENT_WAIT, height, null);
       response.addProperty(COMMITTED_NQT_RESPONSE, Convert.toUnsignedLong(committedAmount));
     }
 

--- a/src/brs/web/api/http/handler/GetAccountATs.java
+++ b/src/brs/web/api/http/handler/GetAccountATs.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Account;
-import brs.BurstException;
+import brs.SignumException;
 import brs.services.ATService;
 import brs.services.ParameterService;
 import brs.util.CollectionWithIndex;
@@ -35,7 +35,7 @@ public final class GetAccountATs extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     Account account = parameterService.getAccount(req);
 
     int firstIndex = ParameterParser.getFirstIndex(req);

--- a/src/brs/web/api/http/handler/GetAccountAssets.java
+++ b/src/brs/web/api/http/handler/GetAccountAssets.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Account;
 import brs.Account.AccountAsset;
-import brs.BurstException;
+import brs.SignumException;
 import brs.services.AccountService;
 import brs.services.ParameterService;
 import brs.util.CollectionWithIndex;
@@ -32,7 +32,7 @@ public final class GetAccountAssets extends ApiServlet.JsonRequestHandler {
 
     @Override
     protected
-    JsonElement processRequest(HttpServletRequest req) throws BurstException {
+    JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
         Account account = parameterService.getAccount(req);
 

--- a/src/brs/web/api/http/handler/GetAccountBlockIds.java
+++ b/src/brs/web/api/http/handler/GetAccountBlockIds.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Account;
 import brs.Block;
 import brs.Blockchain;
-import brs.BurstException;
+import brs.SignumException;
 import brs.services.ParameterService;
 import brs.util.CollectionWithIndex;
 
@@ -33,7 +33,7 @@ public final class GetAccountBlockIds extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     Account account = parameterService.getAccount(req);
 
     int timestamp = ParameterParser.getTimestamp(req);

--- a/src/brs/web/api/http/handler/GetAccountBlocks.java
+++ b/src/brs/web/api/http/handler/GetAccountBlocks.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Account;
 import brs.Block;
 import brs.Blockchain;
-import brs.BurstException;
+import brs.SignumException;
 import brs.web.api.http.common.LegacyDocTag;
 import brs.web.api.http.common.ParameterParser;
 import brs.web.api.http.common.Parameters;
@@ -35,7 +35,7 @@ public final class GetAccountBlocks extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     Account account = parameterService.getAccount(req);
     int timestamp = ParameterParser.getTimestamp(req);

--- a/src/brs/web/api/http/handler/GetAccountCurrentAskOrderIds.java
+++ b/src/brs/web/api/http/handler/GetAccountCurrentAskOrderIds.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.Order;
 import brs.assetexchange.AssetExchange;
 import brs.services.ParameterService;
@@ -32,7 +32,7 @@ public final class GetAccountCurrentAskOrderIds extends ApiServlet.JsonRequestHa
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     long accountId = parameterService.getAccount(req).getId();
     long assetId = 0;
     try {

--- a/src/brs/web/api/http/handler/GetAccountCurrentAskOrders.java
+++ b/src/brs/web/api/http/handler/GetAccountCurrentAskOrders.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Asset;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Order;
 import brs.assetexchange.AssetExchange;
 import brs.services.ParameterService;
@@ -34,7 +34,7 @@ public final class GetAccountCurrentAskOrders extends ApiServlet.JsonRequestHand
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     final long accountId = parameterService.getAccount(req).getId();
 
     long assetId = 0;

--- a/src/brs/web/api/http/handler/GetAccountCurrentBidOrderIds.java
+++ b/src/brs/web/api/http/handler/GetAccountCurrentBidOrderIds.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.Order;
 import brs.assetexchange.AssetExchange;
 import brs.services.ParameterService;
@@ -32,7 +32,7 @@ public final class GetAccountCurrentBidOrderIds extends ApiServlet.JsonRequestHa
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     long accountId = parameterService.getAccount(req).getId();
     long assetId = 0;

--- a/src/brs/web/api/http/handler/GetAccountCurrentBidOrders.java
+++ b/src/brs/web/api/http/handler/GetAccountCurrentBidOrders.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Asset;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Order;
 import brs.assetexchange.AssetExchange;
 import brs.services.ParameterService;
@@ -34,7 +34,7 @@ public final class GetAccountCurrentBidOrders extends ApiServlet.JsonRequestHand
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     long accountId = parameterService.getAccount(req).getId();
     long assetId = 0;

--- a/src/brs/web/api/http/handler/GetAccountEscrowTransactions.java
+++ b/src/brs/web/api/http/handler/GetAccountEscrowTransactions.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Account;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Escrow;
 import brs.services.EscrowService;
 import brs.services.ParameterService;
@@ -32,7 +32,7 @@ public final class GetAccountEscrowTransactions extends ApiServlet.JsonRequestHa
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     final Account account = parameterService.getAccount(req);
 
     Collection<Escrow> accountEscrows = escrowService.getEscrowTransactionsByParticipant(account.getId());

--- a/src/brs/web/api/http/handler/GetAccountPublicKey.java
+++ b/src/brs/web/api/http/handler/GetAccountPublicKey.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Account;
-import brs.BurstException;
+import brs.SignumException;
 import brs.services.ParameterService;
 import brs.util.Convert;
 import brs.util.JSON;
@@ -26,7 +26,7 @@ public final class GetAccountPublicKey extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     Account account = parameterService.getAccount(req);
 

--- a/src/brs/web/api/http/handler/GetAccountSubscriptions.java
+++ b/src/brs/web/api/http/handler/GetAccountSubscriptions.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Account;
 import brs.Alias;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.Subscription;
 import brs.Transaction;
@@ -51,7 +51,7 @@ public final class GetAccountSubscriptions extends ApiServlet.JsonRequestHandler
       Alias alias = aliasService.getAlias(accountSubscription.getRecipientId());
       Alias tld = alias == null ? null : aliasService.getTLD(alias.getTLD());
 
-      Transaction transaction = Burst.getBlockchain().getTransaction(alias == null? accountSubscription.getId() : alias.getId());
+      Transaction transaction = Signum.getBlockchain().getTransaction(alias == null? accountSubscription.getId() : alias.getId());
       subscriptions.add(JSONData.subscription(accountSubscription, alias, tld, transaction));
     }
 

--- a/src/brs/web/api/http/handler/GetAccountSubscriptions.java
+++ b/src/brs/web/api/http/handler/GetAccountSubscriptions.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Account;
 import brs.Alias;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Subscription;
 import brs.Transaction;
 import brs.services.AliasService;
@@ -37,7 +37,7 @@ public final class GetAccountSubscriptions extends ApiServlet.JsonRequestHandler
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     Account account = parameterService.getAccount(req);
 

--- a/src/brs/web/api/http/handler/GetAccountTransactionIds.java
+++ b/src/brs/web/api/http/handler/GetAccountTransactionIds.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Account;
 import brs.Blockchain;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Transaction;
 import brs.services.ParameterService;
 import brs.util.CollectionWithIndex;
@@ -58,7 +58,7 @@ public final class GetAccountTransactionIds extends ApiServlet.JsonRequestHandle
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     Account account = parameterService.getAccount(req, false);
 

--- a/src/brs/web/api/http/handler/GetAccountTransactions.java
+++ b/src/brs/web/api/http/handler/GetAccountTransactions.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Account;
 import brs.Blockchain;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Transaction;
 import brs.services.ParameterService;
 import brs.util.CollectionWithIndex;
@@ -58,7 +58,7 @@ public final class GetAccountTransactions extends ApiServlet.JsonRequestHandler 
   }
 
   @Override
-  protected JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  protected JsonElement processRequest(HttpServletRequest req) throws SignumException {
     Account account = parameterService.getAccount(req, false);
 
     Long senderId = null, recipientId = null;

--- a/src/brs/web/api/http/handler/GetAccountsWithName.java
+++ b/src/brs/web/api/http/handler/GetAccountsWithName.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Account;
-import brs.BurstException;
+import brs.SignumException;
 import brs.services.AccountService;
 import brs.util.Convert;
 import brs.web.api.http.ApiServlet;
@@ -27,7 +27,7 @@ public class GetAccountsWithName extends ApiServlet.JsonRequestHandler {
 
     @Override
     protected
-    JsonElement processRequest(HttpServletRequest request) throws BurstException {
+    JsonElement processRequest(HttpServletRequest request) throws SignumException {
         Collection<Account> accounts = accountService.getAccountsWithName(request.getParameter(NAME_PARAMETER));
         JsonArray accountIds = new JsonArray();
 

--- a/src/brs/web/api/http/handler/GetAccountsWithRewardRecipient.java
+++ b/src/brs/web/api/http/handler/GetAccountsWithRewardRecipient.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Account;
-import brs.BurstException;
+import brs.SignumException;
 import brs.services.AccountService;
 import brs.services.ParameterService;
 import brs.util.Convert;
@@ -29,7 +29,7 @@ public final class GetAccountsWithRewardRecipient extends ApiServlet.JsonRequest
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     JsonObject response = new JsonObject();
 
     Account targetAccount = parameterService.getAccount(req);

--- a/src/brs/web/api/http/handler/GetAliases.java
+++ b/src/brs/web/api/http/handler/GetAliases.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Account;
 import brs.Alias;
 import brs.Alias.Offer;
-import brs.BurstException;
+import brs.SignumException;
 import brs.services.AliasService;
 import brs.services.ParameterService;
 import brs.util.CollectionWithIndex;
@@ -38,7 +38,7 @@ public final class GetAliases extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     final int timestamp = ParameterParser.getTimestamp(req);
     Account account = parameterService.getAccount(req, false);
 

--- a/src/brs/web/api/http/handler/GetAliasesByName.java
+++ b/src/brs/web/api/http/handler/GetAliasesByName.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Alias;
 import brs.Alias.Offer;
-import brs.BurstException;
+import brs.SignumException;
 import brs.services.AliasService;
 import brs.util.CollectionWithIndex;
 import brs.util.Convert;
@@ -34,7 +34,7 @@ public final class GetAliasesByName extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     final int timestamp = ParameterParser.getTimestamp(req);
 
     String aliasName = Convert.emptyToNull(req.getParameter(ALIAS_NAME_PARAMETER));

--- a/src/brs/web/api/http/handler/GetAliasesOnSale.java
+++ b/src/brs/web/api/http/handler/GetAliasesOnSale.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Alias;
-import brs.BurstException;
+import brs.SignumException;
 import brs.services.AliasService;
 import brs.util.CollectionWithIndex;
 import brs.util.Convert;
@@ -31,7 +31,7 @@ public final class GetAliasesOnSale extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     int firstIndex = ParameterParser.getFirstIndex(req);
     int lastIndex = ParameterParser.getLastIndex(req);
 

--- a/src/brs/web/api/http/handler/GetAllAssets.java
+++ b/src/brs/web/api/http/handler/GetAllAssets.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Asset;
-import brs.Burst;
+import brs.Signum;
 import brs.assetexchange.AssetExchange;
 import brs.services.AccountService;
 import brs.util.CollectionWithIndex;
@@ -33,7 +33,7 @@ public final class GetAllAssets extends AbstractAssetsRetrieval {
     int firstIndex = ParameterParser.getFirstIndex(req);
     int lastIndex = ParameterParser.getLastIndex(req);
 
-    int heightEnd = Burst.getBlockchain().getHeight();
+    int heightEnd = Signum.getBlockchain().getHeight();
     // default is one day window
     int heightStart = heightEnd - 360;
 

--- a/src/brs/web/api/http/handler/GetAllTrades.java
+++ b/src/brs/web/api/http/handler/GetAllTrades.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Asset;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Trade;
 import brs.assetexchange.AssetExchange;
 import brs.web.api.http.common.LegacyDocTag;
@@ -30,7 +30,7 @@ public final class GetAllTrades extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     final int timestamp = ParameterParser.getTimestamp(req);
     final int firstIndex = ParameterParser.getFirstIndex(req);
     final int lastIndex = ParameterParser.getLastIndex(req);

--- a/src/brs/web/api/http/handler/GetAskOrder.java
+++ b/src/brs/web/api/http/handler/GetAskOrder.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Asset;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Order;
 import brs.assetexchange.AssetExchange;
 import brs.web.api.http.ApiServlet;
@@ -26,7 +26,7 @@ public final class GetAskOrder extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     long orderId = ParameterParser.getOrderId(req);
     Order.Ask askOrder = assetExchange.getAskOrder(orderId);
     if (askOrder == null) {

--- a/src/brs/web/api/http/handler/GetAskOrderIds.java
+++ b/src/brs/web/api/http/handler/GetAskOrderIds.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.Order;
 import brs.Order.Ask;
 import brs.assetexchange.AssetExchange;
@@ -33,7 +33,7 @@ public final class GetAskOrderIds extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     long assetId = parameterService.getAsset(req).getId();
     int firstIndex = ParameterParser.getFirstIndex(req);

--- a/src/brs/web/api/http/handler/GetAskOrders.java
+++ b/src/brs/web/api/http/handler/GetAskOrders.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Asset;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Order;
 import brs.Order.Ask;
 import brs.assetexchange.AssetExchange;
@@ -35,7 +35,7 @@ public final class GetAskOrders extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     long assetId = parameterService.getAsset(req).getId();
     int firstIndex = ParameterParser.getFirstIndex(req);

--- a/src/brs/web/api/http/handler/GetAsset.java
+++ b/src/brs/web/api/http/handler/GetAsset.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Asset;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.assetexchange.AssetExchange;
 import brs.fluxcapacitor.FluxValues;
@@ -39,13 +39,13 @@ public final class GetAsset extends ApiServlet.JsonRequestHandler {
 
     int tradeCount = assetExchange.getTradeCount(asset.getId());
     int transferCount = assetExchange.getTransferCount(asset.getId());
-    boolean unconfirmed = !Burst.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX);
+    boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX);
     int accountsCount = assetExchange.getAssetAccountsCount(asset, minimumQuantity, true, unconfirmed);
     long circulatingSupply = assetExchange.getAssetCirculatingSupply(asset, true, unconfirmed);
 
     long quantityBurnt = accountService.getUnconfirmedAssetBalanceQNT(accountService.getNullAccount(), asset.getId());
 
-    int heightEnd = Burst.getBlockchain().getHeight();
+    int heightEnd = Signum.getBlockchain().getHeight();
     // default is one day window
     int heightStart = heightEnd - 360;
 

--- a/src/brs/web/api/http/handler/GetAsset.java
+++ b/src/brs/web/api/http/handler/GetAsset.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Asset;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.assetexchange.AssetExchange;
 import brs.fluxcapacitor.FluxValues;
 import brs.services.AccountService;
@@ -33,7 +33,7 @@ public final class GetAsset extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     final Asset asset = parameterService.getAsset(req);
     long minimumQuantity = Convert.parseUnsignedLong(req.getParameter(QUANTITY_MININUM_QNT_PARAMETER));
 

--- a/src/brs/web/api/http/handler/GetAssetAccounts.java
+++ b/src/brs/web/api/http/handler/GetAssetAccounts.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Account;
 import brs.Account.AccountAsset;
 import brs.Asset;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.assetexchange.AssetExchange;
 import brs.fluxcapacitor.FluxValues;
@@ -47,7 +47,7 @@ public final class GetAssetAccounts extends ApiServlet.JsonRequestHandler {
     boolean filterTreasury = "false".equals(req.getParameter(ASSET_IGNORE_TREASURY_PARAMETER)) ? false : true;
 
     JsonArray accountAssetsArray = new JsonArray();
-    boolean unconfirmed = !Burst.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX);
+    boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX);
     CollectionWithIndex<AccountAsset> accountAssets = assetExchange.getAssetAccounts(asset,
         filterTreasury, minimumQuantity, unconfirmed, firstIndex, lastIndex);
     for (Account.AccountAsset accountAsset : accountAssets) {

--- a/src/brs/web/api/http/handler/GetAssetAccounts.java
+++ b/src/brs/web/api/http/handler/GetAssetAccounts.java
@@ -4,7 +4,7 @@ import brs.Account;
 import brs.Account.AccountAsset;
 import brs.Asset;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.assetexchange.AssetExchange;
 import brs.fluxcapacitor.FluxValues;
 import brs.services.ParameterService;
@@ -37,7 +37,7 @@ public final class GetAssetAccounts extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     Asset asset = parameterService.getAsset(req);
     int firstIndex = ParameterParser.getFirstIndex(req);

--- a/src/brs/web/api/http/handler/GetAssetTransfers.java
+++ b/src/brs/web/api/http/handler/GetAssetTransfers.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Account;
 import brs.Asset;
 import brs.AssetTransfer;
-import brs.BurstException;
+import brs.SignumException;
 import brs.assetexchange.AssetExchange;
 import brs.web.api.http.common.LegacyDocTag;
 import brs.web.api.http.common.ParameterParser;
@@ -39,7 +39,7 @@ public final class GetAssetTransfers extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     String assetId = Convert.emptyToNull(req.getParameter(ASSET_PARAMETER));
     String accountId = Convert.emptyToNull(req.getParameter(ACCOUNT_PARAMETER));
 

--- a/src/brs/web/api/http/handler/GetAssetsByIssuer.java
+++ b/src/brs/web/api/http/handler/GetAssetsByIssuer.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Account;
 import brs.Asset;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.assetexchange.AssetExchange;
 import brs.services.AccountService;
 import brs.services.ParameterService;
@@ -35,7 +35,7 @@ public final class GetAssetsByIssuer extends AbstractAssetsRetrieval {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     Account account = parameterService.getAccount(req);
     int firstIndex = ParameterParser.getFirstIndex(req);
     int lastIndex = ParameterParser.getLastIndex(req);

--- a/src/brs/web/api/http/handler/GetAssetsByIssuer.java
+++ b/src/brs/web/api/http/handler/GetAssetsByIssuer.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Account;
 import brs.Asset;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.assetexchange.AssetExchange;
 import brs.services.AccountService;
@@ -40,7 +40,7 @@ public final class GetAssetsByIssuer extends AbstractAssetsRetrieval {
     int firstIndex = ParameterParser.getFirstIndex(req);
     int lastIndex = ParameterParser.getLastIndex(req);
 
-    int heightEnd = Burst.getBlockchain().getHeight();
+    int heightEnd = Signum.getBlockchain().getHeight();
     // default is one day window
     int heightStart = heightEnd - 360;
 

--- a/src/brs/web/api/http/handler/GetAssetsByName.java
+++ b/src/brs/web/api/http/handler/GetAssetsByName.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Asset;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.assetexchange.AssetExchange;
 import brs.services.AccountService;
 import brs.util.CollectionWithIndex;
@@ -33,7 +33,7 @@ public final class GetAssetsByName extends AbstractAssetsRetrieval {
 
     @Override
     protected
-    JsonElement processRequest(HttpServletRequest req) throws BurstException {
+    JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
         String name = req.getParameter(NAME_PARAMETER);
 

--- a/src/brs/web/api/http/handler/GetAssetsByName.java
+++ b/src/brs/web/api/http/handler/GetAssetsByName.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Asset;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.assetexchange.AssetExchange;
 import brs.services.AccountService;
@@ -46,7 +46,7 @@ public final class GetAssetsByName extends AbstractAssetsRetrieval {
           return INCORRECT_ASSET_NAME;
         }
 
-        int heightEnd = Burst.getBlockchain().getHeight();
+        int heightEnd = Signum.getBlockchain().getHeight();
         // default is one day window
         int heightStart = heightEnd - 360;
 

--- a/src/brs/web/api/http/handler/GetAssetsByOwner.java
+++ b/src/brs/web/api/http/handler/GetAssetsByOwner.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Account;
 import brs.Asset;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.assetexchange.AssetExchange;
 import brs.services.AccountService;
@@ -40,7 +40,7 @@ public final class GetAssetsByOwner extends AbstractAssetsRetrieval {
     int firstIndex = ParameterParser.getFirstIndex(req);
     int lastIndex = ParameterParser.getLastIndex(req);
 
-    int heightEnd = Burst.getBlockchain().getHeight();
+    int heightEnd = Signum.getBlockchain().getHeight();
     // default is one day window
     int heightStart = heightEnd - 360;
 

--- a/src/brs/web/api/http/handler/GetAssetsByOwner.java
+++ b/src/brs/web/api/http/handler/GetAssetsByOwner.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Account;
 import brs.Asset;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.assetexchange.AssetExchange;
 import brs.services.AccountService;
 import brs.services.ParameterService;
@@ -35,7 +35,7 @@ public final class GetAssetsByOwner extends AbstractAssetsRetrieval {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     Account account = parameterService.getAccount(req);
     int firstIndex = ParameterParser.getFirstIndex(req);
     int lastIndex = ParameterParser.getLastIndex(req);

--- a/src/brs/web/api/http/handler/GetBalance.java
+++ b/src/brs/web/api/http/handler/GetBalance.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.web.api.http.common.LegacyDocTag;
 import brs.web.api.http.common.Parameters;
 import brs.services.ParameterService;
@@ -21,7 +21,7 @@ public final class GetBalance extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     return JSONData.accountBalance(parameterService.getAccount(req));
   }
 

--- a/src/brs/web/api/http/handler/GetBidOrder.java
+++ b/src/brs/web/api/http/handler/GetBidOrder.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Asset;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Order;
 import brs.assetexchange.AssetExchange;
 import brs.web.api.http.ApiServlet;
@@ -26,7 +26,7 @@ public final class GetBidOrder extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     long orderId = ParameterParser.getOrderId(req);
     Order.Bid bidOrder = assetExchange.getBidOrder(orderId);
 

--- a/src/brs/web/api/http/handler/GetBidOrderIds.java
+++ b/src/brs/web/api/http/handler/GetBidOrderIds.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.Order;
 import brs.Order.Bid;
 import brs.assetexchange.AssetExchange;
@@ -32,7 +32,7 @@ public final class GetBidOrderIds extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     long assetId = parameterService.getAsset(req).getId();
     int firstIndex = ParameterParser.getFirstIndex(req);
     int lastIndex = ParameterParser.getLastIndex(req);

--- a/src/brs/web/api/http/handler/GetBidOrders.java
+++ b/src/brs/web/api/http/handler/GetBidOrders.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Asset;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Order;
 import brs.Order.Bid;
 import brs.assetexchange.AssetExchange;
@@ -35,7 +35,7 @@ public final class GetBidOrders extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     long assetId = parameterService.getAsset(req).getId();
     int firstIndex = ParameterParser.getFirstIndex(req);

--- a/src/brs/web/api/http/handler/GetBlockchainStatus.java
+++ b/src/brs/web/api/http/handler/GetBlockchainStatus.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Block;
 import brs.Blockchain;
 import brs.BlockchainProcessor;
-import brs.Burst;
+import brs.Signum;
 import brs.peer.Peer;
 import brs.props.Props;
 import brs.services.TimeService;
@@ -33,8 +33,8 @@ public final class GetBlockchainStatus extends ApiServlet.JsonRequestHandler {
   protected
   JsonElement processRequest(HttpServletRequest req) {
     JsonObject response = new JsonObject();
-    response.addProperty("application", Burst.getPropertyService().getString(Props.APPLICATION));
-    response.addProperty("version", Burst.getPropertyService().getString(Props.VERSION));
+    response.addProperty("application", Signum.getPropertyService().getString(Props.APPLICATION));
+    response.addProperty("version", Signum.getPropertyService().getString(Props.VERSION));
     response.addProperty(TIME_RESPONSE, timeService.getEpochTime());
     Block lastBlock = blockchain.getLastBlock();
     response.addProperty("lastBlock", lastBlock.getStringId());

--- a/src/brs/web/api/http/handler/GetConstants.java
+++ b/src/brs/web/api/http/handler/GetConstants.java
@@ -8,7 +8,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
-import brs.Burst;
+import brs.Signum;
 import brs.Constants;
 import brs.Genesis;
 import brs.TransactionType;
@@ -31,19 +31,19 @@ public final class GetConstants extends ApiServlet.JsonRequestHandler {
     protected
     JsonElement processRequest(HttpServletRequest req) {
         JsonObject response = new JsonObject();
-        response.addProperty("networkName", Burst.getPropertyService().getString(Props.NETWORK_NAME));
-        response.addProperty("genesisBlockId", Burst.getPropertyService().getString(Props.GENESIS_BLOCK_ID));
+        response.addProperty("networkName", Signum.getPropertyService().getString(Props.NETWORK_NAME));
+        response.addProperty("genesisBlockId", Signum.getPropertyService().getString(Props.GENESIS_BLOCK_ID));
         response.addProperty("genesisAccountId", Convert.toUnsignedLong(Genesis.CREATOR_ID));
-        response.addProperty("maxBlockPayloadLength", (Burst.getFluxCapacitor().getValue(FluxValues.MAX_PAYLOAD_LENGTH)));
+        response.addProperty("maxBlockPayloadLength", (Signum.getFluxCapacitor().getValue(FluxValues.MAX_PAYLOAD_LENGTH)));
         response.addProperty("maxArbitraryMessageLength", Constants.MAX_ARBITRARY_MESSAGE_LENGTH);
         response.addProperty("ordinaryTransactionLength", Constants.ORDINARY_TRANSACTION_BYTES);
         response.addProperty("addressPrefix", SignumUtils.getAddressPrefix());
         response.addProperty("valueSuffix", SignumUtils.getValueSuffix());
-        response.addProperty("blockTime", Burst.getFluxCapacitor().getValue(FluxValues.BLOCK_TIME));
-        response.addProperty("decimalPlaces", Burst.getPropertyService().getInt(Props.DECIMAL_PLACES));
-        response.addProperty("feeQuantNQT", Burst.getFluxCapacitor().getValue(FluxValues.FEE_QUANT));
-        response.addProperty("cashBackId", Burst.getPropertyService().getString(Props.CASH_BACK_ID));
-        response.addProperty("cashBackFactor", Burst.getPropertyService().getInt(Props.CASH_BACK_FACTOR));
+        response.addProperty("blockTime", Signum.getFluxCapacitor().getValue(FluxValues.BLOCK_TIME));
+        response.addProperty("decimalPlaces", Signum.getPropertyService().getInt(Props.DECIMAL_PLACES));
+        response.addProperty("feeQuantNQT", Signum.getFluxCapacitor().getValue(FluxValues.FEE_QUANT));
+        response.addProperty("cashBackId", Signum.getPropertyService().getString(Props.CASH_BACK_ID));
+        response.addProperty("cashBackFactor", Signum.getPropertyService().getInt(Props.CASH_BACK_FACTOR));
 
         JsonArray transactionTypes = new JsonArray();
         TransactionType.getTransactionTypes()
@@ -55,7 +55,7 @@ public final class GetConstants extends ApiServlet.JsonRequestHandler {
                     transactionSubtypes.addAll(value.entrySet().stream()
                             .map(entry -> {
                                 JsonObject transactionSubtype = new JsonObject();
-                                Fee fee = entry.getValue().getBaselineFee(Burst.getBlockchain().getHeight());
+                                Fee fee = entry.getValue().getBaselineFee(Signum.getBlockchain().getHeight());
                                 transactionSubtype.addProperty("value", entry.getKey());
                                 transactionSubtype.addProperty("description", entry.getValue().getDescription());
                                 transactionSubtype.addProperty("minimumFeeConstantNQT", fee.getConstantFee());

--- a/src/brs/web/api/http/handler/GetDGSGood.java
+++ b/src/brs/web/api/http/handler/GetDGSGood.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.services.ParameterService;
 import brs.web.api.http.ApiServlet;
 import brs.web.api.http.common.JSONData;
@@ -22,7 +22,7 @@ public final class GetDGSGood extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     return JSONData.goods(parameterService.getGoods(req));
   }
 

--- a/src/brs/web/api/http/handler/GetDGSGoods.java
+++ b/src/brs/web/api/http/handler/GetDGSGoods.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.DigitalGoodsStore;
 import brs.web.api.http.common.LegacyDocTag;
 import brs.web.api.http.common.ParameterParser;
@@ -29,7 +29,7 @@ public final class GetDGSGoods extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     long sellerId = ParameterParser.getSellerId(req);
     int firstIndex = ParameterParser.getFirstIndex(req);
     int lastIndex = ParameterParser.getLastIndex(req);

--- a/src/brs/web/api/http/handler/GetDGSPendingPurchases.java
+++ b/src/brs/web/api/http/handler/GetDGSPendingPurchases.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.DigitalGoodsStore;
 import brs.services.DGSGoodsStoreService;
 import brs.web.api.http.ApiServlet;
@@ -28,7 +28,7 @@ public final class GetDGSPendingPurchases extends ApiServlet.JsonRequestHandler 
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     long sellerId = ParameterParser.getSellerId(req);
 
     if (sellerId == 0) {

--- a/src/brs/web/api/http/handler/GetDGSPurchase.java
+++ b/src/brs/web/api/http/handler/GetDGSPurchase.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.services.ParameterService;
 import brs.web.api.http.ApiServlet;
 import brs.web.api.http.common.JSONData;
@@ -22,7 +22,7 @@ public final class GetDGSPurchase extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     return JSONData.purchase(parameterService.getPurchase(req));
   }
 

--- a/src/brs/web/api/http/handler/GetDGSPurchases.java
+++ b/src/brs/web/api/http/handler/GetDGSPurchases.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.DigitalGoodsStore;
 import brs.web.api.http.common.LegacyDocTag;
 import brs.web.api.http.common.ParameterParser;
@@ -30,7 +30,7 @@ public final class GetDGSPurchases extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     long sellerId = ParameterParser.getSellerId(req);
     long buyerId = ParameterParser.getBuyerId(req);
     int firstIndex = ParameterParser.getFirstIndex(req);

--- a/src/brs/web/api/http/handler/GetECBlock.java
+++ b/src/brs/web/api/http/handler/GetECBlock.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Block;
 import brs.Blockchain;
-import brs.BurstException;
+import brs.SignumException;
 import brs.EconomicClustering;
 import brs.services.TimeService;
 import brs.web.api.http.ApiServlet;
@@ -32,7 +32,7 @@ public final class GetECBlock extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     int timestamp = ParameterParser.getTimestamp(req);
     if (timestamp == 0) {
       timestamp = timeService.getEpochTime();

--- a/src/brs/web/api/http/handler/GetIndirectIncoming.java
+++ b/src/brs/web/api/http/handler/GetIndirectIncoming.java
@@ -16,7 +16,7 @@ import com.google.gson.JsonElement;
 import brs.Account;
 import brs.Blockchain;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.IndirectIncoming;
 import brs.services.ParameterService;
 import brs.util.Convert;
@@ -34,7 +34,7 @@ public final class GetIndirectIncoming extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     Account account = parameterService.getAccount(req);
     String transactionIdString = Convert.emptyToNull(req.getParameter(TRANSACTION_PARAMETER));

--- a/src/brs/web/api/http/handler/GetIndirectIncoming.java
+++ b/src/brs/web/api/http/handler/GetIndirectIncoming.java
@@ -15,7 +15,7 @@ import com.google.gson.JsonElement;
 
 import brs.Account;
 import brs.Blockchain;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.IndirectIncoming;
 import brs.services.ParameterService;
@@ -49,7 +49,7 @@ public final class GetIndirectIncoming extends ApiServlet.JsonRequestHandler {
       return INCORRECT_TRANSACTION;
     }
 
-    IndirectIncoming indirect = Burst.getStores().getIndirectIncomingStore().getIndirectIncoming(account.getId(), transactionId);
+    IndirectIncoming indirect = Signum.getStores().getIndirectIncomingStore().getIndirectIncoming(account.getId(), transactionId);
 
     if (indirect == null) {
       return UNKNOWN_TRANSACTION;

--- a/src/brs/web/api/http/handler/GetMiningInfo.java
+++ b/src/brs/web/api/http/handler/GetMiningInfo.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Block;
 import brs.Blockchain;
-import brs.Burst;
+import brs.Signum;
 import brs.Generator;
 import brs.web.api.http.common.LegacyDocTag;
 import brs.web.api.http.common.ResultFields;
@@ -33,7 +33,7 @@ public final class GetMiningInfo extends ApiServlet.JsonRequestHandler {
   JsonElement processRequest(HttpServletRequest req) {
     JsonObject response = new JsonObject();
 
-    response.addProperty(ResultFields.HEIGHT_RESPONSE, Long.toString((long)Burst.getBlockchain().getHeight() + 1));
+    response.addProperty(ResultFields.HEIGHT_RESPONSE, Long.toString((long)Signum.getBlockchain().getHeight() + 1));
 
     Block lastBlock = blockchain.getLastBlock();
     byte[] newGenSig = generator.calculateGenerationSignature(lastBlock.getGenerationSignature(), lastBlock.getGeneratorId());
@@ -42,7 +42,7 @@ public final class GetMiningInfo extends ApiServlet.JsonRequestHandler {
     response.addProperty(ResultFields.BASE_TARGET_RESPONSE, Long.toString(lastBlock.getCapacityBaseTarget()));
     response.addProperty(ResultFields.AVERAGE_COMMITMENT_NQT_RESPONSE, Long.toString(lastBlock.getAverageCommitment()));
     response.addProperty(ResultFields.LAST_BLOCK_REWARD_RESPONSE, Long.toString(blockService.getBlockReward(lastBlock)
-        / Burst.getPropertyService().getInt(Props.ONE_COIN_NQT)));
+        / Signum.getPropertyService().getInt(Props.ONE_COIN_NQT)));
     response.addProperty(ResultFields.LAST_BLOCK_REWARD_NQT_RESPONSE, Long.toString(blockService.getBlockReward(lastBlock)));
     response.addProperty(ResultFields.TIMESTAMP_RESPONSE, Long.toString((long)lastBlock.getTimestamp()));
 

--- a/src/brs/web/api/http/handler/GetRewardRecipient.java
+++ b/src/brs/web/api/http/handler/GetRewardRecipient.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Account;
 import brs.Blockchain;
-import brs.BurstException;
+import brs.SignumException;
 import brs.services.AccountService;
 import brs.services.ParameterService;
 import brs.util.Convert;
@@ -31,7 +31,7 @@ public final class GetRewardRecipient extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     JsonObject response = new JsonObject();
 
     final Account account = parameterService.getAccount(req);

--- a/src/brs/web/api/http/handler/GetState.java
+++ b/src/brs/web/api/http/handler/GetState.java
@@ -59,14 +59,14 @@ public final class GetState extends ApiServlet.JsonRequestHandler {
 
     JsonObject response = new JsonObject();
 
-    response.addProperty("application", Burst.getPropertyService().getString(Props.APPLICATION));
-    response.addProperty("version", Burst.getPropertyService().getString(Props.VERSION));
+    response.addProperty("application", Signum.getPropertyService().getString(Props.APPLICATION));
+    response.addProperty("version", Signum.getPropertyService().getString(Props.VERSION));
     response.addProperty(TIME_RESPONSE, timeService.getEpochTime());
     response.addProperty("lastBlock", blockchain.getLastBlock().getStringId());
     response.addProperty(CUMULATIVE_DIFFICULTY_RESPONSE, blockchain.getLastBlock().getCumulativeDifficulty().toString());
     long totalMined = blockchain.getTotalMined();
-    long totalBurnt = Burst.getStores().getAccountStore().getAccountBalanceTable().get(
-            Burst.getStores().getAccountStore().getAccountKeyFactory().newKey(0L)).getBalanceNQT();
+    long totalBurnt = Signum.getStores().getAccountStore().getAccountBalanceTable().get(
+            Signum.getStores().getAccountStore().getAccountKeyFactory().newKey(0L)).getBalanceNQT();
     response.addProperty("totalMinedNQT", totalMined);
     response.addProperty("totalBurntNQT", totalBurnt);
     response.addProperty("circulatingSupplyNQT", totalMined - totalBurnt);
@@ -107,10 +107,10 @@ public final class GetState extends ApiServlet.JsonRequestHandler {
 
     response.addProperty("numberOfPeers", Peers.getAllPeers().size());
     response.addProperty("numberOfUnlockedAccounts", generator.getAllGenerators().size());
-    Peer lastBlockchainFeeder = Burst.getBlockchainProcessor().getLastBlockchainFeeder();
+    Peer lastBlockchainFeeder = Signum.getBlockchainProcessor().getLastBlockchainFeeder();
     response.addProperty("lastBlockchainFeeder", lastBlockchainFeeder == null ? null : lastBlockchainFeeder.getAnnouncedAddress());
-    response.addProperty("lastBlockchainFeederHeight", Burst.getBlockchainProcessor().getLastBlockchainFeederHeight());
-    response.addProperty("isScanning", Burst.getBlockchainProcessor().isScanning());
+    response.addProperty("lastBlockchainFeederHeight", Signum.getBlockchainProcessor().getLastBlockchainFeederHeight());
+    response.addProperty("isScanning", Signum.getBlockchainProcessor().isScanning());
     response.addProperty("availableProcessors", Runtime.getRuntime().availableProcessors());
     response.addProperty("maxMemory", Runtime.getRuntime().maxMemory());
     response.addProperty("totalMemory", Runtime.getRuntime().totalMemory());

--- a/src/brs/web/api/http/handler/GetSubscription.java
+++ b/src/brs/web/api/http/handler/GetSubscription.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Alias;
-import brs.Burst;
+import brs.Signum;
 import brs.Subscription;
 import brs.Transaction;
 import brs.services.AliasService;
@@ -55,7 +55,7 @@ public final class GetSubscription extends ApiServlet.JsonRequestHandler {
     Alias alias = aliasService.getAlias(subscription.getRecipientId());
     Alias tld = alias == null ? null : aliasService.getTLD(alias.getTLD());
 
-    Transaction transaction = Burst.getBlockchain().getTransaction(subscriptionId);
+    Transaction transaction = Signum.getBlockchain().getTransaction(subscriptionId);
 
     return JSONData.subscription(subscription, alias, tld, transaction);
   }

--- a/src/brs/web/api/http/handler/GetSubscriptionPayments.java
+++ b/src/brs/web/api/http/handler/GetSubscriptionPayments.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Attachment;
 import brs.Attachment.AdvancedPaymentSubscriptionPayment;
 import brs.Blockchain;
-import brs.Burst;
+import brs.Signum;
 import brs.Transaction;
 import brs.TransactionType;
 import brs.util.CollectionWithIndex;
@@ -66,7 +66,7 @@ public final class GetSubscriptionPayments extends ApiServlet.JsonRequestHandler
     }
 
     JsonArray transactions = new JsonArray();
-    Blockchain blockchain = Burst.getBlockchain();
+    Blockchain blockchain = Signum.getBlockchain();
     CollectionWithIndex<Transaction> accountTransactions = new CollectionWithIndex<Transaction>(blockchain.getTransactions(tx.getSenderId(), TransactionType.TYPE_ADVANCED_PAYMENT.getType(),
             TransactionType.SUBTYPE_ADVANCED_PAYMENT_SUBSCRIPTION_PAYMENT, TransactionType.SUBTYPE_ADVANCED_PAYMENT_SUBSCRIPTION_PAYMENT, firstIndex, lastIndex), firstIndex, lastIndex);
     for (Transaction transaction : accountTransactions) {

--- a/src/brs/web/api/http/handler/GetSubscriptionsToAccount.java
+++ b/src/brs/web/api/http/handler/GetSubscriptionsToAccount.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Account;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.Subscription;
 import brs.Transaction;
@@ -40,7 +40,7 @@ public final class GetSubscriptionsToAccount extends ApiServlet.JsonRequestHandl
 
     for (Subscription subscription : subscriptionService.getSubscriptionsToId(account.getId())) {
 
-      Transaction transaction = Burst.getBlockchain().getTransaction(subscription.getId());
+      Transaction transaction = Signum.getBlockchain().getTransaction(subscription.getId());
       subscriptions.add(JSONData.subscription(subscription, null, null, transaction));
     }
 

--- a/src/brs/web/api/http/handler/GetSubscriptionsToAccount.java
+++ b/src/brs/web/api/http/handler/GetSubscriptionsToAccount.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Account;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Subscription;
 import brs.Transaction;
 import brs.services.ParameterService;
@@ -31,7 +31,7 @@ public final class GetSubscriptionsToAccount extends ApiServlet.JsonRequestHandl
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     final Account account = parameterService.getAccount(req);
 
     JsonObject response = new JsonObject();

--- a/src/brs/web/api/http/handler/GetTLDs.java
+++ b/src/brs/web/api/http/handler/GetTLDs.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Alias;
 import brs.Alias.Offer;
-import brs.BurstException;
+import brs.SignumException;
 import brs.services.AliasService;
 import brs.util.CollectionWithIndex;
 import brs.web.api.http.ApiServlet;
@@ -29,7 +29,7 @@ public final class GetTLDs extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     final int timestamp = ParameterParser.getTimestamp(req);
     int firstIndex = ParameterParser.getFirstIndex(req);
     int lastIndex = ParameterParser.getLastIndex(req);

--- a/src/brs/web/api/http/handler/GetTradeJournal.java
+++ b/src/brs/web/api/http/handler/GetTradeJournal.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Account;
 import brs.Asset;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Order;
 import brs.Trade;
 import brs.TransactionType;
@@ -37,7 +37,7 @@ public final class GetTradeJournal extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     final Account account = parameterService.getAccount(req);
 

--- a/src/brs/web/api/http/handler/GetTrades.java
+++ b/src/brs/web/api/http/handler/GetTrades.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Account;
 import brs.Asset;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Trade;
 import brs.assetexchange.AssetExchange;
 import brs.web.api.http.common.LegacyDocTag;
@@ -37,7 +37,7 @@ public final class GetTrades extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     String assetId = Convert.emptyToNull(req.getParameter(ASSET_PARAMETER));
     String accountId = Convert.emptyToNull(req.getParameter(ACCOUNT_PARAMETER));

--- a/src/brs/web/api/http/handler/GetTransactionIds.java
+++ b/src/brs/web/api/http/handler/GetTransactionIds.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Blockchain;
-import brs.BurstException;
+import brs.SignumException;
 import brs.services.ParameterService;
 import brs.util.Convert;
 
@@ -30,7 +30,7 @@ public final class GetTransactionIds extends ApiServlet.JsonRequestHandler {
   }
 
   @Override
-  public JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  public JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     Long senderId = null, recipientId = null;
     String senderParameter = Convert.emptyToNull(req.getParameter(SENDER_PARAMETER));

--- a/src/brs/web/api/http/handler/IssueAsset.java
+++ b/src/brs/web/api/http/handler/IssueAsset.java
@@ -30,7 +30,7 @@ public final class IssueAsset extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     String name = req.getParameter(NAME_PARAMETER);
     String description = req.getParameter(DESCRIPTION_PARAMETER);

--- a/src/brs/web/api/http/handler/IssueAsset.java
+++ b/src/brs/web/api/http/handler/IssueAsset.java
@@ -36,7 +36,7 @@ public final class IssueAsset extends CreateTransaction {
     String description = req.getParameter(DESCRIPTION_PARAMETER);
     String decimalsValue = Convert.emptyToNull(req.getParameter(DECIMALS_PARAMETER));
     boolean mintable = "true".equals(req.getParameter(MINTABLE_PARAMETER));
-    if(mintable && !Burst.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
+    if(mintable && !Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
       //only after the fork we are allowed to have a mintable assset
       return JSONResponses.incorrect(MINTABLE_PARAMETER);
     }

--- a/src/brs/web/api/http/handler/MintAsset.java
+++ b/src/brs/web/api/http/handler/MintAsset.java
@@ -41,14 +41,14 @@ public final class MintAsset extends CreateTransaction {
     if(asset.getMintable() == false) {
       return JSONResponses.incorrect("this asset is not mintable");
     }
-    if(!Burst.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
+    if(!Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
       return JSONResponses.incorrect("minting assets is not enabled yet");
     }
     if(asset.getAccountId() != account.getId()) {
       return JSONResponses.incorrect("only the current asset owner can mint new coins");
     }
 
-    boolean unconfirmed = !Burst.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX);
+    boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX);
     long circulatingSupply = assetExchange.getAssetCirculatingSupply(asset, false, unconfirmed);
     long newSupply = circulatingSupply + quantityQNT;
     if (newSupply > Constants.MAX_ASSET_QUANTITY_QNT) {

--- a/src/brs/web/api/http/handler/MintAsset.java
+++ b/src/brs/web/api/http/handler/MintAsset.java
@@ -32,7 +32,7 @@ public final class MintAsset extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     Asset asset = parameterService.getAsset(req);
     long quantityQNT = ParameterParser.getQuantityQNT(req);

--- a/src/brs/web/api/http/handler/ParseTransaction.java
+++ b/src/brs/web/api/http/handler/ParseTransaction.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.Transaction;
 import brs.services.ParameterService;
 import brs.services.TransactionService;
@@ -34,7 +34,7 @@ public final class ParseTransaction extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     String transactionBytes = Convert.emptyToNull(req.getParameter(TRANSACTION_BYTES_PARAMETER));
     String transactionJSON = Convert.emptyToNull(req.getParameter(TRANSACTION_JSON_PARAMETER));
@@ -42,7 +42,7 @@ public final class ParseTransaction extends ApiServlet.JsonRequestHandler {
     JsonObject response = JSONData.unconfirmedTransaction(transaction);
     try {
       transactionService.validate(transaction);
-    } catch (BurstException.ValidationException|RuntimeException e) {
+    } catch (SignumException.ValidationException|RuntimeException e) {
       logger.debug(e.getMessage(), e);
       response.addProperty(VALIDATE_RESPONSE, false);
       response.addProperty(ERROR_CODE_RESPONSE, 4);

--- a/src/brs/web/api/http/handler/PlaceAskOrder.java
+++ b/src/brs/web/api/http/handler/PlaceAskOrder.java
@@ -28,7 +28,7 @@ public final class PlaceAskOrder extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     final Asset asset = parameterService.getAsset(req);
     final long priceNQT = ParameterParser.getPriceNQT(req);

--- a/src/brs/web/api/http/handler/PlaceBidOrder.java
+++ b/src/brs/web/api/http/handler/PlaceBidOrder.java
@@ -26,7 +26,7 @@ public final class PlaceBidOrder extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     Asset asset = parameterService.getAsset(req);
     long priceNQT = ParameterParser.getPriceNQT(req);

--- a/src/brs/web/api/http/handler/RemoveCommitment.java
+++ b/src/brs/web/api/http/handler/RemoveCommitment.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Account;
 import brs.Attachment;
 import brs.Blockchain;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Constants;
 import brs.services.AccountService;
 import brs.services.ParameterService;
@@ -31,7 +31,7 @@ public final class RemoveCommitment extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     final Account account = parameterService.getSenderAccount(req);
     long amountNQT = ParameterParser.getAmountNQT(req);
 

--- a/src/brs/web/api/http/handler/SellAlias.java
+++ b/src/brs/web/api/http/handler/SellAlias.java
@@ -26,7 +26,7 @@ public final class SellAlias extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     Alias alias = parameterService.getAlias(req);
     Account owner = parameterService.getSenderAccount(req);
 

--- a/src/brs/web/api/http/handler/SendMessage.java
+++ b/src/brs/web/api/http/handler/SendMessage.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Account;
 import brs.Attachment;
-import brs.BurstException;
+import brs.SignumException;
 import brs.services.ParameterService;
 import brs.web.api.http.common.APITransactionManager;
 import brs.web.api.http.common.LegacyDocTag;
@@ -24,7 +24,7 @@ public final class SendMessage extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     long recipient = ParameterParser.getRecipientId(req);
     Account account = parameterService.getSenderAccount(req);
     return createTransaction(req, account, recipient, 0, Attachment.ARBITRARY_MESSAGE);

--- a/src/brs/web/api/http/handler/SendMoney.java
+++ b/src/brs/web/api/http/handler/SendMoney.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Account;
-import brs.BurstException;
+import brs.SignumException;
 import brs.services.ParameterService;
 import brs.web.api.http.common.APITransactionManager;
 import brs.web.api.http.common.LegacyDocTag;
@@ -24,7 +24,7 @@ public final class SendMoney extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     long recipient = ParameterParser.getRecipientId(req);
     long amountNQT = ParameterParser.getAmountNQT(req);
     Account account = parameterService.getSenderAccount(req);

--- a/src/brs/web/api/http/handler/SendMoneyEscrow.java
+++ b/src/brs/web/api/http/handler/SendMoneyEscrow.java
@@ -29,7 +29,7 @@ public final class SendMoneyEscrow extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     Account sender = parameterService.getSenderAccount(req);
     Long recipient = ParameterParser.getRecipientId(req);
     Long amountNQT = ParameterParser.getAmountNQT(req);

--- a/src/brs/web/api/http/handler/SendMoneyEscrow.java
+++ b/src/brs/web/api/http/handler/SendMoneyEscrow.java
@@ -83,7 +83,7 @@ public final class SendMoneyEscrow extends CreateTransaction {
       return response;
     }
 
-    long totalAmountNQT = Convert.safeAdd(amountNQT, signers.size() * Constants.ONE_BURST);
+    long totalAmountNQT = Convert.safeAdd(amountNQT, signers.size() * Constants.ONE_SIGNA);
     Account.Balance senderBalance = Account.getAccountBalance(sender.getId());
     if(senderBalance.getBalanceNQT() < totalAmountNQT) {
       JsonObject response = new JsonObject();

--- a/src/brs/web/api/http/handler/SendMoneyMulti.java
+++ b/src/brs/web/api/http/handler/SendMoneyMulti.java
@@ -37,7 +37,7 @@ public final class SendMoneyMulti extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     Account sender = parameterService.getSenderAccount(req);
     String recipientString = Convert.emptyToNull(req.getParameter(RECIPIENTS_PARAMETER));
 

--- a/src/brs/web/api/http/handler/SendMoneyMultiSame.java
+++ b/src/brs/web/api/http/handler/SendMoneyMultiSame.java
@@ -36,7 +36,7 @@ public final class SendMoneyMultiSame extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     long amountNQT = ParameterParser.getAmountNQT(req);
     Account sender = parameterService.getSenderAccount(req);
     String recipientString = Convert.emptyToNull(req.getParameter(RECIPIENTS_PARAMETER));

--- a/src/brs/web/api/http/handler/SendMoneySubscription.java
+++ b/src/brs/web/api/http/handler/SendMoneySubscription.java
@@ -27,7 +27,7 @@ public final class SendMoneySubscription extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     Account sender = parameterService.getSenderAccount(req);
     Long recipient = ParameterParser.getRecipientId(req);
     long amountNQT = ParameterParser.getAmountNQT(req);

--- a/src/brs/web/api/http/handler/SendMoneySubscription.java
+++ b/src/brs/web/api/http/handler/SendMoneySubscription.java
@@ -43,8 +43,8 @@ public final class SendMoneySubscription extends CreateTransaction {
       return response;
     }
 
-    if(frequency < Constants.BURST_SUBSCRIPTION_MIN_FREQ ||
-       frequency > Constants.BURST_SUBSCRIPTION_MAX_FREQ) {
+    if(frequency < Constants.SIGNUM_SUBSCRIPTION_MIN_FREQ ||
+       frequency > Constants.SIGNUM_SUBSCRIPTION_MAX_FREQ) {
       JsonObject response = new JsonObject();
       response.addProperty(ERROR_CODE_RESPONSE, 4);
       response.addProperty(ERROR_DESCRIPTION_RESPONSE, "Invalid frequency amount");

--- a/src/brs/web/api/http/handler/SetAccountInfo.java
+++ b/src/brs/web/api/http/handler/SetAccountInfo.java
@@ -27,7 +27,7 @@ public final class SetAccountInfo extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     String name = Convert.nullToEmpty(req.getParameter(NAME_PARAMETER)).trim();
     String description = Convert.nullToEmpty(req.getParameter(DESCRIPTION_PARAMETER)).trim();

--- a/src/brs/web/api/http/handler/SetAlias.java
+++ b/src/brs/web/api/http/handler/SetAlias.java
@@ -50,7 +50,7 @@ public final class SetAlias extends CreateTransaction {
       return INCORRECT_ALIAS_LENGTH;
     }
 
-    if (Burst.getFluxCapacitor().getValue(FluxValues.SMART_ALIASES)) {
+    if (Signum.getFluxCapacitor().getValue(FluxValues.SMART_ALIASES)) {
       if (!TextUtils.isInAlphabetOrUnderline(aliasName)) {
         return INCORRECT_ALIAS_NAME;
       }

--- a/src/brs/web/api/http/handler/SetAlias.java
+++ b/src/brs/web/api/http/handler/SetAlias.java
@@ -35,7 +35,7 @@ public final class SetAlias extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     String aliasName = Convert.emptyToNull(req.getParameter(ALIAS_NAME_PARAMETER));
     String aliasURI = Convert.nullToEmpty(req.getParameter(ALIAS_URI_PARAMETER));
     String tldName = Convert.emptyToNull(req.getParameter(TLD_PARAMETER));

--- a/src/brs/web/api/http/handler/SetRewardRecipient.java
+++ b/src/brs/web/api/http/handler/SetRewardRecipient.java
@@ -43,7 +43,7 @@ public final class SetRewardRecipient extends CreateTransaction {
       response.addProperty(ERROR_DESCRIPTION_RESPONSE, "recipient account does not have public key");
       return response;
     }
-    Attachment attachment = new Attachment.BurstMiningRewardRecipientAssignment(blockchain.getHeight());
+    Attachment attachment = new Attachment.SignaMiningRewardRecipientAssignment(blockchain.getHeight());
     return createTransaction(req, account, recipient, 0, attachment);
   }
 

--- a/src/brs/web/api/http/handler/SetRewardRecipient.java
+++ b/src/brs/web/api/http/handler/SetRewardRecipient.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Account;
 import brs.Attachment;
 import brs.Blockchain;
-import brs.BurstException;
+import brs.SignumException;
 import brs.services.AccountService;
 import brs.services.ParameterService;
 import brs.web.api.http.common.APITransactionManager;
@@ -33,7 +33,7 @@ public final class SetRewardRecipient extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     final Account account = parameterService.getSenderAccount(req);
     Long recipient = ParameterParser.getRecipientId(req);
     Account recipientAccount = accountService.getAccount(recipient);

--- a/src/brs/web/api/http/handler/SetTLD.java
+++ b/src/brs/web/api/http/handler/SetTLD.java
@@ -35,7 +35,7 @@ public final class SetTLD extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     String tldName = Convert.emptyToNull(req.getParameter(TLD_PARAMETER));
 
     if (tldName == null) {

--- a/src/brs/web/api/http/handler/SetTLD.java
+++ b/src/brs/web/api/http/handler/SetTLD.java
@@ -61,7 +61,7 @@ public final class SetTLD extends CreateTransaction {
 
     long recipient = 0L;
     long amountNQT = ParameterParser.getAmountNQT(req);
-    if(amountNQT < TransactionType.BASELINE_TLD_ASSIGNMENT_FACTOR * Burst.getFluxCapacitor().getValue(FluxValues.FEE_QUANT, blockchain.getLastBlock().getHeight())) {
+    if(amountNQT < TransactionType.BASELINE_TLD_ASSIGNMENT_FACTOR * Signum.getFluxCapacitor().getValue(FluxValues.FEE_QUANT, blockchain.getLastBlock().getHeight())) {
       return incorrect(AMOUNT_NQT_PARAMETER);
     }
 

--- a/src/brs/web/api/http/handler/SignTransaction.java
+++ b/src/brs/web/api/http/handler/SignTransaction.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.Transaction;
 import brs.crypto.Crypto;
 import brs.services.ParameterService;
@@ -36,7 +36,7 @@ public final class SignTransaction extends ApiServlet.JsonRequestHandler {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     String transactionBytes = Convert.emptyToNull(req.getParameter(UNSIGNED_TRANSACTION_BYTES_PARAMETER));
     String transactionJSON = Convert.emptyToNull(req.getParameter(UNSIGNED_TRANSACTION_JSON_PARAMETER));
@@ -66,7 +66,7 @@ public final class SignTransaction extends ApiServlet.JsonRequestHandler {
       response.addProperty(TRANSACTION_BYTES_RESPONSE, Convert.toHexString(transaction.getBytes()));
       response.addProperty(SIGNATURE_HASH_RESPONSE, Convert.toHexString(Crypto.sha256().digest(transaction.getSignature())));
       response.addProperty(VERIFY_RESPONSE, transaction.verifySignature() && transactionService.verifyPublicKey(transaction));
-    } catch (BurstException.ValidationException|RuntimeException e) {
+    } catch (SignumException.ValidationException|RuntimeException e) {
       logger.debug(e.getMessage(), e);
       response.addProperty(ERROR_CODE_RESPONSE, 4);
       response.addProperty(ERROR_DESCRIPTION_RESPONSE, "Incorrect unsigned transaction: " + e.toString());

--- a/src/brs/web/api/http/handler/SubmitNonce.java
+++ b/src/brs/web/api/http/handler/SubmitNonce.java
@@ -39,10 +39,10 @@ public final class SubmitNonce extends ApiServlet.JsonRequestHandler {
 
   public SubmitNonce(PropertyService propertyService, AccountService accountService, Blockchain blockchain, Generator generator) {
     super(new LegacyDocTag[] {LegacyDocTag.MINING}, SECRET_PHRASE_PARAMETER, NONCE_PARAMETER, ACCOUNT_ID_PARAMETER, BLOCK_HEIGHT_PARAMETER, DEADLINE_PARAMETER);
-    SignumCrypto burstCrypto = SignumCrypto.getInstance();
+    SignumCrypto signumCrypto = SignumCrypto.getInstance();
     this.passphrases = propertyService.getStringList(Props.SOLO_MINING_PASSPHRASES)
             .stream()
-            .collect(Collectors.toMap(passphrase -> burstCrypto.getAddressFromPassphrase(passphrase).getSignedLongId(), Function.identity()));
+            .collect(Collectors.toMap(passphrase -> signumCrypto.getAddressFromPassphrase(passphrase).getSignedLongId(), Function.identity()));
     this.allowOtherSoloMiners = propertyService.getBoolean(Props.ALLOW_OTHER_SOLO_MINERS);
     this.checkPointHeight = propertyService.getInt(Props.BRS_CHECKPOINT_HEIGHT);
 

--- a/src/brs/web/api/http/handler/SubscriptionCancel.java
+++ b/src/brs/web/api/http/handler/SubscriptionCancel.java
@@ -30,7 +30,7 @@ public final class SubscriptionCancel extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
     final Account sender = parameterService.getSenderAccount(req);
 
     String subscriptionString = Convert.emptyToNull(req.getParameter(SUBSCRIPTION_PARAMETER));

--- a/src/brs/web/api/http/handler/TransferAsset.java
+++ b/src/brs/web/api/http/handler/TransferAsset.java
@@ -32,7 +32,7 @@ public final class TransferAsset extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     long recipient = ParameterParser.getRecipientId(req);
 

--- a/src/brs/web/api/http/handler/TransferAsset.java
+++ b/src/brs/web/api/http/handler/TransferAsset.java
@@ -56,7 +56,7 @@ public final class TransferAsset extends CreateTransaction {
       if (amountNQT < 0 || amountNQT >= Constants.MAX_BALANCE_NQT) {
         return JSONResponses.incorrect(AMOUNT_NQT_PARAMETER);
       }
-      else if (!Burst.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
+      else if (!Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
         return JSONResponses.incorrect(AMOUNT_NQT_PARAMETER);
       }
     }

--- a/src/brs/web/api/http/handler/TransferAssetMulti.java
+++ b/src/brs/web/api/http/handler/TransferAssetMulti.java
@@ -20,7 +20,7 @@ import brs.Asset;
 import brs.Attachment;
 import brs.Blockchain;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Constants;
 import brs.fluxcapacitor.FluxValues;
 import brs.services.AccountService;
@@ -42,7 +42,7 @@ public final class TransferAssetMulti extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     long recipient = ParameterParser.getRecipientId(req);
     Account account = parameterService.getSenderAccount(req);

--- a/src/brs/web/api/http/handler/TransferAssetMulti.java
+++ b/src/brs/web/api/http/handler/TransferAssetMulti.java
@@ -19,7 +19,7 @@ import brs.Account;
 import brs.Asset;
 import brs.Attachment;
 import brs.Blockchain;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.Constants;
 import brs.fluxcapacitor.FluxValues;
@@ -64,7 +64,7 @@ public final class TransferAssetMulti extends CreateTransaction {
     for(String assetIdString : assetIdsArray) {
       String[] assetIdAndQuantity = assetIdString.split(":", 2);
       long assetId = Convert.parseUnsignedLong(assetIdAndQuantity[0]);
-      Asset asset = Burst.getStores().getAssetStore().getAsset(assetId);
+      Asset asset = Signum.getStores().getAssetStore().getAsset(assetId);
       if(asset == null || assetIds.contains(assetId)) {
         return JSONResponses.incorrect(ASSET_IDS_AND_QUANTITIES_PARAMETER);
       }
@@ -92,7 +92,7 @@ public final class TransferAssetMulti extends CreateTransaction {
       if (amountNQT < 0 || amountNQT >= Constants.MAX_BALANCE_NQT) {
         return JSONResponses.incorrect(AMOUNT_NQT_PARAMETER);
       }
-      else if (!Burst.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
+      else if (!Signum.getFluxCapacitor().getValue(FluxValues.SMART_TOKEN)) {
         return JSONResponses.incorrect(AMOUNT_NQT_PARAMETER);
       }
     }

--- a/src/brs/web/api/http/handler/TransferAssetOwnership.java
+++ b/src/brs/web/api/http/handler/TransferAssetOwnership.java
@@ -32,7 +32,7 @@ public final class TransferAssetOwnership extends CreateTransaction {
 
   @Override
   protected
-  JsonElement processRequest(HttpServletRequest req) throws BurstException {
+  JsonElement processRequest(HttpServletRequest req) throws SignumException {
 
     Account account = parameterService.getSenderAccount(req);
     long recipientId = ParameterParser.getRecipientId(req);

--- a/src/brs/web/api/http/handler/TransferAssetOwnership.java
+++ b/src/brs/web/api/http/handler/TransferAssetOwnership.java
@@ -52,7 +52,7 @@ public final class TransferAssetOwnership extends CreateTransaction {
     if(asset.getAccountId() != account.getId()) {
       return JSONResponses.incorrect(REFERENCED_TRANSACTION_FULL_HASH_PARAMETER, "sender is not the asset current owner");
     }
-    if(!Burst.getFluxCapacitor().getValue(FluxValues.PK_FREEZE2)) {
+    if(!Signum.getFluxCapacitor().getValue(FluxValues.PK_FREEZE2)) {
       return JSONResponses.incorrect(REFERENCED_TRANSACTION_FULL_HASH_PARAMETER, "ownership transfer is not enabled yet");
     }
 

--- a/src/brs/web/api/ws/BlockchainEventNotifier.java
+++ b/src/brs/web/api/ws/BlockchainEventNotifier.java
@@ -63,7 +63,7 @@ public class BlockchainEventNotifier {
 
     notifyExecutor.submit(() -> {
       ConnectedEventData data = new ConnectedEventData();
-      data.version = Burst.VERSION.toString();
+      data.version = Signum.VERSION.toString();
       data.networkName = context.getPropertyService().getString(Props.NETWORK_NAME);
       data.globalHeight = context.getBlockchainProcessor().getLastBlockchainFeederHeight();
       data.localHeight = context.getBlockchain().getHeight();

--- a/src/signum/Launcher.java
+++ b/src/signum/Launcher.java
@@ -41,11 +41,11 @@ public class Launcher {
 
     if (canRunGui) {
       try {
-        Class.forName("brs.BurstGUI")
+        Class.forName("brs.SignumGUI")
           .getDeclaredMethod("main", String[].class)
           .invoke(null, (Object) args);
       } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-        logger.warn("Your build does not seem to include the BurstGUI extension or it cannot be run. Running as headless...");
+        logger.warn("Your build does not seem to include the SignumGUI extension or it cannot be run. Running as headless...");
         Signum.main(args);
       }
     } else {

--- a/src/signum/Launcher.java
+++ b/src/signum/Launcher.java
@@ -7,7 +7,7 @@ import org.apache.commons.cli.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import brs.Burst;
+import brs.Signum;
 
 import java.awt.*;
 import java.lang.reflect.InvocationTargetException;
@@ -18,11 +18,11 @@ public class Launcher {
     boolean canRunGui = true;
 
     try {
-      CommandLine cmd = new DefaultParser().parse(Burst.CLI_OPTIONS, args);
+      CommandLine cmd = new DefaultParser().parse(Signum.CLI_OPTIONS, args);
       if (cmd.hasOption("h")) {
         HelpFormatter formatter = new HelpFormatter();
-        formatter.printHelp("java -jar signum-node.jar", "Signum Node version " + Burst.VERSION,
-          Burst.CLI_OPTIONS,
+        formatter.printHelp("java -jar signum-node.jar", "Signum Node version " + Signum.VERSION,
+          Signum.CLI_OPTIONS,
           "Check for updates at https://github.com/signum-network/signum-node", true);
         return;
       }
@@ -46,10 +46,10 @@ public class Launcher {
           .invoke(null, (Object) args);
       } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
         logger.warn("Your build does not seem to include the BurstGUI extension or it cannot be run. Running as headless...");
-        Burst.main(args);
+        Signum.main(args);
       }
     } else {
-      Burst.main(args);
+      Signum.main(args);
     }
   }
 }

--- a/test/java/brs/GeneratorImplTest.java
+++ b/test/java/brs/GeneratorImplTest.java
@@ -25,7 +25,7 @@ public class GeneratorImplTest {
 
     private static final byte[] exampleGenSig = Convert.parseHexString("6ec823b5fd86c4aee9f7c3453cacaf4a43296f48ede77e70060ca8225c2855d0");
     private static final long exampleBaseTarget = 70312;
-    private static final long exampleAverageCommitment = Constants.ONE_BURST * 10;
+    private static final long exampleAverageCommitment = Constants.ONE_SIGNA * 10;
     private static final int exampleHeight = 500000;
 
     @Before

--- a/test/java/brs/assetexchange/AssetServiceImplTest.java
+++ b/test/java/brs/assetexchange/AssetServiceImplTest.java
@@ -7,8 +7,8 @@ import brs.Attachment.ColoredCoinsAssetIssuance;
 import brs.Trade;
 import brs.Transaction;
 import brs.common.AbstractUnitTest;
-import brs.db.BurstKey;
-import brs.db.BurstKey.LongKeyFactory;
+import brs.db.SignumKey;
+import brs.db.SignumKey.LongKeyFactory;
 import brs.db.sql.EntitySqlTable;
 import brs.db.store.AssetStore;
 import org.junit.Before;
@@ -54,7 +54,7 @@ public class AssetServiceImplTest extends AbstractUnitTest {
   public void getAsset() {
     final long assetId = 123l;
     final Asset mockAsset = mock(Asset.class);
-    final BurstKey assetKeyMock = mock(BurstKey.class);
+    final SignumKey assetKeyMock = mock(SignumKey.class);
 
     when(assetDbKeyFactoryMock.newKey(eq(assetId))).thenReturn(assetKeyMock);
     when(assetTableMock.get(eq(assetKeyMock))).thenReturn(mockAsset);
@@ -134,7 +134,7 @@ public class AssetServiceImplTest extends AbstractUnitTest {
 
   @Test
   public void addAsset() {
-    final BurstKey assetKey = mock(BurstKey.class);
+    final SignumKey assetKey = mock(SignumKey.class);
 
     long transactionId = 123L;
 

--- a/test/java/brs/assetexchange/OrderServiceImplTest.java
+++ b/test/java/brs/assetexchange/OrderServiceImplTest.java
@@ -2,8 +2,8 @@ package brs.assetexchange;
 
 import brs.Order.Ask;
 import brs.Order.Bid;
-import brs.db.BurstKey;
-import brs.db.BurstKey.LongKeyFactory;
+import brs.db.SignumKey;
+import brs.db.SignumKey.LongKeyFactory;
 import brs.db.VersionedEntityTable;
 import brs.db.store.OrderStore;
 import brs.services.AccountService;
@@ -51,7 +51,7 @@ public class OrderServiceImplTest {
 
   @Test
   public void getAskOrder() {
-    final BurstKey mockAskKey = mock(BurstKey.class);
+    final SignumKey mockAskKey = mock(SignumKey.class);
     final Ask mockAsk = mock(Ask.class);
 
     final long askKey = 123l;
@@ -64,7 +64,7 @@ public class OrderServiceImplTest {
 
   @Test
   public void getBidOrder() {
-    final BurstKey mockBidKey = mock(BurstKey.class);
+    final SignumKey mockBidKey = mock(SignumKey.class);
     final Bid mockBid = mock(Bid.class);
 
     final long bidKey = 123l;

--- a/test/java/brs/at/ATTest.java
+++ b/test/java/brs/at/ATTest.java
@@ -1,7 +1,7 @@
 package brs.at;
 
 import brs.Account;
-import brs.Burst;
+import brs.Signum;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Burst.class, Account.class})
+@PrepareForTest({Signum.class, Account.class})
 public class ATTest {
     @Before
     public void setUp() {

--- a/test/java/brs/at/AtControllerTest.java
+++ b/test/java/brs/at/AtControllerTest.java
@@ -1,7 +1,7 @@
 package brs.at;
 
 import brs.Account;
-import brs.Burst;
+import brs.Signum;
 import brs.util.Convert;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Burst.class, Account.class})
+@PrepareForTest({Signum.class, Account.class})
 public class AtControllerTest {
     @Before
     public void setUp() {

--- a/test/java/brs/at/AtTestHelper.java
+++ b/test/java/brs/at/AtTestHelper.java
@@ -5,7 +5,7 @@ import brs.Blockchain;
 import brs.Signum;
 import brs.common.QuickMocker;
 import brs.common.TestConstants;
-import brs.db.BurstKey;
+import brs.db.SignumKey;
 import brs.db.VersionedBatchEntityTable;
 import brs.db.VersionedEntityTable;
 import brs.db.store.ATStore;
@@ -55,9 +55,9 @@ public class AtTestHelper {
         ATStore mockAtStore = mock(ATStore.class);
         FluxCapacitor mockFluxCapacitor = QuickMocker.latestValueFluxCapacitor();
         //noinspection unchecked
-        BurstKey.LongKeyFactory<AT> atLongKeyFactory = mock(BurstKey.LongKeyFactory.class);
+        SignumKey.LongKeyFactory<AT> atLongKeyFactory = mock(SignumKey.LongKeyFactory.class);
         //noinspection unchecked
-        BurstKey.LongKeyFactory<AT.ATState> atStateLongKeyFactory = mock(BurstKey.LongKeyFactory.class);
+        SignumKey.LongKeyFactory<AT.ATState> atStateLongKeyFactory = mock(SignumKey.LongKeyFactory.class);
         mockStatic(Signum.class);
         Blockchain mockBlockchain = mock(Blockchain.class);
         PropertyService mockPropertyService = mock(PropertyService.class);
@@ -69,7 +69,7 @@ public class AtTestHelper {
         VersionedEntityTable<AT.ATState> mockAtStateTable = mock(VersionedEntityTable.class);
         AccountStore mockAccountStore = mock(AccountStore.class);
         //noinspection unchecked
-        BurstKey.LongKeyFactory<Account> mockAccountKeyFactory = mock(BurstKey.LongKeyFactory.class);
+        SignumKey.LongKeyFactory<Account> mockAccountKeyFactory = mock(SignumKey.LongKeyFactory.class);
         Account mockAccount = mock(Account.class);
         Account.Balance mockAccountBalance = mock(Account.Balance.class);
         mockStatic(Account.class);

--- a/test/java/brs/at/AtTestHelper.java
+++ b/test/java/brs/at/AtTestHelper.java
@@ -2,7 +2,7 @@ package brs.at;
 
 import brs.Account;
 import brs.Blockchain;
-import brs.Burst;
+import brs.Signum;
 import brs.common.QuickMocker;
 import brs.common.TestConstants;
 import brs.db.BurstKey;
@@ -58,7 +58,7 @@ public class AtTestHelper {
         BurstKey.LongKeyFactory<AT> atLongKeyFactory = mock(BurstKey.LongKeyFactory.class);
         //noinspection unchecked
         BurstKey.LongKeyFactory<AT.ATState> atStateLongKeyFactory = mock(BurstKey.LongKeyFactory.class);
-        mockStatic(Burst.class);
+        mockStatic(Signum.class);
         Blockchain mockBlockchain = mock(Blockchain.class);
         PropertyService mockPropertyService = mock(PropertyService.class);
         //noinspection unchecked
@@ -120,14 +120,14 @@ public class AtTestHelper {
         when(mockAtStore.getAtStateTable()).thenReturn(mockAtStateTable);
         when(mockPropertyService.getBoolean(ArgumentMatchers.eq(Props.ENABLE_AT_DEBUG_LOG))).thenReturn(true);
         when(mockAtStore.getAtTable()).thenReturn(mockAtTable);
-        when(Burst.getPropertyService()).thenReturn(mockPropertyService);
-        when(Burst.getBlockchain()).thenReturn(mockBlockchain);
+        when(Signum.getPropertyService()).thenReturn(mockPropertyService);
+        when(Signum.getBlockchain()).thenReturn(mockBlockchain);
         when(mockBlockchain.getHeight()).thenReturn(Integer.MAX_VALUE);
         when(mockAtStore.getAtDbKeyFactory()).thenReturn(atLongKeyFactory);
         when(mockAtStore.getAtStateDbKeyFactory()).thenReturn(atStateLongKeyFactory);
         when(mockStores.getAtStore()).thenReturn(mockAtStore);
-        when(Burst.getStores()).thenReturn(mockStores);
-        when(Burst.getFluxCapacitor()).thenReturn(mockFluxCapacitor);
+        when(Signum.getStores()).thenReturn(mockStores);
+        when(Signum.getFluxCapacitor()).thenReturn(mockFluxCapacitor);
     }
 
     static void clearAddedAts() {

--- a/test/java/brs/at/AtTestHelper.java
+++ b/test/java/brs/at/AtTestHelper.java
@@ -82,8 +82,8 @@ public class AtTestHelper {
             }
             return null;
         }).when(mockAtTable).insert(ArgumentMatchers.any());
-        when(mockAccount.getBalanceNQT()).thenReturn(TestConstants.TEN_BURST);
-        when(mockAccountBalance.getBalanceNQT()).thenReturn(TestConstants.TEN_BURST);
+        when(mockAccount.getBalanceNQT()).thenReturn(TestConstants.TEN_SIGNA);
+        when(mockAccountBalance.getBalanceNQT()).thenReturn(TestConstants.TEN_SIGNA);
         when(mockAccountStore.getAccountTable()).thenReturn(mockAccountTable);
         when(mockAccountStore.setOrVerify(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.anyInt()))
                 .thenReturn(true);
@@ -154,7 +154,7 @@ public class AtTestHelper {
         short dpages = 1;
         short cspages = 1;
         short uspages = 1;
-        long minActivationAmount = TestConstants.TEN_BURST;
+        long minActivationAmount = TestConstants.TEN_SIGNA;
         byte[] data = new byte[0];
         int creationLength = 4; // version + reserved
         creationLength += 8; // pages

--- a/test/java/brs/common/TestConstants.java
+++ b/test/java/brs/common/TestConstants.java
@@ -2,7 +2,7 @@ package brs.common;
 
 import brs.crypto.Crypto;
 
-import static brs.Constants.ONE_BURST;
+import static brs.Constants.ONE_SIGNA;
 
 public class TestConstants {
 
@@ -20,7 +20,7 @@ public class TestConstants {
 
   public static final String DEADLINE = "400";
 
-  public static final String FEE = "" + ONE_BURST;
+  public static final String FEE = "" + ONE_SIGNA;
 
-  public static final long TEN_BURST = ONE_BURST * 10;
+  public static final long TEN_SIGNA = ONE_SIGNA * 10;
 }

--- a/test/java/brs/crypto/CryptoTest.java
+++ b/test/java/brs/crypto/CryptoTest.java
@@ -85,19 +85,19 @@ public class CryptoTest {
 
     @Test
     public void testCryptoRsEncode() {
-        SignumCrypto burstCrypto = SignumCrypto.getInstance();
-        assertEquals("23YP-M8H9-FA5W-5CX9B", Crypto.rsEncode(burstCrypto.getAddressFromPassphrase("").getSignedLongId()));
-        assertEquals("BTKQ-5ST6-6HAL-HKVYW", Crypto.rsEncode(burstCrypto.getAddressFromPassphrase("Testing").getSignedLongId()));
-        assertEquals("4KFW-N4LS-7UVW-8AUZJ", Crypto.rsEncode(burstCrypto.getAddressFromPassphrase("Burstcoin!").getSignedLongId()));
-        assertEquals("T7XD-7M3X-MB9F-38DU8", Crypto.rsEncode(burstCrypto.getAddressFromPassphrase("Burst Apps Team").getSignedLongId()));
+        SignumCrypto signumCrypto = SignumCrypto.getInstance();
+        assertEquals("23YP-M8H9-FA5W-5CX9B", Crypto.rsEncode(signumCrypto.getAddressFromPassphrase("").getSignedLongId()));
+        assertEquals("BTKQ-5ST6-6HAL-HKVYW", Crypto.rsEncode(signumCrypto.getAddressFromPassphrase("Testing").getSignedLongId()));
+        assertEquals("4KFW-N4LS-7UVW-8AUZJ", Crypto.rsEncode(signumCrypto.getAddressFromPassphrase("Burstcoin!").getSignedLongId()));
+        assertEquals("T7XD-7M3X-MB9F-38DU8", Crypto.rsEncode(signumCrypto.getAddressFromPassphrase("Burst Apps Team").getSignedLongId()));
     }
 
     @Test
     public void testCryptoRsDecode() {
-        SignumCrypto burstCrypto = SignumCrypto.getInstance();
-        assertEquals(burstCrypto.getAddressFromPassphrase("").getSignedLongId(), Crypto.rsDecode("23YP-M8H9-FA5W-5CX9B"));
-        assertEquals(burstCrypto.getAddressFromPassphrase("Testing").getSignedLongId(), Crypto.rsDecode("BTKQ-5ST6-6HAL-HKVYW"));
-        assertEquals(burstCrypto.getAddressFromPassphrase("Burstcoin!").getSignedLongId(), Crypto.rsDecode("4KFW-N4LS-7UVW-8AUZJ"));
-        assertEquals(burstCrypto.getAddressFromPassphrase("Burst Apps Team").getSignedLongId(), Crypto.rsDecode("T7XD-7M3X-MB9F-38DU8"));
+        SignumCrypto signumCrypto = SignumCrypto.getInstance();
+        assertEquals(signumCrypto.getAddressFromPassphrase("").getSignedLongId(), Crypto.rsDecode("23YP-M8H9-FA5W-5CX9B"));
+        assertEquals(signumCrypto.getAddressFromPassphrase("Testing").getSignedLongId(), Crypto.rsDecode("BTKQ-5ST6-6HAL-HKVYW"));
+        assertEquals(signumCrypto.getAddressFromPassphrase("Burstcoin!").getSignedLongId(), Crypto.rsDecode("4KFW-N4LS-7UVW-8AUZJ"));
+        assertEquals(signumCrypto.getAddressFromPassphrase("Burst Apps Team").getSignedLongId(), Crypto.rsDecode("T7XD-7M3X-MB9F-38DU8"));
     }
 }

--- a/test/java/brs/deeplink/DeeplinkQRCodeGeneratorTest.java
+++ b/test/java/brs/deeplink/DeeplinkQRCodeGeneratorTest.java
@@ -23,7 +23,7 @@ public class DeeplinkQRCodeGeneratorTest {
 
     @Test
     public void testDeeplinkQrCodeGenerator() throws WriterException {
-        BufferedImage image = deeplinkQRCodeGenerator.generateRequestBurstDeepLinkQRCode(TestConstants.TEST_ACCOUNT_NUMERIC_ID, TestConstants.TEN_SIGNA, FeeSuggestionType.STANDARD, 0L, "Test!", true);
+        BufferedImage image = deeplinkQRCodeGenerator.generateRequestSignumDeepLinkQRCode(TestConstants.TEST_ACCOUNT_NUMERIC_ID, TestConstants.TEN_SIGNA, FeeSuggestionType.STANDARD, 0L, "Test!", true);
         assertNotNull(image);
     }
 }

--- a/test/java/brs/deeplink/DeeplinkQRCodeGeneratorTest.java
+++ b/test/java/brs/deeplink/DeeplinkQRCodeGeneratorTest.java
@@ -23,7 +23,7 @@ public class DeeplinkQRCodeGeneratorTest {
 
     @Test
     public void testDeeplinkQrCodeGenerator() throws WriterException {
-        BufferedImage image = deeplinkQRCodeGenerator.generateRequestBurstDeepLinkQRCode(TestConstants.TEST_ACCOUNT_NUMERIC_ID, TestConstants.TEN_BURST, FeeSuggestionType.STANDARD, 0L, "Test!", true);
+        BufferedImage image = deeplinkQRCodeGenerator.generateRequestBurstDeepLinkQRCode(TestConstants.TEST_ACCOUNT_NUMERIC_ID, TestConstants.TEN_SIGNA, FeeSuggestionType.STANDARD, 0L, "Test!", true);
         assertNotNull(image);
     }
 }

--- a/test/java/brs/feesuggestions/FeeSuggestionCalculatorTest.java
+++ b/test/java/brs/feesuggestions/FeeSuggestionCalculatorTest.java
@@ -2,7 +2,7 @@ package brs.feesuggestions;
 
 import brs.Block;
 import brs.BlockchainProcessor;
-import brs.Burst;
+import brs.Signum;
 import brs.Constants;
 import brs.BlockchainProcessor.Event;
 import brs.common.AbstractUnitTest;
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class FeeSuggestionCalculatorTest extends AbstractUnitTest {
 
   private FeeSuggestionCalculator t;
@@ -42,13 +42,13 @@ public class FeeSuggestionCalculatorTest extends AbstractUnitTest {
 
   @Before
   public void setUp() {
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
 
     blockchainProcessorMock = mock(BlockchainProcessor.class);
     unconfirmedTransactionStoreMock = mock(UnconfirmedTransactionStore.class);
 
     FluxCapacitor mockFluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.PRE_POC2, FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(mockFluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(mockFluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(mockFluxCapacitor).getValue(eq(FluxValues.FEE_QUANT), anyInt());
     doReturn(Constants.FEE_QUANT_SIP3).when(mockFluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 

--- a/test/java/brs/services/impl/AccountServiceImplTest.java
+++ b/test/java/brs/services/impl/AccountServiceImplTest.java
@@ -2,8 +2,8 @@ package brs.services.impl;
 
 import brs.Account;
 import brs.Account.RewardRecipientAssignment;
-import brs.db.BurstKey;
-import brs.db.BurstKey.LongKeyFactory;
+import brs.db.SignumKey;
+import brs.db.SignumKey.LongKeyFactory;
 import brs.db.VersionedBatchEntityTable;
 import brs.db.store.AccountStore;
 import brs.db.store.AssetTransferStore;
@@ -42,7 +42,7 @@ public class AccountServiceImplTest {
   @Test
   public void getAccount() {
     final long mockId = 123l;
-    final BurstKey mockKey = mock(BurstKey.class);
+    final SignumKey mockKey = mock(SignumKey.class);
     final Account mockResultAccount = mock(Account.class);
 
     when(accountBurstKeyFactoryMock.newKey(eq(mockId))).thenReturn(mockKey);
@@ -60,7 +60,7 @@ public class AccountServiceImplTest {
   public void getAccount_withHeight() {
     final long id = 123l;
     final int height = 2;
-    final BurstKey mockKey = mock(BurstKey.class);
+    final SignumKey mockKey = mock(SignumKey.class);
     final Account mockResultAccount = mock(Account.class);
 
     when(accountBurstKeyFactoryMock.newKey(eq(id))).thenReturn(mockKey);
@@ -79,7 +79,7 @@ public class AccountServiceImplTest {
     byte[] publicKey = new byte[1];
     publicKey[0] = (byte) 1;
 
-    final BurstKey mockKey = mock(BurstKey.class);
+    final SignumKey mockKey = mock(SignumKey.class);
     final Account mockAccount = mock(Account.class);
 
     when(accountBurstKeyFactoryMock.newKey(anyLong())).thenReturn(mockKey);
@@ -95,7 +95,7 @@ public class AccountServiceImplTest {
     byte[] publicKey = new byte[1];
     publicKey[0] = (byte) 1;
 
-    final BurstKey mockKey = mock(BurstKey.class);
+    final SignumKey mockKey = mock(SignumKey.class);
     final Account mockAccount = mock(Account.class);
 
     when(accountBurstKeyFactoryMock.newKey(anyLong())).thenReturn(mockKey);
@@ -109,7 +109,7 @@ public class AccountServiceImplTest {
   @Test
   public void getAccount_withPublicKey_notFoundReturnsNull() {
     final byte[] publicKey = new byte[0];
-    final BurstKey mockKey = mock(BurstKey.class);
+    final SignumKey mockKey = mock(SignumKey.class);
 
     when(accountBurstKeyFactoryMock.newKey(anyLong())).thenReturn(mockKey);
     when(accountTableMock.get(mockKey)).thenReturn(null);
@@ -124,7 +124,7 @@ public class AccountServiceImplTest {
     byte[] otherPublicKey = new byte[1];
     otherPublicKey[0] = (byte) 2;
 
-    final BurstKey mockKey = mock(BurstKey.class);
+    final SignumKey mockKey = mock(SignumKey.class);
     final Account mockAccount = mock(Account.class);
 
     when(accountBurstKeyFactoryMock.newKey(anyLong())).thenReturn(mockKey);
@@ -189,7 +189,7 @@ public class AccountServiceImplTest {
   public void getOrAddAccount_addAccount() {
     long accountId = 123L;
 
-    final BurstKey mockKey = mock(BurstKey.class);
+    final SignumKey mockKey = mock(SignumKey.class);
 
     when(accountBurstKeyFactoryMock.newKey(eq(accountId))).thenReturn(mockKey);
     when(accountTableMock.get(eq(mockKey))).thenReturn(null);
@@ -206,7 +206,7 @@ public class AccountServiceImplTest {
   public void getOrAddAccount_getAccount() {
     long accountId = 123L;
 
-    final BurstKey mockKey = mock(BurstKey.class);
+    final SignumKey mockKey = mock(SignumKey.class);
     final Account mockAccount = mock(Account.class);
 
     when(accountBurstKeyFactoryMock.newKey(eq(accountId))).thenReturn(mockKey);

--- a/test/java/brs/services/impl/AccountServiceImplTest.java
+++ b/test/java/brs/services/impl/AccountServiceImplTest.java
@@ -21,7 +21,7 @@ public class AccountServiceImplTest {
 
   private AccountStore accountStoreMock;
   private VersionedBatchEntityTable<Account> accountTableMock;
-  private LongKeyFactory<Account> accountBurstKeyFactoryMock;
+  private LongKeyFactory<Account> accountSignumKeyFactoryMock;
   private AssetTransferStore assetTransferStoreMock;
 
   private AccountServiceImpl t;
@@ -30,11 +30,11 @@ public class AccountServiceImplTest {
   public void setUp() {
     accountStoreMock = mock(AccountStore.class);
     accountTableMock = mock(VersionedBatchEntityTable.class);
-    accountBurstKeyFactoryMock = mock(LongKeyFactory.class);
+    accountSignumKeyFactoryMock = mock(LongKeyFactory.class);
     assetTransferStoreMock = mock(AssetTransferStore.class);
 
     when(accountStoreMock.getAccountTable()).thenReturn(accountTableMock);
-    when(accountStoreMock.getAccountKeyFactory()).thenReturn(accountBurstKeyFactoryMock);
+    when(accountStoreMock.getAccountKeyFactory()).thenReturn(accountSignumKeyFactoryMock);
 
     t = new AccountServiceImpl(accountStoreMock, assetTransferStoreMock);
   }
@@ -45,7 +45,7 @@ public class AccountServiceImplTest {
     final SignumKey mockKey = mock(SignumKey.class);
     final Account mockResultAccount = mock(Account.class);
 
-    when(accountBurstKeyFactoryMock.newKey(eq(mockId))).thenReturn(mockKey);
+    when(accountSignumKeyFactoryMock.newKey(eq(mockId))).thenReturn(mockKey);
     when(accountTableMock.get(eq((mockKey)))).thenReturn(mockResultAccount);
 
     assertEquals(mockResultAccount, t.getAccount(mockId));
@@ -63,7 +63,7 @@ public class AccountServiceImplTest {
     final SignumKey mockKey = mock(SignumKey.class);
     final Account mockResultAccount = mock(Account.class);
 
-    when(accountBurstKeyFactoryMock.newKey(eq(id))).thenReturn(mockKey);
+    when(accountSignumKeyFactoryMock.newKey(eq(id))).thenReturn(mockKey);
     when(accountTableMock.get(eq(mockKey), eq(height))).thenReturn(mockResultAccount);
 
     assertEquals(mockResultAccount, t.getAccount(id, height));
@@ -82,7 +82,7 @@ public class AccountServiceImplTest {
     final SignumKey mockKey = mock(SignumKey.class);
     final Account mockAccount = mock(Account.class);
 
-    when(accountBurstKeyFactoryMock.newKey(anyLong())).thenReturn(mockKey);
+    when(accountSignumKeyFactoryMock.newKey(anyLong())).thenReturn(mockKey);
     when(accountTableMock.get(mockKey)).thenReturn(mockAccount);
 
     when(mockAccount.getPublicKey()).thenReturn(publicKey);
@@ -98,7 +98,7 @@ public class AccountServiceImplTest {
     final SignumKey mockKey = mock(SignumKey.class);
     final Account mockAccount = mock(Account.class);
 
-    when(accountBurstKeyFactoryMock.newKey(anyLong())).thenReturn(mockKey);
+    when(accountSignumKeyFactoryMock.newKey(anyLong())).thenReturn(mockKey);
     when(accountTableMock.get(mockKey)).thenReturn(mockAccount);
 
     when(mockAccount.getPublicKey()).thenReturn(null);
@@ -111,7 +111,7 @@ public class AccountServiceImplTest {
     final byte[] publicKey = new byte[0];
     final SignumKey mockKey = mock(SignumKey.class);
 
-    when(accountBurstKeyFactoryMock.newKey(anyLong())).thenReturn(mockKey);
+    when(accountSignumKeyFactoryMock.newKey(anyLong())).thenReturn(mockKey);
     when(accountTableMock.get(mockKey)).thenReturn(null);
 
     assertNull(t.getAccount(publicKey));
@@ -127,7 +127,7 @@ public class AccountServiceImplTest {
     final SignumKey mockKey = mock(SignumKey.class);
     final Account mockAccount = mock(Account.class);
 
-    when(accountBurstKeyFactoryMock.newKey(anyLong())).thenReturn(mockKey);
+    when(accountSignumKeyFactoryMock.newKey(anyLong())).thenReturn(mockKey);
     when(accountTableMock.get(mockKey)).thenReturn(mockAccount);
 
     when(mockAccount.getPublicKey()).thenReturn(otherPublicKey);
@@ -191,7 +191,7 @@ public class AccountServiceImplTest {
 
     final SignumKey mockKey = mock(SignumKey.class);
 
-    when(accountBurstKeyFactoryMock.newKey(eq(accountId))).thenReturn(mockKey);
+    when(accountSignumKeyFactoryMock.newKey(eq(accountId))).thenReturn(mockKey);
     when(accountTableMock.get(eq(mockKey))).thenReturn(null);
 
     final Account createdAccount = t.getOrAddAccount(accountId);
@@ -209,7 +209,7 @@ public class AccountServiceImplTest {
     final SignumKey mockKey = mock(SignumKey.class);
     final Account mockAccount = mock(Account.class);
 
-    when(accountBurstKeyFactoryMock.newKey(eq(accountId))).thenReturn(mockKey);
+    when(accountSignumKeyFactoryMock.newKey(eq(accountId))).thenReturn(mockKey);
     when(accountTableMock.get(eq(mockKey))).thenReturn(mockAccount);
 
     final Account retrievedAccount = t.getOrAddAccount(accountId);

--- a/test/java/brs/services/impl/AliasServiceImplTest.java
+++ b/test/java/brs/services/impl/AliasServiceImplTest.java
@@ -8,8 +8,8 @@ import brs.Attachment.MessagingAliasSell;
 import brs.Transaction;
 import brs.common.AbstractUnitTest;
 import brs.common.QuickMocker;
-import brs.db.BurstKey;
-import brs.db.BurstKey.LongKeyFactory;
+import brs.db.SignumKey;
+import brs.db.SignumKey.LongKeyFactory;
 import brs.db.VersionedEntityTable;
 import brs.db.store.AliasStore;
 import brs.fluxcapacitor.FluxCapacitor;
@@ -39,9 +39,9 @@ public class AliasServiceImplTest extends AbstractUnitTest {
 
   private AliasStore aliasStoreMock;
   private VersionedEntityTable<Alias> aliasTableMock;
-  private BurstKey.LongKeyFactory<Alias> aliasDbKeyFactoryMock;
+  private SignumKey.LongKeyFactory<Alias> aliasDbKeyFactoryMock;
   private VersionedEntityTable<Offer> offerTableMock;
-  private BurstKey.LongKeyFactory<Offer> offerDbKeyFactoryMock;
+  private SignumKey.LongKeyFactory<Offer> offerDbKeyFactoryMock;
 
   @Before
   public void setUp() {
@@ -77,7 +77,7 @@ public class AliasServiceImplTest extends AbstractUnitTest {
   @Test
   public void getAlias_byId() {
     final long id = 123l;
-    final BurstKey mockKey = mock(BurstKey.class);
+    final SignumKey mockKey = mock(SignumKey.class);
     final Alias mockAlias = mock(Alias.class);
 
     when(aliasDbKeyFactoryMock.newKey(eq(id))).thenReturn(mockKey);
@@ -91,7 +91,7 @@ public class AliasServiceImplTest extends AbstractUnitTest {
     final Long aliasId = 123l;
     final Alias mockAlias = mock(Alias.class);
     when(mockAlias.getId()).thenReturn(aliasId);
-    final BurstKey mockOfferKey = mock(BurstKey.class);
+    final SignumKey mockOfferKey = mock(SignumKey.class);
     final Offer mockOffer = mock(Offer.class);
 
     when(offerDbKeyFactoryMock.newKey(eq(aliasId))).thenReturn(mockOfferKey);
@@ -175,7 +175,7 @@ public class AliasServiceImplTest extends AbstractUnitTest {
 
     when(aliasStoreMock.getAlias(eq(aliasName), eq(0L))).thenReturn(mockAlias);
 
-    final BurstKey mockOfferKey = mock(BurstKey.class);
+    final SignumKey mockOfferKey = mock(SignumKey.class);
     when(offerDbKeyFactoryMock.newKey(eq(aliasId))).thenReturn(mockOfferKey);
 
     final long priceNQT = 500L;
@@ -210,7 +210,7 @@ public class AliasServiceImplTest extends AbstractUnitTest {
 
     when(aliasStoreMock.getAlias(eq(aliasName), eq(0L))).thenReturn(mockAlias);
 
-    final BurstKey mockOfferKey = mock(BurstKey.class);
+    final SignumKey mockOfferKey = mock(SignumKey.class);
     final Offer mockOffer = mock(Offer.class);
     when(offerDbKeyFactoryMock.newKey(eq(aliasId))).thenReturn(mockOfferKey);
     when(offerTableMock.get(eq(mockOfferKey))).thenReturn(mockOffer);
@@ -244,7 +244,7 @@ public class AliasServiceImplTest extends AbstractUnitTest {
 
     when(aliasStoreMock.getAlias(eq(aliasName), eq(0L))).thenReturn(mockAlias);
 
-    final BurstKey mockOfferKey = mock(BurstKey.class);
+    final SignumKey mockOfferKey = mock(SignumKey.class);
     final Offer mockOffer = mock(Offer.class);
     when(offerDbKeyFactoryMock.newKey(eq(aliasId))).thenReturn(mockOfferKey);
     when(offerTableMock.get(eq(mockOfferKey))).thenReturn(mockOffer);
@@ -279,7 +279,7 @@ public class AliasServiceImplTest extends AbstractUnitTest {
 
     when(aliasStoreMock.getAlias(eq(aliasName), eq(0L))).thenReturn(mockAlias);
 
-    final BurstKey mockOfferKey = mock(BurstKey.class);
+    final SignumKey mockOfferKey = mock(SignumKey.class);
     final Offer mockOffer = mock(Offer.class);
     when(offerDbKeyFactoryMock.newKey(eq(aliasId))).thenReturn(mockOfferKey);
     when(offerTableMock.get(eq(mockOfferKey))).thenReturn(mockOffer);

--- a/test/java/brs/services/impl/AliasServiceImplTest.java
+++ b/test/java/brs/services/impl/AliasServiceImplTest.java
@@ -1,7 +1,7 @@
 package brs.services.impl;
 
 import brs.Alias;
-import brs.Burst;
+import brs.Signum;
 import brs.Alias.Offer;
 import brs.Attachment.MessagingAliasAssignment;
 import brs.Attachment.MessagingAliasSell;
@@ -32,7 +32,7 @@ import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class AliasServiceImplTest extends AbstractUnitTest {
 
   private AliasServiceImpl t;
@@ -45,7 +45,7 @@ public class AliasServiceImplTest extends AbstractUnitTest {
 
   @Before
   public void setUp() {
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
 
     aliasStoreMock = mock(AliasStore.class);
     aliasTableMock = mock(VersionedEntityTable.class);
@@ -54,7 +54,7 @@ public class AliasServiceImplTest extends AbstractUnitTest {
     offerDbKeyFactoryMock = mock(LongKeyFactory.class);
 
     FluxCapacitor mockFluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.PRE_POC2, FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(mockFluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(mockFluxCapacitor);
 
     when(aliasStoreMock.getAliasTable()).thenReturn(aliasTableMock);
     when(aliasStoreMock.getAliasDbKeyFactory()).thenReturn(aliasDbKeyFactoryMock);

--- a/test/java/brs/services/impl/AliasServiceImplTest.java
+++ b/test/java/brs/services/impl/AliasServiceImplTest.java
@@ -167,7 +167,7 @@ public class AliasServiceImplTest extends AbstractUnitTest {
   }
 
   @Test
-  public void sellAlias_forBurst_newOffer() {
+  public void sellAlias_forSigna_newOffer() {
     final String aliasName = "aliasName";
     final long aliasId = 123L;
     final Alias mockAlias = mock(Alias.class);
@@ -202,7 +202,7 @@ public class AliasServiceImplTest extends AbstractUnitTest {
   }
 
   @Test
-  public void sellAlias_forBurst_offerExists() {
+  public void sellAlias_forSigna_offerExists() {
     final String aliasName = "aliasName";
     final long aliasId = 123L;
     final Alias mockAlias = mock(Alias.class);

--- a/test/java/brs/services/impl/DGSGoodsStoreServiceImplTest.java
+++ b/test/java/brs/services/impl/DGSGoodsStoreServiceImplTest.java
@@ -5,8 +5,8 @@ import brs.DigitalGoodsStore;
 import brs.DigitalGoodsStore.Goods;
 import brs.DigitalGoodsStore.Purchase;
 import brs.common.AbstractUnitTest;
-import brs.db.BurstKey;
-import brs.db.BurstKey.LongKeyFactory;
+import brs.db.SignumKey;
+import brs.db.SignumKey.LongKeyFactory;
 import brs.db.VersionedEntityTable;
 import brs.db.store.DigitalGoodsStoreStore;
 import brs.services.AccountService;
@@ -51,7 +51,7 @@ public class DGSGoodsStoreServiceImplTest extends AbstractUnitTest {
 
   @Test
   public void getGoods() {
-    final BurstKey mockKey = mock(BurstKey.class);
+    final SignumKey mockKey = mock(SignumKey.class);
     final Goods mockGoods = mock(Goods.class);
 
     when(mockGoodsDbKeyFactory.newKey(eq(1l))).thenReturn(mockKey);

--- a/test/java/brs/services/impl/EscrowServiceImplTest.java
+++ b/test/java/brs/services/impl/EscrowServiceImplTest.java
@@ -2,8 +2,8 @@ package brs.services.impl;
 
 import brs.Blockchain;
 import brs.Escrow;
-import brs.db.BurstKey;
-import brs.db.BurstKey.LongKeyFactory;
+import brs.db.SignumKey;
+import brs.db.SignumKey.LongKeyFactory;
 import brs.db.VersionedEntityTable;
 import brs.db.store.EscrowStore;
 import brs.services.AccountService;
@@ -59,7 +59,7 @@ public class EscrowServiceImplTest {
   public void getEscrowTransaction() {
     final long escrowId = 123L;
 
-    final BurstKey mockEscrowKey = mock(BurstKey.class);
+    final SignumKey mockEscrowKey = mock(SignumKey.class);
     final Escrow mockEscrow = mock(Escrow.class);
 
     when(mockEscrowDbKeyFactory.newKey(eq(escrowId))).thenReturn(mockEscrowKey);

--- a/test/java/brs/services/impl/IndirectIncomingServiceImplTest.java
+++ b/test/java/brs/services/impl/IndirectIncomingServiceImplTest.java
@@ -38,7 +38,7 @@ public class IndirectIncomingServiceImplTest {
     }
 
     @Test
-    public void testIndirectIncomingServiceImplTestMultiOutTransaction() throws BurstException.NotValidException {
+    public void testIndirectIncomingServiceImplTestMultiOutTransaction() throws SignumException.NotValidException {
         addIndirectIncomingsRunnable.set(indirectIncomings -> {
             assertEquals(4, indirectIncomings.size());
             assertEquals(new HashSet<>(indirectIncomings).size(), indirectIncomings.size()); // Assert that there are no duplicates
@@ -57,7 +57,7 @@ public class IndirectIncomingServiceImplTest {
     }
 
     @Test
-    public void testIndirectIncomingServiceImplTestMultiOutSameTransaction() throws BurstException.NotValidException {
+    public void testIndirectIncomingServiceImplTestMultiOutSameTransaction() throws SignumException.NotValidException {
         addIndirectIncomingsRunnable.set(indirectIncomings -> {
             assertEquals(4, indirectIncomings.size());
             assertEquals(new HashSet<>(indirectIncomings).size(), indirectIncomings.size()); // Assert that there are no duplicates

--- a/test/java/brs/services/impl/IndirectIncomingServiceImplTest.java
+++ b/test/java/brs/services/impl/IndirectIncomingServiceImplTest.java
@@ -44,10 +44,10 @@ public class IndirectIncomingServiceImplTest {
             assertEquals(new HashSet<>(indirectIncomings).size(), indirectIncomings.size()); // Assert that there are no duplicates
         });
         List<List<Long>> recipients = new ArrayList<>();
-        recipients.add(Arrays.asList(1L, Constants.ONE_BURST));
-        recipients.add(Arrays.asList(2L, Constants.ONE_BURST));
-        recipients.add(Arrays.asList(3L, Constants.ONE_BURST));
-        recipients.add(Arrays.asList(4L, Constants.ONE_BURST));
+        recipients.add(Arrays.asList(1L, Constants.ONE_SIGNA));
+        recipients.add(Arrays.asList(2L, Constants.ONE_SIGNA));
+        recipients.add(Arrays.asList(3L, Constants.ONE_SIGNA));
+        recipients.add(Arrays.asList(4L, Constants.ONE_SIGNA));
         Attachment.PaymentMultiOutCreation attachment = mock(Attachment.PaymentMultiOutCreation.class);
         when(attachment.getRecipients()).thenReturn(recipients);
         Transaction multiOut = mock(Transaction.class);

--- a/test/java/brs/services/impl/ParameterServiceImplTest.java
+++ b/test/java/brs/services/impl/ParameterServiceImplTest.java
@@ -1,7 +1,7 @@
 package brs.services.impl;
 
 import brs.*;
-import brs.BurstException.ValidationException;
+import brs.SignumException.ValidationException;
 import brs.assetexchange.AssetExchange;
 import brs.at.AT;
 import brs.common.QuickMocker;
@@ -58,7 +58,7 @@ public class ParameterServiceImplTest {
   }
 
   @Test
-  public void getAccount() throws BurstException {
+  public void getAccount() throws SignumException {
     final String accountId = "123";
     final Account mockAccount = mock(Account.class);
 
@@ -70,13 +70,13 @@ public class ParameterServiceImplTest {
   }
 
   @Test(expected = ParameterException.class)
-  public void getAccount_MissingAccountWhenNoAccountParameterGiven() throws BurstException {
+  public void getAccount_MissingAccountWhenNoAccountParameterGiven() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
     t.getAccount(req);
   }
 
   @Test(expected = ParameterException.class)
-  public void getAccount_UnknownAccountWhenIdNotFound() throws BurstException {
+  public void getAccount_UnknownAccountWhenIdNotFound() throws SignumException {
     final String accountId = "123";
     final HttpServletRequest req = QuickMocker.httpServletRequest(new MockParam(ACCOUNT_PARAMETER, accountId));
 
@@ -86,7 +86,7 @@ public class ParameterServiceImplTest {
   }
 
   @Test(expected = ParameterException.class)
-  public void getAccount_IncorrectAccountWhenRuntimeExceptionOccurs() throws BurstException {
+  public void getAccount_IncorrectAccountWhenRuntimeExceptionOccurs() throws SignumException {
     final String accountId = "123";
     final HttpServletRequest req = QuickMocker.httpServletRequest(new MockParam(ACCOUNT_PARAMETER, accountId));
 
@@ -663,7 +663,7 @@ public class ParameterServiceImplTest {
 
   @Test(expected = ParameterException.class)
   public void parseTransaction_transactionJSON_validationExceptionOccurs() throws ParameterException, ValidationException {
-    when(transactionProcessorMock.parseTransaction(any(JsonObject.class))).thenThrow(new BurstException.NotValidException(""));
+    when(transactionProcessorMock.parseTransaction(any(JsonObject.class))).thenThrow(new SignumException.NotValidException(""));
 
     t.parseTransaction(null, "{}");
   }

--- a/test/java/brs/services/impl/SubscriptionServiceImplTest.java
+++ b/test/java/brs/services/impl/SubscriptionServiceImplTest.java
@@ -3,8 +3,8 @@ package brs.services.impl;
 import brs.Blockchain;
 import brs.Subscription;
 import brs.common.AbstractUnitTest;
-import brs.db.BurstKey;
-import brs.db.BurstKey.LongKeyFactory;
+import brs.db.SignumKey;
+import brs.db.SignumKey.LongKeyFactory;
 import brs.db.TransactionDb;
 import brs.db.VersionedEntityTable;
 import brs.db.store.SubscriptionStore;
@@ -49,7 +49,7 @@ public class SubscriptionServiceImplTest extends AbstractUnitTest {
   public void getSubscription() {
     final long subscriptionId = 123L;
 
-    final BurstKey mockSubscriptionKey = mock(BurstKey.class);
+    final SignumKey mockSubscriptionKey = mock(SignumKey.class);
 
     final Subscription mockSubscription = mock(Subscription.class);
 

--- a/test/java/brs/transactionduplicates/TransactionDuplicatesCheckerImplTest.java
+++ b/test/java/brs/transactionduplicates/TransactionDuplicatesCheckerImplTest.java
@@ -6,7 +6,7 @@ import brs.Attachment.MessagingAliasSell;
 import brs.BlockchainImpl;
 import brs.Signum;
 import brs.Constants;
-import brs.BurstException.NotValidException;
+import brs.SignumException.NotValidException;
 import brs.Escrow.DecisionType;
 import brs.Transaction;
 import brs.TransactionType;

--- a/test/java/brs/transactionduplicates/TransactionDuplicatesCheckerImplTest.java
+++ b/test/java/brs/transactionduplicates/TransactionDuplicatesCheckerImplTest.java
@@ -4,7 +4,7 @@ import brs.Attachment.AdvancedPaymentEscrowResult;
 import brs.Attachment.AdvancedPaymentSubscriptionSubscribe;
 import brs.Attachment.MessagingAliasSell;
 import brs.BlockchainImpl;
-import brs.Burst;
+import brs.Signum;
 import brs.Constants;
 import brs.BurstException.NotValidException;
 import brs.Escrow.DecisionType;
@@ -31,20 +31,20 @@ import static org.mockito.Mockito.doReturn;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class TransactionDuplicatesCheckerImplTest {
 
   private TransactionDuplicatesCheckerImpl t = new TransactionDuplicatesCheckerImpl();
 
   @Before
   public void setUp() {
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
 
     final FluxCapacitor mockFluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.PRE_POC2);
-    when(Burst.getFluxCapacitor()).thenReturn(mockFluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(mockFluxCapacitor);
     BlockchainImpl mockBlockchain = mock(BlockchainImpl.class);
     when(mockBlockchain.getHeight()).thenReturn(4);
-    when(Burst.getBlockchain()).thenReturn(mockBlockchain);
+    when(Signum.getBlockchain()).thenReturn(mockBlockchain);
 
     doReturn(Constants.FEE_QUANT_SIP3).when(mockFluxCapacitor).getValue(eq(FluxValues.FEE_QUANT), anyInt());
 

--- a/test/java/brs/unconfirmedtransactions/UnconfirmedTransactionStoreTest.java
+++ b/test/java/brs/unconfirmedtransactions/UnconfirmedTransactionStoreTest.java
@@ -41,7 +41,7 @@ import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class UnconfirmedTransactionStoreTest {
 
   private BlockchainImpl mockBlockChain;
@@ -55,16 +55,16 @@ public class UnconfirmedTransactionStoreTest {
 
   @Before
   public void setUp() {
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
 
     final PropertyService mockPropertyService = mock(PropertyService.class);
-    when(Burst.getPropertyService()).thenReturn(mockPropertyService);
+    when(Signum.getPropertyService()).thenReturn(mockPropertyService);
     when(mockPropertyService.getInt(eq(Props.P2P_MAX_UNCONFIRMED_TRANSACTIONS))).thenReturn(8192);
     when(mockPropertyService.getInt(eq(Props.P2P_MAX_PERCENTAGE_UNCONFIRMED_TRANSACTIONS_FULL_HASH_REFERENCE))).thenReturn(5);
     when(mockPropertyService.getInt(eq(Props.P2P_MAX_UNCONFIRMED_TRANSACTIONS_RAW_SIZE_BYTES_TO_SEND))).thenReturn(175000);
 
     mockBlockChain = mock(BlockchainImpl.class);
-    when(Burst.getBlockchain()).thenReturn(mockBlockChain);
+    when(Signum.getBlockchain()).thenReturn(mockBlockChain);
 
     accountStoreMock = mock(AccountStore.class);
     accountTableMock = mock(VersionedBatchEntityTable.class);
@@ -81,7 +81,7 @@ public class UnconfirmedTransactionStoreTest {
 
     FluxCapacitor mockFluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.PRE_POC2, FluxValues.DIGITAL_GOODS_STORE);
 
-    when(Burst.getFluxCapacitor()).thenReturn(mockFluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(mockFluxCapacitor);
 
     doReturn(Constants.FEE_QUANT_SIP3).when(mockFluxCapacitor).getValue(eq(FluxValues.FEE_QUANT), anyInt());
     doReturn(Constants.FEE_QUANT_SIP3).when(mockFluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));

--- a/test/java/brs/unconfirmedtransactions/UnconfirmedTransactionStoreTest.java
+++ b/test/java/brs/unconfirmedtransactions/UnconfirmedTransactionStoreTest.java
@@ -48,7 +48,7 @@ public class UnconfirmedTransactionStoreTest {
 
   private AccountStore accountStoreMock;
   private VersionedBatchEntityTable<Account> accountTableMock;
-  private LongKeyFactory<Account> accountBurstKeyFactoryMock;
+  private LongKeyFactory<Account> accountSignumKeyFactoryMock;
 
   private TimeService timeService = new TimeServiceImpl();
   private UnconfirmedTransactionStore t;
@@ -68,14 +68,14 @@ public class UnconfirmedTransactionStoreTest {
 
     accountStoreMock = mock(AccountStore.class);
     accountTableMock = mock(VersionedBatchEntityTable.class);
-    accountBurstKeyFactoryMock = mock(LongKeyFactory.class);
+    accountSignumKeyFactoryMock = mock(LongKeyFactory.class);
     TransactionDb transactionDbMock = mock(TransactionDb.class, Answers.RETURNS_DEFAULTS);
     when(accountStoreMock.getAccountTable()).thenReturn(accountTableMock);
-    when(accountStoreMock.getAccountKeyFactory()).thenReturn(accountBurstKeyFactoryMock);
+    when(accountStoreMock.getAccountKeyFactory()).thenReturn(accountSignumKeyFactoryMock);
 
     final Account mockAccount = mock(Account.class);
     final SignumKey mockAccountKey = mock(SignumKey.class);
-    when(accountBurstKeyFactoryMock.newKey(eq(123L))).thenReturn(mockAccountKey);
+    when(accountSignumKeyFactoryMock.newKey(eq(123L))).thenReturn(mockAccountKey);
     when(accountTableMock.get(eq(mockAccountKey))).thenReturn(mockAccount);
     when(mockAccount.getUnconfirmedBalanceNQT()).thenReturn(Constants.MAX_BALANCE_NQT);
 

--- a/test/java/brs/unconfirmedtransactions/UnconfirmedTransactionStoreTest.java
+++ b/test/java/brs/unconfirmedtransactions/UnconfirmedTransactionStoreTest.java
@@ -2,8 +2,8 @@ package brs.unconfirmedtransactions;
 
 import brs.*;
 import brs.Attachment.MessagingAliasSell;
-import brs.BurstException.NotCurrentlyValidException;
-import brs.BurstException.ValidationException;
+import brs.SignumException.NotCurrentlyValidException;
+import brs.SignumException.ValidationException;
 import brs.Transaction.Builder;
 import brs.common.QuickMocker;
 import brs.common.TestConstants;

--- a/test/java/brs/unconfirmedtransactions/UnconfirmedTransactionStoreTest.java
+++ b/test/java/brs/unconfirmedtransactions/UnconfirmedTransactionStoreTest.java
@@ -7,8 +7,8 @@ import brs.SignumException.ValidationException;
 import brs.Transaction.Builder;
 import brs.common.QuickMocker;
 import brs.common.TestConstants;
-import brs.db.BurstKey;
-import brs.db.BurstKey.LongKeyFactory;
+import brs.db.SignumKey;
+import brs.db.SignumKey.LongKeyFactory;
 import brs.db.TransactionDb;
 import brs.db.VersionedBatchEntityTable;
 import brs.db.store.AccountStore;
@@ -74,7 +74,7 @@ public class UnconfirmedTransactionStoreTest {
     when(accountStoreMock.getAccountKeyFactory()).thenReturn(accountBurstKeyFactoryMock);
 
     final Account mockAccount = mock(Account.class);
-    final BurstKey mockAccountKey = mock(BurstKey.class);
+    final SignumKey mockAccountKey = mock(SignumKey.class);
     when(accountBurstKeyFactoryMock.newKey(eq(123L))).thenReturn(mockAccountKey);
     when(accountTableMock.get(eq(mockAccountKey))).thenReturn(mockAccount);
     when(mockAccount.getUnconfirmedBalanceNQT()).thenReturn(Constants.MAX_BALANCE_NQT);

--- a/test/java/brs/web/api/http/handler/AbstractTransactionTest.java
+++ b/test/java/brs/web/api/http/handler/AbstractTransactionTest.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Account;
 import brs.Attachment;
-import brs.BurstException;
+import brs.SignumException;
 import brs.common.AbstractUnitTest;
 import brs.web.api.http.common.APITransactionManager;
 import com.google.gson.JsonElement;
@@ -18,10 +18,10 @@ public abstract class AbstractTransactionTest extends AbstractUnitTest {
 
   @FunctionalInterface
   public interface TransactionCreationFunction<R> {
-    R apply() throws BurstException;
+    R apply() throws SignumException;
   }
 
-  protected Attachment attachmentCreatedTransaction(TransactionCreationFunction r, APITransactionManager apiTransactionManagerMock) throws BurstException {
+  protected Attachment attachmentCreatedTransaction(TransactionCreationFunction r, APITransactionManager apiTransactionManagerMock) throws SignumException {
     final ArgumentCaptor<Attachment> ac = ArgumentCaptor.forClass(Attachment.class);
 
     when(apiTransactionManagerMock.createTransaction(any(HttpServletRequest.class), nullable(Account.class), nullable(Long.class), anyLong(), ac.capture(), anyLong())).thenReturn(mock(JsonElement.class));

--- a/test/java/brs/web/api/http/handler/BroadcastTransactionTest.java
+++ b/test/java/brs/web/api/http/handler/BroadcastTransactionTest.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Transaction;
 import brs.TransactionProcessor;
 import brs.common.QuickMocker;
@@ -53,7 +53,7 @@ public class BroadcastTransactionTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final String mockTransactionBytesParameter = "mockTransactionBytesParameter";
     final String mockTransactionJson = "mockTransactionJson";
 
@@ -80,7 +80,7 @@ public class BroadcastTransactionTest {
   }
 
   @Test
-  public void processRequest_validationException() throws BurstException {
+  public void processRequest_validationException() throws SignumException {
     final String mockTransactionBytesParameter = "mockTransactionBytesParameter";
     final String mockTransactionJson = "mockTransactionJson";
 
@@ -92,7 +92,7 @@ public class BroadcastTransactionTest {
 
     when(parameterServiceMock.parseTransaction(eq(mockTransactionBytesParameter), eq(mockTransactionJson))).thenReturn(mockTransaction);
 
-    Mockito.doThrow(BurstException.NotCurrentlyValidException.class).when(transactionServiceMock).validate(eq(mockTransaction));
+    Mockito.doThrow(SignumException.NotCurrentlyValidException.class).when(transactionServiceMock).validate(eq(mockTransaction));
 
     final JsonObject result = (JsonObject) t.processRequest(req);
 

--- a/test/java/brs/web/api/http/handler/BroadcastTransactionTest.java
+++ b/test/java/brs/web/api/http/handler/BroadcastTransactionTest.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.Transaction;
 import brs.TransactionProcessor;
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class BroadcastTransactionTest {
 
   private BroadcastTransaction t;
@@ -45,9 +45,9 @@ public class BroadcastTransactionTest {
     this.parameterServiceMock = mock(ParameterService.class);
     this.transactionServiceMock = mock(TransactionService.class);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     FluxCapacitor mockFluxCapacitor = QuickMocker.latestValueFluxCapacitor();
-    when(Burst.getFluxCapacitor()).thenReturn(mockFluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(mockFluxCapacitor);
 
     t = new BroadcastTransaction(transactionProcessorMock, parameterServiceMock, transactionServiceMock);
   }

--- a/test/java/brs/web/api/http/handler/BuyAliasTest.java
+++ b/test/java/brs/web/api/http/handler/BuyAliasTest.java
@@ -50,7 +50,7 @@ public class BuyAliasTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     mockStatic(Signum.class);
     final HttpServletRequest req = QuickMocker.httpServletRequestDefaultKeys(new MockParam(AMOUNT_NQT_PARAMETER, "" + Constants.ONE_BURST));
 
@@ -80,7 +80,7 @@ public class BuyAliasTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_aliasNotForSale() throws BurstException {
+  public void processRequest_aliasNotForSale() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(new MockParam(AMOUNT_NQT_PARAMETER, "3"));
     final Alias mockAlias = mock(Alias.class);
 

--- a/test/java/brs/web/api/http/handler/BuyAliasTest.java
+++ b/test/java/brs/web/api/http/handler/BuyAliasTest.java
@@ -52,7 +52,7 @@ public class BuyAliasTest extends AbstractTransactionTest {
   @Test
   public void processRequest() throws SignumException {
     mockStatic(Signum.class);
-    final HttpServletRequest req = QuickMocker.httpServletRequestDefaultKeys(new MockParam(AMOUNT_NQT_PARAMETER, "" + Constants.ONE_BURST));
+    final HttpServletRequest req = QuickMocker.httpServletRequestDefaultKeys(new MockParam(AMOUNT_NQT_PARAMETER, "" + Constants.ONE_SIGNA));
 
     final Offer mockOfferOnAlias = mock(Offer.class);
 

--- a/test/java/brs/web/api/http/handler/BuyAliasTest.java
+++ b/test/java/brs/web/api/http/handler/BuyAliasTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Burst.class})
+@PrepareForTest({Signum.class})
 public class BuyAliasTest extends AbstractTransactionTest {
 
   private BuyAlias t;
@@ -51,7 +51,7 @@ public class BuyAliasTest extends AbstractTransactionTest {
 
   @Test
   public void processRequest() throws BurstException {
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final HttpServletRequest req = QuickMocker.httpServletRequestDefaultKeys(new MockParam(AMOUNT_NQT_PARAMETER, "" + Constants.ONE_BURST));
 
     final Offer mockOfferOnAlias = mock(Offer.class);
@@ -67,9 +67,9 @@ public class BuyAliasTest extends AbstractTransactionTest {
 
     when(parameterServiceMock.getAlias(eq(req))).thenReturn(mockAlias);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(fluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 
     final Attachment.MessagingAliasBuy attachment = (Attachment.MessagingAliasBuy) attachmentCreatedTransaction(() -> t.processRequest(req), apiTransactionManagerMock);

--- a/test/java/brs/web/api/http/handler/CancelAskOrderTest.java
+++ b/test/java/brs/web/api/http/handler/CancelAskOrderTest.java
@@ -50,7 +50,7 @@ public class CancelAskOrderTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final long orderId = 5;
     final long sellerId = 6;
 
@@ -81,7 +81,7 @@ public class CancelAskOrderTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_orderDataNotFound() throws BurstException {
+  public void processRequest_orderDataNotFound() throws SignumException {
     int orderId = 5;
 
     final HttpServletRequest req = QuickMocker.httpServletRequest(
@@ -94,7 +94,7 @@ public class CancelAskOrderTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_orderOtherAccount() throws BurstException {
+  public void processRequest_orderOtherAccount() throws SignumException {
     final long orderId = 5;
     final long accountId = 6;
     final long otherAccountId = 7;

--- a/test/java/brs/web/api/http/handler/CancelAskOrderTest.java
+++ b/test/java/brs/web/api/http/handler/CancelAskOrderTest.java
@@ -29,7 +29,7 @@ import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class CancelAskOrderTest extends AbstractTransactionTest {
 
   private CancelAskOrder t;
@@ -67,9 +67,9 @@ public class CancelAskOrderTest extends AbstractTransactionTest {
     when(assetExchangeMock.getAskOrder(eq(orderId))).thenReturn(order);
     when(parameterServiceMock.getSenderAccount(eq(req))).thenReturn(sellerAccount);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(fluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 
     final Attachment.ColoredCoinsAskOrderCancellation attachment = (brs.Attachment.ColoredCoinsAskOrderCancellation) attachmentCreatedTransaction(() -> t.processRequest(req),

--- a/test/java/brs/web/api/http/handler/CancelBidOrderTest.java
+++ b/test/java/brs/web/api/http/handler/CancelBidOrderTest.java
@@ -51,7 +51,7 @@ public class CancelBidOrderTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final int orderId = 123;
     final long orderAccountId = 1;
     final long senderAccountId = orderAccountId;
@@ -81,12 +81,12 @@ public class CancelBidOrderTest extends AbstractTransactionTest {
   }
 
   @Test(expected = ParameterException.class)
-  public void processRequest_orderParameterMissing() throws BurstException {
+  public void processRequest_orderParameterMissing() throws SignumException {
     t.processRequest(QuickMocker.httpServletRequest());
   }
 
   @Test
-  public void processRequest_orderDataMissingUnkownOrder() throws BurstException {
+  public void processRequest_orderDataMissingUnkownOrder() throws SignumException {
     final int orderId = 123;
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(ORDER_PARAMETER, orderId)
@@ -98,7 +98,7 @@ public class CancelBidOrderTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_accountIdNotSameAsOrder() throws BurstException {
+  public void processRequest_accountIdNotSameAsOrder() throws SignumException {
     final int orderId = 123;
     final long orderAccountId = 1;
     final long senderAccountId = 2;

--- a/test/java/brs/web/api/http/handler/CancelBidOrderTest.java
+++ b/test/java/brs/web/api/http/handler/CancelBidOrderTest.java
@@ -30,7 +30,7 @@ import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class CancelBidOrderTest extends AbstractTransactionTest {
 
   private CancelBidOrder t;
@@ -68,9 +68,9 @@ public class CancelBidOrderTest extends AbstractTransactionTest {
     when(mockAccount.getId()).thenReturn(senderAccountId);
     when(parameterServiceMock.getSenderAccount(eq(req))).thenReturn(mockAccount);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(fluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 
     final Attachment.ColoredCoinsBidOrderCancellation attachment = (brs.Attachment.ColoredCoinsBidOrderCancellation) attachmentCreatedTransaction(() -> t.processRequest(req), apiTransactionManagerMock);

--- a/test/java/brs/web/api/http/handler/DGSDelistingTest.java
+++ b/test/java/brs/web/api/http/handler/DGSDelistingTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class DGSDelistingTest extends AbstractTransactionTest {
 
   private DGSDelisting t;
@@ -58,9 +58,9 @@ public class DGSDelistingTest extends AbstractTransactionTest {
     when(mockParameterService.getSenderAccount(eq(req))).thenReturn(mockAccount);
     when(mockParameterService.getGoods(eq(req))).thenReturn(mockGoods);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(fluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 
     final Attachment.DigitalGoodsDelisting attachment = (Attachment.DigitalGoodsDelisting) attachmentCreatedTransaction(() -> t.processRequest(req), apiTransactionManagerMock);

--- a/test/java/brs/web/api/http/handler/DGSDelistingTest.java
+++ b/test/java/brs/web/api/http/handler/DGSDelistingTest.java
@@ -45,7 +45,7 @@ public class DGSDelistingTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     final Account mockAccount = mock(Account.class);
@@ -71,7 +71,7 @@ public class DGSDelistingTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_goodsDelistedUnknownGoods() throws BurstException {
+  public void processRequest_goodsDelistedUnknownGoods() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     final Account mockAccount = mock(Account.class);
@@ -86,7 +86,7 @@ public class DGSDelistingTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_otherSellerIdUnknownGoods() throws BurstException {
+  public void processRequest_otherSellerIdUnknownGoods() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     final Account mockAccount = mock(Account.class);

--- a/test/java/brs/web/api/http/handler/DGSDeliveryTest.java
+++ b/test/java/brs/web/api/http/handler/DGSDeliveryTest.java
@@ -52,7 +52,7 @@ public class DGSDeliveryTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final long discountNQTParameter = 1;
     final String goodsToEncryptParameter = "beef";
 
@@ -91,7 +91,7 @@ public class DGSDeliveryTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_sellerAccountIdDifferentFromAccountSellerIdIsIncorrectPurchase() throws BurstException {
+  public void processRequest_sellerAccountIdDifferentFromAccountSellerIdIsIncorrectPurchase() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     final Account mockSellerAccount = mock(Account.class);
@@ -107,7 +107,7 @@ public class DGSDeliveryTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_purchaseNotPendingIsAlreadyDelivered() throws BurstException {
+  public void processRequest_purchaseNotPendingIsAlreadyDelivered() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     final Account mockSellerAccount = mock(Account.class);
@@ -125,7 +125,7 @@ public class DGSDeliveryTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_dgsDiscountNotAValidNumberIsIncorrectDGSDiscount() throws BurstException {
+  public void processRequest_dgsDiscountNotAValidNumberIsIncorrectDGSDiscount() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(DISCOUNT_NQT_PARAMETER, "Bob")
     );
@@ -145,7 +145,7 @@ public class DGSDeliveryTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_dgsDiscountNegativeIsIncorrectDGSDiscount() throws BurstException {
+  public void processRequest_dgsDiscountNegativeIsIncorrectDGSDiscount() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(DISCOUNT_NQT_PARAMETER, "-1")
     );
@@ -165,7 +165,7 @@ public class DGSDeliveryTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_dgsDiscountOverMaxBalanceNQTIsIncorrectDGSDiscount() throws BurstException {
+  public void processRequest_dgsDiscountOverMaxBalanceNQTIsIncorrectDGSDiscount() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(DISCOUNT_NQT_PARAMETER, "" + (MAX_BALANCE_NQT + 1))
     );
@@ -185,7 +185,7 @@ public class DGSDeliveryTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_dgsDiscountNegativeIsNotSafeMultiply() throws BurstException {
+  public void processRequest_dgsDiscountNegativeIsNotSafeMultiply() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(DISCOUNT_NQT_PARAMETER, "99999999999")
     );
@@ -207,7 +207,7 @@ public class DGSDeliveryTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_goodsToEncryptIsEmptyIsIncorrectDGSGoods() throws BurstException {
+  public void processRequest_goodsToEncryptIsEmptyIsIncorrectDGSGoods() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(DISCOUNT_NQT_PARAMETER, "9"),
         new MockParam(GOODS_TO_ENCRYPT_PARAMETER, ""),

--- a/test/java/brs/web/api/http/handler/DGSDeliveryTest.java
+++ b/test/java/brs/web/api/http/handler/DGSDeliveryTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class DGSDeliveryTest extends AbstractTransactionTest {
 
   private DGSDelivery t;
@@ -78,9 +78,9 @@ public class DGSDeliveryTest extends AbstractTransactionTest {
     when(parameterServiceMock.getPurchase(eq(req))).thenReturn(mockPurchase);
     when(accountServiceMock.getAccount(eq(mockPurchase.getBuyerId()))).thenReturn(mockBuyerAccount);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(fluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 
     final Attachment.DigitalGoodsDelivery attachment = (Attachment.DigitalGoodsDelivery) attachmentCreatedTransaction(() -> t.processRequest(req), apiTransactionManagerMock);

--- a/test/java/brs/web/api/http/handler/DGSFeedbackTest.java
+++ b/test/java/brs/web/api/http/handler/DGSFeedbackTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class DGSFeedbackTest extends AbstractTransactionTest {
 
   private DGSFeedback t;
@@ -69,9 +69,9 @@ public class DGSFeedbackTest extends AbstractTransactionTest {
     when(mockPurchase.getEncryptedGoods()).thenReturn(mockEncryptedGoods);
     when(mockPurchase.getSellerId()).thenReturn(2L);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(fluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 
     final Attachment.DigitalGoodsFeedback attachment = (Attachment.DigitalGoodsFeedback) attachmentCreatedTransaction(() -> t.processRequest(req), apiTransactionManagerMock);

--- a/test/java/brs/web/api/http/handler/DGSFeedbackTest.java
+++ b/test/java/brs/web/api/http/handler/DGSFeedbackTest.java
@@ -50,7 +50,7 @@ public class DGSFeedbackTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     final long mockPurchaseId = 123L;
@@ -82,7 +82,7 @@ public class DGSFeedbackTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_incorrectPurchaseWhenOtherBuyerId() throws BurstException {
+  public void processRequest_incorrectPurchaseWhenOtherBuyerId() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     final Purchase mockPurchase = mock(Purchase.class);
@@ -98,7 +98,7 @@ public class DGSFeedbackTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_goodsNotDeliveredWhenNoEncryptedGoods() throws BurstException {
+  public void processRequest_goodsNotDeliveredWhenNoEncryptedGoods() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     final Purchase mockPurchase = mock(Purchase.class);

--- a/test/java/brs/web/api/http/handler/DGSListingTest.java
+++ b/test/java/brs/web/api/http/handler/DGSListingTest.java
@@ -46,7 +46,7 @@ public class DGSListingTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final Account mockAccount = mock(Account.class);
 
     final String dgsName = "dgsName";
@@ -82,7 +82,7 @@ public class DGSListingTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_missingName() throws BurstException {
+  public void processRequest_missingName() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(PRICE_NQT_PARAMETER, 123),
         new MockParam(QUANTITY_PARAMETER, 1)
@@ -92,7 +92,7 @@ public class DGSListingTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_incorrectDGSListingName() throws BurstException {
+  public void processRequest_incorrectDGSListingName() throws SignumException {
     String tooLongName = "";
 
     for (int i = 0; i < 101; i++) {
@@ -109,7 +109,7 @@ public class DGSListingTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_incorrectDgsListingDescription() throws BurstException {
+  public void processRequest_incorrectDgsListingDescription() throws SignumException {
     String tooLongDescription = "";
 
     for (int i = 0; i < 1001; i++) {
@@ -127,7 +127,7 @@ public class DGSListingTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_incorrectDgsListingTags() throws BurstException {
+  public void processRequest_incorrectDgsListingTags() throws SignumException {
     String tooLongTags = "";
 
     for (int i = 0; i < 101; i++) {

--- a/test/java/brs/web/api/http/handler/DGSListingTest.java
+++ b/test/java/brs/web/api/http/handler/DGSListingTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class DGSListingTest extends AbstractTransactionTest {
 
   private DGSListing t;
@@ -65,9 +65,9 @@ public class DGSListingTest extends AbstractTransactionTest {
 
     when(mockParameterService.getSenderAccount(eq(req))).thenReturn(mockAccount);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(fluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 
     final Attachment.DigitalGoodsListing attachment = (Attachment.DigitalGoodsListing) attachmentCreatedTransaction(() -> t.processRequest(req), apiTransactionManagerMock);

--- a/test/java/brs/web/api/http/handler/DGSPriceChangeTest.java
+++ b/test/java/brs/web/api/http/handler/DGSPriceChangeTest.java
@@ -47,7 +47,7 @@ public class DGSPriceChangeTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final int priceNQTParameter = 5;
 
     final HttpServletRequest req = QuickMocker.httpServletRequest(
@@ -80,7 +80,7 @@ public class DGSPriceChangeTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_goodsDelistedUnknownGoods() throws BurstException {
+  public void processRequest_goodsDelistedUnknownGoods() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(PRICE_NQT_PARAMETER, 123L)
     );
@@ -97,7 +97,7 @@ public class DGSPriceChangeTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_goodsWrongSellerIdUnknownGoods() throws BurstException {
+  public void processRequest_goodsWrongSellerIdUnknownGoods() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(PRICE_NQT_PARAMETER, 123L)
     );

--- a/test/java/brs/web/api/http/handler/DGSPriceChangeTest.java
+++ b/test/java/brs/web/api/http/handler/DGSPriceChangeTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class DGSPriceChangeTest extends AbstractTransactionTest {
 
   private DGSPriceChange t;
@@ -66,9 +66,9 @@ public class DGSPriceChangeTest extends AbstractTransactionTest {
     when(parameterServiceMock.getSenderAccount(eq(req))).thenReturn(mockAccount);
     when(parameterServiceMock.getGoods(eq(req))).thenReturn(mockGoods);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(fluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 
     final Attachment.DigitalGoodsPriceChange attachment = (Attachment.DigitalGoodsPriceChange) attachmentCreatedTransaction(() -> t.processRequest(req), apiTransactionManagerMock);

--- a/test/java/brs/web/api/http/handler/DGSPurchaseTest.java
+++ b/test/java/brs/web/api/http/handler/DGSPurchaseTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class DGSPurchaseTest extends AbstractTransactionTest {
 
   private DGSPurchase t;
@@ -80,9 +80,9 @@ public class DGSPurchaseTest extends AbstractTransactionTest {
 
     when(mockAccountService.getAccount(eq(mockSellerId))).thenReturn(mockSellerAccount);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(fluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 
     final Attachment.DigitalGoodsPurchase attachment = (Attachment.DigitalGoodsPurchase) attachmentCreatedTransaction(() -> t.processRequest(req), apiTransactionManagerMock);

--- a/test/java/brs/web/api/http/handler/DGSPurchaseTest.java
+++ b/test/java/brs/web/api/http/handler/DGSPurchaseTest.java
@@ -53,7 +53,7 @@ public class DGSPurchaseTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final int goodsQuantity = 5;
     final long goodsPrice = 10L;
     final long deliveryDeadlineTimestamp = 100;
@@ -96,7 +96,7 @@ public class DGSPurchaseTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_unknownGoods() throws BurstException {
+  public void processRequest_unknownGoods() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     final Goods mockGoods = mock(Goods.class);
@@ -108,7 +108,7 @@ public class DGSPurchaseTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_incorrectPurchaseQuantity() throws BurstException {
+  public void processRequest_incorrectPurchaseQuantity() throws SignumException {
     final int goodsQuantity = 5;
 
     final HttpServletRequest req = QuickMocker.httpServletRequest(
@@ -125,7 +125,7 @@ public class DGSPurchaseTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_incorrectPurchasePrice() throws BurstException {
+  public void processRequest_incorrectPurchasePrice() throws SignumException {
     final int goodsQuantity = 5;
     final long goodsPrice = 5L;
 
@@ -146,7 +146,7 @@ public class DGSPurchaseTest extends AbstractTransactionTest {
 
 
   @Test
-  public void processRequest_missingDeliveryDeadlineTimestamp() throws BurstException {
+  public void processRequest_missingDeliveryDeadlineTimestamp() throws SignumException {
     final int goodsQuantity = 5;
     final long goodsPrice = 10L;
 
@@ -166,7 +166,7 @@ public class DGSPurchaseTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_incorrectDeliveryDeadlineTimestamp_unParsable() throws BurstException {
+  public void processRequest_incorrectDeliveryDeadlineTimestamp_unParsable() throws SignumException {
     final int goodsQuantity = 5;
     final long goodsPrice = 10L;
 
@@ -187,7 +187,7 @@ public class DGSPurchaseTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_incorrectDeliveryDeadlineTimestamp_beforeCurrentTime() throws BurstException {
+  public void processRequest_incorrectDeliveryDeadlineTimestamp_beforeCurrentTime() throws SignumException {
     final int goodsQuantity = 5;
     final long goodsPrice = 10L;
     final long deliveryDeadlineTimestamp = 100;

--- a/test/java/brs/web/api/http/handler/DGSQuantityChangeTest.java
+++ b/test/java/brs/web/api/http/handler/DGSQuantityChangeTest.java
@@ -46,7 +46,7 @@ public class DGSQuantityChangeTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final int deltaQualityParameter = 5;
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(DELTA_QUANTITY_PARAMETER, deltaQualityParameter)
@@ -78,7 +78,7 @@ public class DGSQuantityChangeTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_unknownGoodsBecauseDelisted() throws BurstException {
+  public void processRequest_unknownGoodsBecauseDelisted() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     final Goods mockGoods = mock(Goods.class);
@@ -93,7 +93,7 @@ public class DGSQuantityChangeTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_unknownGoodsBecauseWrongSellerId() throws BurstException {
+  public void processRequest_unknownGoodsBecauseWrongSellerId() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     final Goods mockGoods = mock(Goods.class);
@@ -110,7 +110,7 @@ public class DGSQuantityChangeTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_missingDeltaQuantity() throws BurstException {
+  public void processRequest_missingDeltaQuantity() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(DELTA_QUANTITY_PARAMETER, null)
     );
@@ -129,7 +129,7 @@ public class DGSQuantityChangeTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_deltaQuantityWrongFormat() throws BurstException {
+  public void processRequest_deltaQuantityWrongFormat() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(DELTA_QUANTITY_PARAMETER, "Bob")
     );
@@ -148,7 +148,7 @@ public class DGSQuantityChangeTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_deltaQuantityOverMaxIncorrectDeltaQuantity() throws BurstException {
+  public void processRequest_deltaQuantityOverMaxIncorrectDeltaQuantity() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(DELTA_QUANTITY_PARAMETER, Integer.MIN_VALUE)
     );
@@ -167,7 +167,7 @@ public class DGSQuantityChangeTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_deltaQuantityLowerThanNegativeMaxIncorrectDeltaQuantity() throws BurstException {
+  public void processRequest_deltaQuantityLowerThanNegativeMaxIncorrectDeltaQuantity() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(DELTA_QUANTITY_PARAMETER, Integer.MAX_VALUE)
     );

--- a/test/java/brs/web/api/http/handler/DGSQuantityChangeTest.java
+++ b/test/java/brs/web/api/http/handler/DGSQuantityChangeTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class DGSQuantityChangeTest extends AbstractTransactionTest {
 
   private DGSQuantityChange t;
@@ -64,9 +64,9 @@ public class DGSQuantityChangeTest extends AbstractTransactionTest {
     when(mockParameterService.getSenderAccount(eq(req))).thenReturn(mockSenderAccount);
     when(mockParameterService.getGoods(eq(req))).thenReturn(mockGoods);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(fluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 
     final Attachment.DigitalGoodsQuantityChange attachment = (Attachment.DigitalGoodsQuantityChange) attachmentCreatedTransaction(() -> t.processRequest(req), apiTransactionManagerMock);

--- a/test/java/brs/web/api/http/handler/DGSRefundTest.java
+++ b/test/java/brs/web/api/http/handler/DGSRefundTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class DGSRefundTest extends AbstractTransactionTest {
 
   private DGSRefund t;
@@ -76,9 +76,9 @@ public class DGSRefundTest extends AbstractTransactionTest {
 
     when(mockAccountService.getAccount(eq(mockPurchase.getBuyerId()))).thenReturn(mockBuyerAccount);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(fluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 
     final Attachment.DigitalGoodsRefund attachment = (Attachment.DigitalGoodsRefund) attachmentCreatedTransaction(() -> t.processRequest(req), apiTransactionManagerMock);

--- a/test/java/brs/web/api/http/handler/DGSRefundTest.java
+++ b/test/java/brs/web/api/http/handler/DGSRefundTest.java
@@ -51,7 +51,7 @@ public class DGSRefundTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final long refundNQTParameter = 5;
 
     final HttpServletRequest req = QuickMocker.httpServletRequest(
@@ -90,7 +90,7 @@ public class DGSRefundTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_incorrectPurchase() throws BurstException {
+  public void processRequest_incorrectPurchase() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     final Account mockSellerAccount = mock(Account.class);
@@ -106,7 +106,7 @@ public class DGSRefundTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_duplicateRefund() throws BurstException {
+  public void processRequest_duplicateRefund() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     final Account mockSellerAccount = mock(Account.class);
@@ -123,7 +123,7 @@ public class DGSRefundTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_goodsNotDelivered() throws BurstException {
+  public void processRequest_goodsNotDelivered() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     final Account mockSellerAccount = mock(Account.class);
@@ -141,7 +141,7 @@ public class DGSRefundTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_incorrectDgsRefundWrongFormat() throws BurstException {
+  public void processRequest_incorrectDgsRefundWrongFormat() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(REFUND_NQT_PARAMETER, "Bob")
     );
@@ -161,7 +161,7 @@ public class DGSRefundTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_negativeIncorrectDGSRefund() throws BurstException {
+  public void processRequest_negativeIncorrectDGSRefund() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(REFUND_NQT_PARAMETER, -5)
     );
@@ -181,7 +181,7 @@ public class DGSRefundTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_overMaxBalanceNQTIncorrectDGSRefund() throws BurstException {
+  public void processRequest_overMaxBalanceNQTIncorrectDGSRefund() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(REFUND_NQT_PARAMETER, Constants.MAX_BALANCE_NQT + 1)
     );

--- a/test/java/brs/web/api/http/handler/DecryptFromTest.java
+++ b/test/java/brs/web/api/http/handler/DecryptFromTest.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Account;
-import brs.BurstException;
+import brs.SignumException;
 import brs.common.QuickMocker;
 import brs.common.QuickMocker.MockParam;
 import brs.crypto.EncryptedData;
@@ -37,7 +37,7 @@ public class DecryptFromTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(SECRET_PHRASE_PARAMETER, TEST_SECRET_PHRASE),
         new MockParam(DECRYPTED_MESSAGE_IS_TEXT_PARAMETER, "true"),
@@ -58,7 +58,7 @@ public class DecryptFromTest {
   }
 
   @Test
-  public void processRequest_accountWithoutPublicKeyIsIncorrectAccount() throws BurstException {
+  public void processRequest_accountWithoutPublicKeyIsIncorrectAccount() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     when(mockParameterService.getAccount(req)).thenReturn(mock(Account.class));

--- a/test/java/brs/web/api/http/handler/EscrowSignTest.java
+++ b/test/java/brs/web/api/http/handler/EscrowSignTest.java
@@ -53,7 +53,7 @@ public class EscrowSignTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_positiveAsEscrowSender() throws BurstException {
+  public void processRequest_positiveAsEscrowSender() throws SignumException {
     final long escrowId = 5;
     final long senderId = 6;
 
@@ -86,7 +86,7 @@ public class EscrowSignTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_positiveAsEscrowRecipient() throws BurstException {
+  public void processRequest_positiveAsEscrowRecipient() throws SignumException {
     final long escrowId = 5;
     final long senderId = 6;
 
@@ -119,7 +119,7 @@ public class EscrowSignTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_positiveAsEscrowSigner() throws BurstException {
+  public void processRequest_positiveAsEscrowSigner() throws SignumException {
     final long escrowId = 5;
     final long senderId = 6;
 
@@ -154,7 +154,7 @@ public class EscrowSignTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_invalidEscrowId() throws BurstException {
+  public void processRequest_invalidEscrowId() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(ESCROW_PARAMETER, "NotANumber")
     );
@@ -165,7 +165,7 @@ public class EscrowSignTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_escrowNotFound() throws BurstException {
+  public void processRequest_escrowNotFound() throws SignumException {
     final long escrowId = 5;
 
     final HttpServletRequest req = QuickMocker.httpServletRequest(
@@ -180,7 +180,7 @@ public class EscrowSignTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_invalidDecisionType() throws BurstException {
+  public void processRequest_invalidDecisionType() throws SignumException {
     final long escrowId = 5;
 
     final HttpServletRequest req = QuickMocker.httpServletRequest(
@@ -198,7 +198,7 @@ public class EscrowSignTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_invalidSender() throws BurstException {
+  public void processRequest_invalidSender() throws SignumException {
     final long escrowId = 5;
     final long senderId = 6;
 
@@ -225,7 +225,7 @@ public class EscrowSignTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_senderCanOnlyRelease() throws BurstException {
+  public void processRequest_senderCanOnlyRelease() throws SignumException {
     final long escrowId = 5;
     final long senderId = 6;
 
@@ -249,7 +249,7 @@ public class EscrowSignTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_recipientCanOnlyRefund() throws BurstException {
+  public void processRequest_recipientCanOnlyRefund() throws SignumException {
     final long escrowId = 5;
     final long senderId = 6;
 

--- a/test/java/brs/web/api/http/handler/EscrowSignTest.java
+++ b/test/java/brs/web/api/http/handler/EscrowSignTest.java
@@ -32,7 +32,7 @@ import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class EscrowSignTest extends AbstractTransactionTest {
 
   private ParameterService parameterServiceMock;
@@ -69,9 +69,9 @@ public class EscrowSignTest extends AbstractTransactionTest {
     final Account sender = mock(Account.class);
     when(sender.getId()).thenReturn(senderId);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(fluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 
     when(escrowServiceMock.getEscrowTransaction(eq(escrowId))).thenReturn(escrow);
@@ -105,9 +105,9 @@ public class EscrowSignTest extends AbstractTransactionTest {
     when(escrowServiceMock.getEscrowTransaction(eq(escrowId))).thenReturn(escrow);
     when(parameterServiceMock.getSenderAccount(eq(req))).thenReturn(sender);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(fluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 
     final Attachment.AdvancedPaymentEscrowSign attachment = (brs.Attachment.AdvancedPaymentEscrowSign) attachmentCreatedTransaction(() -> t.processRequest(req),
@@ -135,9 +135,9 @@ public class EscrowSignTest extends AbstractTransactionTest {
     final Account sender = mock(Account.class);
     when(sender.getId()).thenReturn(senderId);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(fluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 
     when(escrowServiceMock.isIdSigner(eq(senderId), eq(escrow))).thenReturn(true);

--- a/test/java/brs/web/api/http/handler/GetAccountATsTest.java
+++ b/test/java/brs/web/api/http/handler/GetAccountATsTest.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Account;
-import brs.BurstException;
+import brs.SignumException;
 import brs.at.AT;
 import brs.at.AtConstants;
 import brs.at.AtMachineState;
@@ -48,7 +48,7 @@ public class GetAccountATsTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     final long mockAccountId = 123L;

--- a/test/java/brs/web/api/http/handler/GetAccountBlockIdsTest.java
+++ b/test/java/brs/web/api/http/handler/GetAccountBlockIdsTest.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Account;
 import brs.Block;
 import brs.Blockchain;
-import brs.BurstException;
+import brs.SignumException;
 import brs.common.AbstractUnitTest;
 import brs.common.QuickMocker;
 import brs.common.QuickMocker.MockParam;
@@ -44,7 +44,7 @@ public class GetAccountBlockIdsTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final int timestamp = 1;
     final int firstIndex = 0;
     final int lastIndex = 1;

--- a/test/java/brs/web/api/http/handler/GetAccountBlocksTest.java
+++ b/test/java/brs/web/api/http/handler/GetAccountBlocksTest.java
@@ -61,7 +61,7 @@ public class GetAccountBlocksTest extends AbstractUnitTest {
     mockStatic(Signum.class);
     PropertyService propertyService = mock(PropertyService.class);
     when(Signum.getPropertyService()).thenReturn(propertyService);
-    doReturn((int)Constants.ONE_BURST).when(propertyService).getInt(eq(Props.ONE_COIN_NQT));
+    doReturn((int)Constants.ONE_SIGNA).when(propertyService).getInt(eq(Props.ONE_COIN_NQT));
 
     t = new GetAccountBlocks(blockchainMock, parameterServiceMock, blockServiceMock);
   }

--- a/test/java/brs/web/api/http/handler/GetAccountBlocksTest.java
+++ b/test/java/brs/web/api/http/handler/GetAccountBlocksTest.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Account;
 import brs.Block;
 import brs.Blockchain;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.Constants;
 import brs.common.AbstractUnitTest;
@@ -43,7 +43,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @SuppressStaticInitializationFor("brs.Block")
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class GetAccountBlocksTest extends AbstractUnitTest {
 
   private GetAccountBlocks t;
@@ -58,9 +58,9 @@ public class GetAccountBlocksTest extends AbstractUnitTest {
     parameterServiceMock = mock(ParameterService.class);
     blockServiceMock = mock(BlockService.class);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     PropertyService propertyService = mock(PropertyService.class);
-    when(Burst.getPropertyService()).thenReturn(propertyService);
+    when(Signum.getPropertyService()).thenReturn(propertyService);
     doReturn((int)Constants.ONE_BURST).when(propertyService).getInt(eq(Props.ONE_COIN_NQT));
 
     t = new GetAccountBlocks(blockchainMock, parameterServiceMock, blockServiceMock);

--- a/test/java/brs/web/api/http/handler/GetAccountBlocksTest.java
+++ b/test/java/brs/web/api/http/handler/GetAccountBlocksTest.java
@@ -4,7 +4,7 @@ import brs.Account;
 import brs.Block;
 import brs.Blockchain;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Constants;
 import brs.common.AbstractUnitTest;
 import brs.common.QuickMocker;
@@ -67,7 +67,7 @@ public class GetAccountBlocksTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final int mockTimestamp = 1;
     final int mockFirstIndex = 2;
     final int mockLastIndex = 3;

--- a/test/java/brs/web/api/http/handler/GetAccountCurrentAskOrderIdsTest.java
+++ b/test/java/brs/web/api/http/handler/GetAccountCurrentAskOrderIdsTest.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Account;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Order;
 import brs.Order.Ask;
 import brs.assetexchange.AssetExchange;
@@ -45,7 +45,7 @@ public class GetAccountCurrentAskOrderIdsTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_getAskOrdersByAccount() throws BurstException {
+  public void processRequest_getAskOrdersByAccount() throws SignumException {
     final long accountId = 2L;
     final int firstIndex = 1;
     final int lastIndex = 2;
@@ -79,7 +79,7 @@ public class GetAccountCurrentAskOrderIdsTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_getAskOrdersByAccountAsset() throws BurstException {
+  public void processRequest_getAskOrdersByAccountAsset() throws SignumException {
     final long assetId = 1L;
     final long accountId = 2L;
     final int firstIndex = 1;

--- a/test/java/brs/web/api/http/handler/GetAccountCurrentAskOrdersTest.java
+++ b/test/java/brs/web/api/http/handler/GetAccountCurrentAskOrdersTest.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Account;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Order;
 import brs.Order.Ask;
 import brs.assetexchange.AssetExchange;
@@ -45,7 +45,7 @@ public class GetAccountCurrentAskOrdersTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_getAskOrdersByAccount() throws BurstException {
+  public void processRequest_getAskOrdersByAccount() throws SignumException {
     final long accountId = 2L;
     final int firstIndex = 1;
     final int lastIndex = 2;
@@ -75,7 +75,7 @@ public class GetAccountCurrentAskOrdersTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_getAskOrdersByAccountAsset() throws BurstException {
+  public void processRequest_getAskOrdersByAccountAsset() throws SignumException {
     final long assetId = 1L;
     final long accountId = 2L;
     final int firstIndex = 1;

--- a/test/java/brs/web/api/http/handler/GetAccountCurrentBidOrderIdsTest.java
+++ b/test/java/brs/web/api/http/handler/GetAccountCurrentBidOrderIdsTest.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Account;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Order;
 import brs.Order.Bid;
 import brs.assetexchange.AssetExchange;
@@ -45,7 +45,7 @@ public class GetAccountCurrentBidOrderIdsTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_byAccount() throws BurstException {
+  public void processRequest_byAccount() throws SignumException {
     final long accountId = 123L;
     final int firstIndex = 0;
     final int lastIndex = 1;
@@ -78,7 +78,7 @@ public class GetAccountCurrentBidOrderIdsTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_byAccountAsset() throws BurstException {
+  public void processRequest_byAccountAsset() throws SignumException {
     final long accountId = 123L;
     final long assetId = 234L;
     final int firstIndex = 0;

--- a/test/java/brs/web/api/http/handler/GetAccountCurrentBidOrdersTest.java
+++ b/test/java/brs/web/api/http/handler/GetAccountCurrentBidOrdersTest.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Account;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Order;
 import brs.Order.Bid;
 import brs.assetexchange.AssetExchange;
@@ -46,7 +46,7 @@ public class GetAccountCurrentBidOrdersTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_byAccount() throws BurstException {
+  public void processRequest_byAccount() throws SignumException {
     final long accountId = 123L;
     final int firstIndex = 0;
     final int lastIndex = 1;
@@ -82,7 +82,7 @@ public class GetAccountCurrentBidOrdersTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_byAccountAsset() throws BurstException {
+  public void processRequest_byAccountAsset() throws SignumException {
     final long accountId = 123L;
     final long assetId = 234L;
     final int firstIndex = 0;

--- a/test/java/brs/web/api/http/handler/GetAccountEscrowTransactionsTest.java
+++ b/test/java/brs/web/api/http/handler/GetAccountEscrowTransactionsTest.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Account;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Escrow;
 import brs.Escrow.Decision;
 import brs.Escrow.DecisionType;
@@ -48,7 +48,7 @@ public class GetAccountEscrowTransactionsTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final long accountId = 5;
 
     final HttpServletRequest req = QuickMocker.httpServletRequest(

--- a/test/java/brs/web/api/http/handler/GetAccountPublicKeyTest.java
+++ b/test/java/brs/web/api/http/handler/GetAccountPublicKeyTest.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Account;
-import brs.BurstException;
+import brs.SignumException;
 import brs.common.QuickMocker;
 import brs.common.TestConstants;
 import brs.services.ParameterService;
@@ -33,7 +33,7 @@ public class GetAccountPublicKeyTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     final Account mockAccount = mock(Account.class);
@@ -48,7 +48,7 @@ public class GetAccountPublicKeyTest {
   }
 
   @Test
-  public void processRequest_withoutPublicKey() throws BurstException {
+  public void processRequest_withoutPublicKey() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     final Account mockAccount = mock(Account.class);

--- a/test/java/brs/web/api/http/handler/GetAccountSubscriptionsTest.java
+++ b/test/java/brs/web/api/http/handler/GetAccountSubscriptionsTest.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Account;
 import brs.Blockchain;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.Subscription;
 import brs.common.AbstractUnitTest;
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class GetAccountSubscriptionsTest extends AbstractUnitTest {
 
   private ParameterService parameterServiceMock;
@@ -45,14 +45,14 @@ public class GetAccountSubscriptionsTest extends AbstractUnitTest {
 
   @Before
   public void setUp() {
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
 
     parameterServiceMock = mock(ParameterService.class);
     subscriptionServiceMock = mock(SubscriptionService.class);
     aliasServiceMock = mock(AliasService.class);
 
     Blockchain mockBlockchain = mock(Blockchain.class);
-    when(Burst.getBlockchain()).thenReturn(mockBlockchain);
+    when(Signum.getBlockchain()).thenReturn(mockBlockchain);
 
     t = new GetAccountSubscriptions(parameterServiceMock, subscriptionServiceMock, aliasServiceMock);
   }

--- a/test/java/brs/web/api/http/handler/GetAccountSubscriptionsTest.java
+++ b/test/java/brs/web/api/http/handler/GetAccountSubscriptionsTest.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Account;
 import brs.Blockchain;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Subscription;
 import brs.common.AbstractUnitTest;
 import brs.common.QuickMocker;
@@ -58,7 +58,7 @@ public class GetAccountSubscriptionsTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final long userId = 123L;
 
     final HttpServletRequest req = QuickMocker.httpServletRequest(

--- a/test/java/brs/web/api/http/handler/GetAccountTest.java
+++ b/test/java/brs/web/api/http/handler/GetAccountTest.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Account;
 import brs.Account.AccountAsset;
 import brs.Blockchain;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Generator;
 import brs.common.AbstractUnitTest;
 import brs.common.QuickMocker;
@@ -46,7 +46,7 @@ public class GetAccountTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final long mockAccountId = 123L;
     final String mockAccountName = "accountName";
     final String mockAccountDescription = "accountDescription";

--- a/test/java/brs/web/api/http/handler/GetAccountsWithNameTest.java
+++ b/test/java/brs/web/api/http/handler/GetAccountsWithNameTest.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Account;
-import brs.BurstException;
+import brs.SignumException;
 import brs.common.AbstractUnitTest;
 import brs.common.QuickMocker;
 import brs.services.AccountService;
@@ -36,7 +36,7 @@ public class GetAccountsWithNameTest extends AbstractUnitTest {
     }
 
     @Test
-    public void processRequest() throws BurstException {
+    public void processRequest() throws SignumException {
         final long targetAccountId = 4L;
         final String targetAccountName = "exampleAccountName";
 
@@ -61,7 +61,7 @@ public class GetAccountsWithNameTest extends AbstractUnitTest {
     }
 
     @Test
-    public void processRequest_noAccountFound() throws BurstException {
+    public void processRequest_noAccountFound() throws SignumException {
         final String targetAccountName = "exampleAccountName";
 
         final HttpServletRequest req = QuickMocker.httpServletRequest(

--- a/test/java/brs/web/api/http/handler/GetAccountsWithRewardRecipientTest.java
+++ b/test/java/brs/web/api/http/handler/GetAccountsWithRewardRecipientTest.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Account;
 import brs.Account.RewardRecipientAssignment;
-import brs.BurstException;
+import brs.SignumException;
 import brs.common.AbstractUnitTest;
 import brs.common.QuickMocker;
 import brs.common.QuickMocker.MockParam;
@@ -40,7 +40,7 @@ public class GetAccountsWithRewardRecipientTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final long targetAccountId = 4L;
 
     final HttpServletRequest req = QuickMocker.httpServletRequest(
@@ -68,7 +68,7 @@ public class GetAccountsWithRewardRecipientTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_withRewardRecipientAssignmentKnown() throws BurstException {
+  public void processRequest_withRewardRecipientAssignmentKnown() throws SignumException {
     final long targetAccountId = 4L;
 
     final HttpServletRequest req = QuickMocker.httpServletRequest(

--- a/test/java/brs/web/api/http/handler/GetAliasesTest.java
+++ b/test/java/brs/web/api/http/handler/GetAliasesTest.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Account;
 import brs.Alias;
 import brs.Alias.Offer;
-import brs.BurstException;
+import brs.SignumException;
 import brs.common.AbstractUnitTest;
 import brs.common.QuickMocker;
 import brs.services.AliasService;
@@ -41,7 +41,7 @@ public class GetAliasesTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final long accountId = 123L;
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 

--- a/test/java/brs/web/api/http/handler/GetAllAssetsTest.java
+++ b/test/java/brs/web/api/http/handler/GetAllAssetsTest.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Asset;
 import brs.Blockchain;
-import brs.Burst;
+import brs.Signum;
 import brs.assetexchange.AssetExchange;
 import brs.common.AbstractUnitTest;
 import brs.common.QuickMocker;
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.*;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class GetAllAssetsTest extends AbstractUnitTest {
 
   private GetAllAssets t;
@@ -45,9 +45,9 @@ public class GetAllAssetsTest extends AbstractUnitTest {
     assetExchange = mock(AssetExchange.class);
     accountService = mock(AccountService.class);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     Blockchain mockBlockchain = mock(Blockchain.class);
-    when(Burst.getBlockchain()).thenReturn(mockBlockchain);
+    when(Signum.getBlockchain()).thenReturn(mockBlockchain);
     when(mockBlockchain.getHeight()).thenReturn(Integer.MAX_VALUE);
 
     t = new GetAllAssets(assetExchange, accountService);

--- a/test/java/brs/web/api/http/handler/GetAllTradesTest.java
+++ b/test/java/brs/web/api/http/handler/GetAllTradesTest.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Asset;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Trade;
 import brs.assetexchange.AssetExchange;
 import brs.common.AbstractUnitTest;
@@ -39,7 +39,7 @@ public class GetAllTradesTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_withAssetsInformation() throws BurstException {
+  public void processRequest_withAssetsInformation() throws SignumException {
     final int timestamp = 1;
     final int firstIndex = 0;
     final int lastIndex = 1;
@@ -84,7 +84,7 @@ public class GetAllTradesTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_withoutAssetsInformation() throws BurstException {
+  public void processRequest_withoutAssetsInformation() throws SignumException {
     final int timestamp = 1;
     final int firstIndex = 0;
     final int lastIndex = 1;

--- a/test/java/brs/web/api/http/handler/GetAskOrderIdsTest.java
+++ b/test/java/brs/web/api/http/handler/GetAskOrderIdsTest.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Asset;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Order;
 import brs.Order.Ask;
 import brs.assetexchange.AssetExchange;
@@ -45,7 +45,7 @@ public class GetAskOrderIdsTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final long assetIndex = 5;
     final int firstIndex = 1;
     final int lastIndex = 3;

--- a/test/java/brs/web/api/http/handler/GetAskOrderTest.java
+++ b/test/java/brs/web/api/http/handler/GetAskOrderTest.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.Order.Ask;
 import brs.assetexchange.AssetExchange;
 import brs.common.QuickMocker;
@@ -33,7 +33,7 @@ public class GetAskOrderTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final long orderId = 123L;
 
     final Ask mockOrder = mock(Ask.class);
@@ -49,7 +49,7 @@ public class GetAskOrderTest {
   }
 
   @Test
-  public void processRequest_unknownOrder() throws BurstException {
+  public void processRequest_unknownOrder() throws SignumException {
     final long orderId = 123L;
 
     when(mockAssetExchange.getAskOrder(eq(orderId))).thenReturn(null);

--- a/test/java/brs/web/api/http/handler/GetAskOrdersTest.java
+++ b/test/java/brs/web/api/http/handler/GetAskOrdersTest.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Asset;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Order;
 import brs.Order.Ask;
 import brs.assetexchange.AssetExchange;
@@ -45,7 +45,7 @@ public class GetAskOrdersTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final long assetIndex = 5;
     final int firstIndex = 1;
     final int lastIndex = 3;

--- a/test/java/brs/web/api/http/handler/GetAssetTest.java
+++ b/test/java/brs/web/api/http/handler/GetAssetTest.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Asset;
 import brs.Blockchain;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.assetexchange.AssetExchange;
 import brs.common.AbstractUnitTest;
 import brs.common.QuickMocker;
@@ -55,7 +55,7 @@ public class GetAssetTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final long assetId = 4;
 
     final HttpServletRequest req = QuickMocker.httpServletRequest(

--- a/test/java/brs/web/api/http/handler/GetAssetTest.java
+++ b/test/java/brs/web/api/http/handler/GetAssetTest.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Asset;
 import brs.Blockchain;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.assetexchange.AssetExchange;
 import brs.common.AbstractUnitTest;
@@ -29,7 +29,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.powermock.api.mockito.PowerMockito.*;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class GetAssetTest extends AbstractUnitTest {
 
   private ParameterService parameterServiceMock;
@@ -45,11 +45,11 @@ public class GetAssetTest extends AbstractUnitTest {
     mockAccountService = mock(AccountService.class);
     FluxCapacitor mockFluxCapacitor = QuickMocker.latestValueFluxCapacitor();
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     Blockchain mockBlockchain = mock(Blockchain.class);
-    when(Burst.getBlockchain()).thenReturn(mockBlockchain);
+    when(Signum.getBlockchain()).thenReturn(mockBlockchain);
     when(mockBlockchain.getHeight()).thenReturn(Integer.MAX_VALUE);
-    when(Burst.getFluxCapacitor()).thenReturn(mockFluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(mockFluxCapacitor);
 
     t = new GetAsset(parameterServiceMock, mockAssetExchange, mockAccountService);
   }

--- a/test/java/brs/web/api/http/handler/GetAssetTransfersTest.java
+++ b/test/java/brs/web/api/http/handler/GetAssetTransfersTest.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Account;
 import brs.Asset;
 import brs.AssetTransfer;
-import brs.BurstException;
+import brs.SignumException;
 import brs.assetexchange.AssetExchange;
 import brs.common.AbstractUnitTest;
 import brs.common.QuickMocker;
@@ -48,7 +48,7 @@ public class GetAssetTransfersTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_byAsset() throws BurstException {
+  public void processRequest_byAsset() throws SignumException {
     final long assetId = 123L;
     final int firstIndex = 0;
     final int lastIndex = 1;
@@ -76,7 +76,7 @@ public class GetAssetTransfersTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_byAccount() throws BurstException {
+  public void processRequest_byAccount() throws SignumException {
     final long accountId = 234L;
     final int firstIndex = 0;
     final int lastIndex = 1;
@@ -104,7 +104,7 @@ public class GetAssetTransfersTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_byAccountAndAsset() throws BurstException {
+  public void processRequest_byAccountAndAsset() throws SignumException {
     final long assetId = 123L;
     final long accountId = 234L;
     final int firstIndex = 0;

--- a/test/java/brs/web/api/http/handler/GetAssetsByIssuerTest.java
+++ b/test/java/brs/web/api/http/handler/GetAssetsByIssuerTest.java
@@ -4,7 +4,7 @@ import brs.Account;
 import brs.Asset;
 import brs.Blockchain;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.assetexchange.AssetExchange;
 import brs.common.AbstractUnitTest;
 import brs.common.QuickMocker;
@@ -59,7 +59,7 @@ public class GetAssetsByIssuerTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final int firstIndex = 1;
     final int lastIndex = 2;
 

--- a/test/java/brs/web/api/http/handler/GetAssetsByIssuerTest.java
+++ b/test/java/brs/web/api/http/handler/GetAssetsByIssuerTest.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Account;
 import brs.Asset;
 import brs.Blockchain;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.assetexchange.AssetExchange;
 import brs.common.AbstractUnitTest;
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.*;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class GetAssetsByIssuerTest extends AbstractUnitTest {
 
   private GetAssetsByIssuer t;
@@ -50,9 +50,9 @@ public class GetAssetsByIssuerTest extends AbstractUnitTest {
     mockAssetExchange = mock(AssetExchange.class);
     mockAccountService = mock(AccountService.class);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     Blockchain mockBlockchain = mock(Blockchain.class);
-    when(Burst.getBlockchain()).thenReturn(mockBlockchain);
+    when(Signum.getBlockchain()).thenReturn(mockBlockchain);
     when(mockBlockchain.getHeight()).thenReturn(Integer.MAX_VALUE);
 
     t = new GetAssetsByIssuer(mockParameterService, mockAssetExchange, mockAccountService);

--- a/test/java/brs/web/api/http/handler/GetBalanceTest.java
+++ b/test/java/brs/web/api/http/handler/GetBalanceTest.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Account;
-import brs.BurstException;
+import brs.SignumException;
 import brs.common.QuickMocker;
 import brs.services.ParameterService;
 import brs.util.JSON;
@@ -30,7 +30,7 @@ public class GetBalanceTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
     Account mockAccount = mock(Account.class);
 
@@ -49,7 +49,7 @@ public class GetBalanceTest {
   }
 
   @Test
-  public void processRequest_noAccountFound() throws BurstException {
+  public void processRequest_noAccountFound() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     when(parameterServiceMock.getAccount(eq(req))).thenReturn(null);

--- a/test/java/brs/web/api/http/handler/GetBidOrderTest.java
+++ b/test/java/brs/web/api/http/handler/GetBidOrderTest.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.Order.Bid;
 import brs.assetexchange.AssetExchange;
 import brs.common.QuickMocker;
@@ -35,7 +35,7 @@ public class GetBidOrderTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final long bidOrderId = 123L;
     Bid mockBid = mock(Bid.class);
     when(mockBid.getId()).thenReturn(bidOrderId);
@@ -50,7 +50,7 @@ public class GetBidOrderTest {
   }
 
   @Test
-  public void processRequest_orderNotFoundUnknownOrder() throws BurstException {
+  public void processRequest_orderNotFoundUnknownOrder() throws SignumException {
     final long bidOrderId = 123L;
 
     HttpServletRequest req = QuickMocker.httpServletRequest(new MockParam(ORDER_PARAMETER, bidOrderId));

--- a/test/java/brs/web/api/http/handler/GetBidOrdersTest.java
+++ b/test/java/brs/web/api/http/handler/GetBidOrdersTest.java
@@ -1,7 +1,7 @@
 package brs.web.api.http.handler;
 
 import brs.Asset;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Order;
 import brs.Order.Bid;
 import brs.assetexchange.AssetExchange;
@@ -47,7 +47,7 @@ public class GetBidOrdersTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final long assetId = 123L;
     final int firstIndex = 0;
     final int lastIndex = 1;

--- a/test/java/brs/web/api/http/handler/GetBlockTest.java
+++ b/test/java/brs/web/api/http/handler/GetBlockTest.java
@@ -47,7 +47,7 @@ public class GetBlockTest {
     mockStatic(Signum.class);
     PropertyService propertyService = mock(PropertyService.class);
     when(Signum.getPropertyService()).thenReturn(propertyService);
-    doReturn((int)Constants.ONE_BURST).when(propertyService).getInt(eq(Props.ONE_COIN_NQT));
+    doReturn((int)Constants.ONE_SIGNA).when(propertyService).getInt(eq(Props.ONE_COIN_NQT));
 
     t = new GetBlock(blockchainMock, blockServiceMock);
   }

--- a/test/java/brs/web/api/http/handler/GetBlockTest.java
+++ b/test/java/brs/web/api/http/handler/GetBlockTest.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Block;
 import brs.Blockchain;
-import brs.Burst;
+import brs.Signum;
 import brs.Constants;
 import brs.common.QuickMocker;
 import brs.common.QuickMocker.MockParam;
@@ -31,7 +31,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import java.math.BigInteger;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class GetBlockTest {
 
   private GetBlock t;
@@ -44,9 +44,9 @@ public class GetBlockTest {
     blockchainMock = mock(Blockchain.class);
     blockServiceMock = mock(BlockService.class);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     PropertyService propertyService = mock(PropertyService.class);
-    when(Burst.getPropertyService()).thenReturn(propertyService);
+    when(Signum.getPropertyService()).thenReturn(propertyService);
     doReturn((int)Constants.ONE_BURST).when(propertyService).getInt(eq(Props.ONE_COIN_NQT));
 
     t = new GetBlock(blockchainMock, blockServiceMock);

--- a/test/java/brs/web/api/http/handler/GetDGSGoodTest.java
+++ b/test/java/brs/web/api/http/handler/GetDGSGoodTest.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.DigitalGoodsStore;
 import brs.common.QuickMocker;
 import brs.services.ParameterService;
@@ -34,7 +34,7 @@ public class GetDGSGoodTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final DigitalGoodsStore.Goods mockGoods = mock(DigitalGoodsStore.Goods.class);
     when(mockGoods.getId()).thenReturn(1L);
     when(mockGoods.getName()).thenReturn("name");

--- a/test/java/brs/web/api/http/handler/GetDGSGoodsTest.java
+++ b/test/java/brs/web/api/http/handler/GetDGSGoodsTest.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.DigitalGoodsStore;
 import brs.DigitalGoodsStore.Goods;
 import brs.common.AbstractUnitTest;
@@ -46,7 +46,7 @@ public class GetDGSGoodsTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_getSellerGoods() throws BurstException {
+  public void processRequest_getSellerGoods() throws SignumException {
     final long sellerId = 1L;
     final int firstIndex = 2;
     final int lastIndex = 3;
@@ -86,7 +86,7 @@ public class GetDGSGoodsTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_getAllGoods() throws BurstException {
+  public void processRequest_getAllGoods() throws SignumException {
     final long sellerId = 0L;
     final int firstIndex = 2;
     final int lastIndex = 3;
@@ -126,7 +126,7 @@ public class GetDGSGoodsTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_getGoodsInStock() throws BurstException {
+  public void processRequest_getGoodsInStock() throws SignumException {
     final long sellerId = 0L;
     final int firstIndex = 2;
     final int lastIndex = 3;

--- a/test/java/brs/web/api/http/handler/GetDGSPendingPurchasesTest.java
+++ b/test/java/brs/web/api/http/handler/GetDGSPendingPurchasesTest.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.DigitalGoodsStore.Purchase;
 import brs.common.AbstractUnitTest;
 import brs.common.QuickMocker;
@@ -39,7 +39,7 @@ public class GetDGSPendingPurchasesTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final long sellerId = 123L;
     final int firstIndex = 1;
     final int lastIndex = 2;
@@ -65,7 +65,7 @@ public class GetDGSPendingPurchasesTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_missingSeller() throws BurstException {
+  public void processRequest_missingSeller() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(SELLER_PARAMETER, 0)
     );

--- a/test/java/brs/web/api/http/handler/GetDGSPurchaseTest.java
+++ b/test/java/brs/web/api/http/handler/GetDGSPurchaseTest.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.DigitalGoodsStore.Purchase;
 import brs.common.QuickMocker;
 import brs.crypto.EncryptedData;
@@ -36,7 +36,7 @@ public class GetDGSPurchaseTest {
 
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     final EncryptedData mockEncryptedData = mock(EncryptedData.class);

--- a/test/java/brs/web/api/http/handler/GetDGSPurchasesTest.java
+++ b/test/java/brs/web/api/http/handler/GetDGSPurchasesTest.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.DigitalGoodsStore.Purchase;
 import brs.common.AbstractUnitTest;
 import brs.common.QuickMocker;
@@ -38,7 +38,7 @@ public class GetDGSPurchasesTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_getAllPurchases() throws BurstException {
+  public void processRequest_getAllPurchases() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(SELLER_PARAMETER, 0),
         new MockParam(BUYER_PARAMETER, 0),
@@ -63,7 +63,7 @@ public class GetDGSPurchasesTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_getSellerPurchases() throws BurstException {
+  public void processRequest_getSellerPurchases() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(SELLER_PARAMETER, 1),
         new MockParam(BUYER_PARAMETER, 0),
@@ -88,7 +88,7 @@ public class GetDGSPurchasesTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_getBuyerPurchases() throws BurstException {
+  public void processRequest_getBuyerPurchases() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(SELLER_PARAMETER, 0),
         new MockParam(BUYER_PARAMETER, 1),
@@ -113,7 +113,7 @@ public class GetDGSPurchasesTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_getSellerBuyerPurchases() throws BurstException {
+  public void processRequest_getSellerBuyerPurchases() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(SELLER_PARAMETER, 1),
         new MockParam(BUYER_PARAMETER, 2),

--- a/test/java/brs/web/api/http/handler/GetTradesTest.java
+++ b/test/java/brs/web/api/http/handler/GetTradesTest.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Account;
 import brs.Asset;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Trade;
 import brs.assetexchange.AssetExchange;
 import brs.common.AbstractUnitTest;
@@ -43,7 +43,7 @@ public class GetTradesTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_withAssetId() throws BurstException {
+  public void processRequest_withAssetId() throws SignumException {
     final long assetId = 123L;
     final int firstIndex = 0;
     final int lastIndex = 1;
@@ -77,7 +77,7 @@ public class GetTradesTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_withAccountId() throws BurstException {
+  public void processRequest_withAccountId() throws SignumException {
     final long accountId = 321L;
     final int firstIndex = 0;
     final int lastIndex = 1;
@@ -111,7 +111,7 @@ public class GetTradesTest extends AbstractUnitTest {
   }
 
   @Test
-  public void processRequest_withAssetIdAndAccountId() throws BurstException {
+  public void processRequest_withAssetIdAndAccountId() throws SignumException {
     final long assetId = 123L;
     final long accountId = 321L;
     final int firstIndex = 0;

--- a/test/java/brs/web/api/http/handler/IssueAssetTest.java
+++ b/test/java/brs/web/api/http/handler/IssueAssetTest.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Attachment;
 import brs.Blockchain;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Constants;
 import brs.common.QuickMocker;
 import brs.common.QuickMocker.MockParam;
@@ -51,7 +51,7 @@ public class IssueAssetTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final String nameParameter = stringWithLength(MIN_ASSET_NAME_LENGTH + 1);
     final String descriptionParameter = stringWithLength(MAX_ASSET_DESCRIPTION_LENGTH - 1);
     final int decimalsParameter = 4;
@@ -80,14 +80,14 @@ public class IssueAssetTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_missingName() throws BurstException {
+  public void processRequest_missingName() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     assertEquals(MISSING_NAME, t.processRequest(req));
   }
 
   @Test
-  public void processRequest_incorrectAssetNameLength_smallerThanMin() throws BurstException {
+  public void processRequest_incorrectAssetNameLength_smallerThanMin() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(NAME_PARAMETER, stringWithLength(MIN_ASSET_NAME_LENGTH - 1))
     );
@@ -96,7 +96,7 @@ public class IssueAssetTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_incorrectAssetNameLength_largerThanMax() throws BurstException {
+  public void processRequest_incorrectAssetNameLength_largerThanMax() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(NAME_PARAMETER, stringWithLength(MAX_ASSET_NAME_LENGTH + 1))
     );
@@ -105,7 +105,7 @@ public class IssueAssetTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_incorrectAssetName() throws BurstException {
+  public void processRequest_incorrectAssetName() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(NAME_PARAMETER, stringWithLength(MIN_ASSET_NAME_LENGTH + 1) + "[")
     );
@@ -114,7 +114,7 @@ public class IssueAssetTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_incorrectAssetDescription() throws BurstException {
+  public void processRequest_incorrectAssetDescription() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(NAME_PARAMETER, stringWithLength(MIN_ASSET_NAME_LENGTH + 1)),
         new MockParam(DESCRIPTION_PARAMETER, stringWithLength(MAX_ASSET_DESCRIPTION_LENGTH + 1))
@@ -124,7 +124,7 @@ public class IssueAssetTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_incorrectDecimals_unParsable() throws BurstException {
+  public void processRequest_incorrectDecimals_unParsable() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(NAME_PARAMETER, stringWithLength(MIN_ASSET_NAME_LENGTH + 1)),
         new MockParam(DESCRIPTION_PARAMETER, stringWithLength(MAX_ASSET_DESCRIPTION_LENGTH - 1)),
@@ -135,7 +135,7 @@ public class IssueAssetTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_incorrectDecimals_negativeNumber() throws BurstException {
+  public void processRequest_incorrectDecimals_negativeNumber() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(NAME_PARAMETER, stringWithLength(MIN_ASSET_NAME_LENGTH + 1)),
         new MockParam(DESCRIPTION_PARAMETER, stringWithLength(MAX_ASSET_DESCRIPTION_LENGTH - 1)),
@@ -146,7 +146,7 @@ public class IssueAssetTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_incorrectDecimals_moreThan8() throws BurstException {
+  public void processRequest_incorrectDecimals_moreThan8() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(NAME_PARAMETER, stringWithLength(MIN_ASSET_NAME_LENGTH + 1)),
         new MockParam(DESCRIPTION_PARAMETER, stringWithLength(MAX_ASSET_DESCRIPTION_LENGTH - 1)),

--- a/test/java/brs/web/api/http/handler/IssueAssetTest.java
+++ b/test/java/brs/web/api/http/handler/IssueAssetTest.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Attachment;
 import brs.Blockchain;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.Constants;
 import brs.common.QuickMocker;
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class IssueAssetTest extends AbstractTransactionTest {
 
   private IssueAsset t;
@@ -64,9 +64,9 @@ public class IssueAssetTest extends AbstractTransactionTest {
         new MockParam(QUANTITY_QNT_PARAMETER, quantityQNTParameter)
     );
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(fluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 
     final Attachment.ColoredCoinsAssetIssuance attachment = (Attachment.ColoredCoinsAssetIssuance) attachmentCreatedTransaction(() -> t.processRequest(req), apiTransactionManagerMock);

--- a/test/java/brs/web/api/http/handler/SellAliasTest.java
+++ b/test/java/brs/web/api/http/handler/SellAliasTest.java
@@ -49,7 +49,7 @@ public class SellAliasTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final int priceParameter = 10;
     final int recipientId = 5;
 
@@ -81,14 +81,14 @@ public class SellAliasTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_missingPrice() throws BurstException {
+  public void processRequest_missingPrice() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     assertEquals(MISSING_PRICE, t.processRequest(req));
   }
 
   @Test
-  public void processRequest_incorrectPrice_unParsable() throws BurstException {
+  public void processRequest_incorrectPrice_unParsable() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
       new MockParam(PRICE_NQT_PARAMETER, "unParsable")
     );
@@ -97,7 +97,7 @@ public class SellAliasTest extends AbstractTransactionTest {
   }
 
   @Test(expected = ParameterException.class)
-  public void processRequest_incorrectPrice_negative() throws BurstException {
+  public void processRequest_incorrectPrice_negative() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(PRICE_NQT_PARAMETER, -10)
     );
@@ -106,7 +106,7 @@ public class SellAliasTest extends AbstractTransactionTest {
   }
 
   @Test(expected = ParameterException.class)
-  public void processRequest_incorrectPrice_overMaxBalance() throws BurstException {
+  public void processRequest_incorrectPrice_overMaxBalance() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(PRICE_NQT_PARAMETER, MAX_BALANCE_NQT + 1)
     );
@@ -115,7 +115,7 @@ public class SellAliasTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_incorrectRecipient_unparsable() throws BurstException {
+  public void processRequest_incorrectRecipient_unparsable() throws SignumException {
     final int price = 10;
 
     final HttpServletRequest req = QuickMocker.httpServletRequest(
@@ -127,7 +127,7 @@ public class SellAliasTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_incorrectRecipient_zero() throws BurstException {
+  public void processRequest_incorrectRecipient_zero() throws SignumException {
     final int price = 10;
     final int recipientId = 0;
 
@@ -140,7 +140,7 @@ public class SellAliasTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_incorrectAliasOwner() throws BurstException {
+  public void processRequest_incorrectAliasOwner() throws SignumException {
     final int price = 10;
     final int recipientId = 5;
 

--- a/test/java/brs/web/api/http/handler/SellAliasTest.java
+++ b/test/java/brs/web/api/http/handler/SellAliasTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class SellAliasTest extends AbstractTransactionTest {
 
   private SellAlias t;
@@ -68,9 +68,9 @@ public class SellAliasTest extends AbstractTransactionTest {
     when(parameterServiceMock.getSenderAccount(req)).thenReturn(mockSender);
     when(parameterServiceMock.getAlias(req)).thenReturn(mockAlias);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(fluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 
     final Attachment.MessagingAliasSell attachment = (Attachment.MessagingAliasSell) attachmentCreatedTransaction(() -> t.processRequest(req), apiTransactionManagerMock);

--- a/test/java/brs/web/api/http/handler/SetAliasTest.java
+++ b/test/java/brs/web/api/http/handler/SetAliasTest.java
@@ -2,7 +2,7 @@ package brs.web.api.http.handler;
 
 import brs.Attachment;
 import brs.Blockchain;
-import brs.Burst;
+import brs.Signum;
 import brs.BurstException;
 import brs.Constants;
 import brs.common.QuickMocker;
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class SetAliasTest extends AbstractTransactionTest {
 
   private SetAlias t;
@@ -45,7 +45,7 @@ public class SetAliasTest extends AbstractTransactionTest {
 
   @Before
   public void setUp() {
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
 
     parameterServiceMock = mock(ParameterService.class);
     blockchainMock = mock(Blockchain.class);
@@ -53,7 +53,7 @@ public class SetAliasTest extends AbstractTransactionTest {
     apiTransactionManagerMock = mock(APITransactionManager.class);
 
     FluxCapacitor mockFluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.PRE_POC2, FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(mockFluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(mockFluxCapacitor);
 
     t = new SetAlias(parameterServiceMock, blockchainMock, aliasServiceMock, apiTransactionManagerMock);
   }
@@ -68,9 +68,9 @@ public class SetAliasTest extends AbstractTransactionTest {
         new MockParam(ALIAS_URI_PARAMETER, aliasUrl)
     );
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(fluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 
     final Attachment.MessagingAliasAssignment attachment = (Attachment.MessagingAliasAssignment) attachmentCreatedTransaction(() -> t.processRequest(req), apiTransactionManagerMock);

--- a/test/java/brs/web/api/http/handler/SetAliasTest.java
+++ b/test/java/brs/web/api/http/handler/SetAliasTest.java
@@ -3,7 +3,7 @@ package brs.web.api.http.handler;
 import brs.Attachment;
 import brs.Blockchain;
 import brs.Signum;
-import brs.BurstException;
+import brs.SignumException;
 import brs.Constants;
 import brs.common.QuickMocker;
 import brs.common.QuickMocker.MockParam;
@@ -59,7 +59,7 @@ public class SetAliasTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final String aliasNameParameter = "aliasNameParameter";
     final String aliasUrl = "aliasUrl";
 
@@ -82,7 +82,7 @@ public class SetAliasTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_missingAliasName() throws BurstException {
+  public void processRequest_missingAliasName() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(ALIAS_NAME_PARAMETER, null),
         new MockParam(ALIAS_URI_PARAMETER, "aliasUrl")
@@ -92,7 +92,7 @@ public class SetAliasTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_incorrectAliasLength_nameOnlySpaces() throws BurstException {
+  public void processRequest_incorrectAliasLength_nameOnlySpaces() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(ALIAS_NAME_PARAMETER, "  "),
         new MockParam(ALIAS_URI_PARAMETER, null)
@@ -103,7 +103,7 @@ public class SetAliasTest extends AbstractTransactionTest {
 
 
   @Test
-  public void processRequest_incorrectAliasLength_incorrectAliasName() throws BurstException {
+  public void processRequest_incorrectAliasLength_incorrectAliasName() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(ALIAS_NAME_PARAMETER, "[]"),
         new MockParam(ALIAS_URI_PARAMETER, null)
@@ -113,7 +113,7 @@ public class SetAliasTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_incorrectUriLengthWhenOver1000Characters() throws BurstException {
+  public void processRequest_incorrectUriLengthWhenOver1000Characters() throws SignumException {
     final StringBuilder uriOver1000Characters = new StringBuilder();
 
     for (int i = 0; i < 1001; i++) {

--- a/test/java/brs/web/api/http/handler/SetRewardRecipientTest.java
+++ b/test/java/brs/web/api/http/handler/SetRewardRecipientTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class SetRewardRecipientTest extends AbstractTransactionTest {
 
   private SetRewardRecipient t;
@@ -61,9 +61,9 @@ public class SetRewardRecipientTest extends AbstractTransactionTest {
     when(parameterServiceMock.getAccount(eq(req))).thenReturn(mockSenderAccount);
     when(accountServiceMock.getAccount(eq(123L))).thenReturn(mockRecipientAccount);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(fluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 
     final Attachment.BurstMiningRewardRecipientAssignment attachment = (Attachment.BurstMiningRewardRecipientAssignment) attachmentCreatedTransaction(() -> t.processRequest(req), apiTransactionManagerMock);
@@ -79,9 +79,9 @@ public class SetRewardRecipientTest extends AbstractTransactionTest {
 
     when(parameterServiceMock.getAccount(eq(req))).thenReturn(mockSenderAccount);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(false).when(fluxCapacitor).getValue(eq(FluxValues.SMART_TOKEN));
 
     assertEquals(8, JSONTestHelper.errorCode(t.processRequest(req)));
@@ -96,9 +96,9 @@ public class SetRewardRecipientTest extends AbstractTransactionTest {
     when(parameterServiceMock.getAccount(eq(req))).thenReturn(mockSenderAccount);
     when(accountServiceMock.getAccount(eq(123L))).thenReturn(mockRecipientAccount);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(false).when(fluxCapacitor).getValue(eq(FluxValues.SMART_TOKEN));
 
     assertEquals(8, JSONTestHelper.errorCode(t.processRequest(req)));

--- a/test/java/brs/web/api/http/handler/SetRewardRecipientTest.java
+++ b/test/java/brs/web/api/http/handler/SetRewardRecipientTest.java
@@ -19,7 +19,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import javax.servlet.http.HttpServletRequest;
 
-import static brs.TransactionType.BurstMining.REWARD_RECIPIENT_ASSIGNMENT;
+import static brs.TransactionType.SignaMining.REWARD_RECIPIENT_ASSIGNMENT;
 import static brs.web.api.http.common.Parameters.RECIPIENT_PARAMETER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -66,7 +66,7 @@ public class SetRewardRecipientTest extends AbstractTransactionTest {
     when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(fluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 
-    final Attachment.BurstMiningRewardRecipientAssignment attachment = (Attachment.BurstMiningRewardRecipientAssignment) attachmentCreatedTransaction(() -> t.processRequest(req), apiTransactionManagerMock);
+    final Attachment.SignaMiningRewardRecipientAssignment attachment = (Attachment.SignaMiningRewardRecipientAssignment) attachmentCreatedTransaction(() -> t.processRequest(req), apiTransactionManagerMock);
     assertNotNull(attachment);
 
     assertEquals(REWARD_RECIPIENT_ASSIGNMENT, attachment.getTransactionType());

--- a/test/java/brs/web/api/http/handler/SetRewardRecipientTest.java
+++ b/test/java/brs/web/api/http/handler/SetRewardRecipientTest.java
@@ -51,7 +51,7 @@ public class SetRewardRecipientTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(new MockParam(RECIPIENT_PARAMETER, "123"));
     final Account mockSenderAccount = mock(Account.class);
     final Account mockRecipientAccount = mock(Account.class);
@@ -73,7 +73,7 @@ public class SetRewardRecipientTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_recipientAccountDoesNotExist_errorCode8() throws BurstException {
+  public void processRequest_recipientAccountDoesNotExist_errorCode8() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(new MockParam(RECIPIENT_PARAMETER, "123"));
     final Account mockSenderAccount = mock(Account.class);
 
@@ -88,7 +88,7 @@ public class SetRewardRecipientTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_recipientAccountDoesNotHavePublicKey_errorCode8() throws BurstException {
+  public void processRequest_recipientAccountDoesNotHavePublicKey_errorCode8() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(new MockParam(RECIPIENT_PARAMETER, "123"));
     final Account mockSenderAccount = mock(Account.class);
     final Account mockRecipientAccount = mock(Account.class);

--- a/test/java/brs/web/api/http/handler/SubscriptionCancelTest.java
+++ b/test/java/brs/web/api/http/handler/SubscriptionCancelTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class SubscriptionCancelTest extends AbstractTransactionTest {
 
   private SubscriptionCancel t;
@@ -69,9 +69,9 @@ public class SubscriptionCancelTest extends AbstractTransactionTest {
     when(parameterServiceMock.getSenderAccount(eq(req))).thenReturn(mockSender);
     when(subscriptionServiceMock.getSubscription(eq(subscriptionIdParameter))).thenReturn(mockSubscription);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(fluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 
     final Attachment.AdvancedPaymentSubscriptionCancel attachment = (Attachment.AdvancedPaymentSubscriptionCancel) attachmentCreatedTransaction(() -> t.processRequest(req), apiTransactionManagerMock);

--- a/test/java/brs/web/api/http/handler/SubscriptionCancelTest.java
+++ b/test/java/brs/web/api/http/handler/SubscriptionCancelTest.java
@@ -51,7 +51,7 @@ public class SubscriptionCancelTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final Long subscriptionIdParameter = 123L;
 
     final HttpServletRequest req = QuickMocker.httpServletRequest(
@@ -82,7 +82,7 @@ public class SubscriptionCancelTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_missingSubscriptionParameter() throws BurstException {
+  public void processRequest_missingSubscriptionParameter() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     final JsonObject response = (JsonObject) t.processRequest(req);
@@ -92,7 +92,7 @@ public class SubscriptionCancelTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_failedToParseSubscription() throws BurstException {
+  public void processRequest_failedToParseSubscription() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
       new MockParam(SUBSCRIPTION_PARAMETER, "notALong")
     );
@@ -104,7 +104,7 @@ public class SubscriptionCancelTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_subscriptionNotFound() throws BurstException {
+  public void processRequest_subscriptionNotFound() throws SignumException {
     final long subscriptionId = 123L;
 
     final HttpServletRequest req = QuickMocker.httpServletRequest(
@@ -120,7 +120,7 @@ public class SubscriptionCancelTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_userIsNotSenderOrRecipient() throws BurstException {
+  public void processRequest_userIsNotSenderOrRecipient() throws SignumException {
     final long subscriptionId = 123L;
 
     final HttpServletRequest req = QuickMocker.httpServletRequest(

--- a/test/java/brs/web/api/http/handler/SuggestFeeTest.java
+++ b/test/java/brs/web/api/http/handler/SuggestFeeTest.java
@@ -1,6 +1,6 @@
 package brs.web.api.http.handler;
 
-import brs.BurstException;
+import brs.SignumException;
 import brs.common.QuickMocker;
 import brs.feesuggestions.FeeSuggestion;
 import brs.feesuggestions.FeeSuggestionCalculator;
@@ -31,7 +31,7 @@ public class SuggestFeeTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest();
 
     final long cheap = 1 * FEE_QUANT_SIP3;

--- a/test/java/brs/web/api/http/handler/TransferAssetTest.java
+++ b/test/java/brs/web/api/http/handler/TransferAssetTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Burst.class)
+@PrepareForTest(Signum.class)
 public class TransferAssetTest extends AbstractTransactionTest {
 
   private TransferAsset t;
@@ -71,9 +71,9 @@ public class TransferAssetTest extends AbstractTransactionTest {
 
     when(parameterServiceMock.getSenderAccount(eq(req))).thenReturn(mockSenderAccount);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(Constants.FEE_QUANT_SIP3).when(fluxCapacitor).getValue(eq(FluxValues.FEE_QUANT));
 
     final Attachment.ColoredCoinsAssetTransfer attachment = (Attachment.ColoredCoinsAssetTransfer) attachmentCreatedTransaction(() -> t.processRequest(req), apiTransactionManagerMock);
@@ -102,9 +102,9 @@ public class TransferAssetTest extends AbstractTransactionTest {
 
     when(accountServiceMock.getUnconfirmedAssetBalanceQNT(eq(mockSenderAccount), anyLong())).thenReturn(2L);
 
-    mockStatic(Burst.class);
+    mockStatic(Signum.class);
     final FluxCapacitor fluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.DIGITAL_GOODS_STORE);
-    when(Burst.getFluxCapacitor()).thenReturn(fluxCapacitor);
+    when(Signum.getFluxCapacitor()).thenReturn(fluxCapacitor);
     doReturn(false).when(fluxCapacitor).getValue(eq(FluxValues.SMART_TOKEN));
 
     assertEquals(NOT_ENOUGH_ASSETS, t.processRequest(req));

--- a/test/java/brs/web/api/http/handler/TransferAssetTest.java
+++ b/test/java/brs/web/api/http/handler/TransferAssetTest.java
@@ -50,7 +50,7 @@ public class TransferAssetTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest() throws BurstException {
+  public void processRequest() throws SignumException {
     final long recipientParameter = 34L;
     final long assetIdParameter = 456L;
     final long quantityQNTParameter = 56L;
@@ -85,7 +85,7 @@ public class TransferAssetTest extends AbstractTransactionTest {
   }
 
   @Test
-  public void processRequest_assetBalanceLowerThanQuantityNQTParameter() throws BurstException {
+  public void processRequest_assetBalanceLowerThanQuantityNQTParameter() throws SignumException {
     final HttpServletRequest req = QuickMocker.httpServletRequest(
         new MockParam(RECIPIENT_PARAMETER, "123"),
         new MockParam(ASSET_PARAMETER, "456"),

--- a/test/java/chain/ChainUtils.java
+++ b/test/java/chain/ChainUtils.java
@@ -1,6 +1,6 @@
 package chain;
 
-import brs.Burst;
+import brs.Signum;
 import signumj.Constants;
 import signumj.crypto.SignumCrypto;
 import signumj.entity.SignumAddress;
@@ -31,7 +31,7 @@ public class ChainUtils {
         
         // a mock node with memory DB
         String[] args = {"-l", "-c", "conf/junit"};
-        Burst.main(args);
+        Signum.main(args);
 
         crypto = SignumCrypto.getInstance();
         nodeService = new HttpNodeService(Constants.HTTP_NODE_LOCAL_TESTNET, "mock-node-testing");

--- a/test/java/it/common/AbstractIT.java
+++ b/test/java/it/common/AbstractIT.java
@@ -1,6 +1,6 @@
 package it.common;
 
-import brs.Burst;
+import brs.Signum;
 import brs.common.TestInfrastructure;
 import brs.peer.Peers;
 import brs.peer.ProcessBlock;
@@ -29,14 +29,14 @@ public abstract class AbstractIT {
   @Before
   public void setUp() {
     mockStatic(Peers.class);
-    Burst.init(testProperties());
+    Signum.init(testProperties());
 
-    processBlock = new ProcessBlock(Burst.getBlockchain(), Burst.getBlockchainProcessor());
+    processBlock = new ProcessBlock(Signum.getBlockchain(), Signum.getBlockchainProcessor());
   }
 
   @After
   public void shutdown() {
-    Burst.shutdown(true);
+    Signum.shutdown(true);
   }
 
   private Properties testProperties() {
@@ -61,6 +61,6 @@ public abstract class AbstractIT {
   }
 
   public void rollback(int height) {
-    Burst.getBlockchainProcessor().popOffTo(0);
+    Signum.getBlockchainProcessor().popOffTo(0);
   }
 }


### PR DESCRIPTION
Spent some time renaming every type, method, and variable that included the word 'burst' to include either 'signum' or 'signa', as appropriate, and correctly cased.

I purposely left strings alone for now as that will require more manual intervention that just letting the IDE handle renaming tokens. Strings will require gaining an understanding of the process they're each a part of and ensuring that changing them doesn't break anything.

I also purposely left any javascript, OpenAPI, or GUI webapp code alone, as I do not yet understand how any of those work.

This is mutually exclusive with #787 at the moment, but I will rebase whichever doesn't get approved first and push corrections.