### PR TITLE
Update broken documentation links

### DIFF
--- a/conf/node-default.properties
+++ b/conf/node-default.properties
@@ -68,7 +68,7 @@
 # P2P.UPnP = yes
 
 ## My platform, to be announced to peers.
-## Enter your Signum address here for SNR rewards, see here: https://signum.community/signum-snr-awards/
+## Enter your Signum address here for SNR rewards, see here: https://wiki.signum.network/signum-snr-awards/
 
 # P2P.myPlatform = PC
 

--- a/doc/History.md
+++ b/doc/History.md
@@ -1,4 +1,4 @@
-[History of Signum](https://signum.community/signum-development/)
+[History of Signum](https://wiki.signum.network/signum-development/)
 
 ```
 2020-04-06 v3.0.0
@@ -70,7 +70,7 @@
 - Default to submit nonce whitelist off
 - Revert removal of rejection of surplus parameters
 - Add option to bind V2 API to specific interface
-- MariaDB Settings tweaks 
+- MariaDB Settings tweaks
 - Various bug fixes and improvements
 
 2019-07-01 v2.4.0

--- a/openapi/paths/addCommitment.json
+++ b/openapi/paths/addCommitment.json
@@ -1,10 +1,8 @@
 {
   "post": {
     "summary": "Add Commitment",
-    "description": "Adds commitment to improve mining power. The commitment will be blocked, but never leave your account.<br/>Read more about mining on the [official Signum Site](https://signum.network/mining) and on the [community wiki](https://signum.community/signum-mining/#commitment).<br/>See also [removeCommitment](#get-/api-requestType-removeCommitment) ",
-    "tags": [
-      "account", "mining"
-    ],
+    "description": "Adds commitment to improve mining power. The commitment will be blocked, but never leave your account.<br/>Read more about mining on the [official Signum Site](https://signum.network/mining) and on the [community wiki](https://wiki.signum.network/signum-mining/#commitment).<br/>See also [removeCommitment](#get-/api-requestType-removeCommitment) ",
+    "tags": ["account", "mining"],
     "parameters": [
       {
         "$ref": "../parameters/transaction/amountNQT.json"
@@ -29,7 +27,7 @@
       "200": {
         "$ref": "../responses/transaction.json"
       },
-      "500" : {
+      "500": {
         "$ref": "../responses/error.json"
       }
     }

--- a/openapi/paths/contract/createATProgram.json
+++ b/openapi/paths/contract/createATProgram.json
@@ -1,10 +1,8 @@
 {
   "post": {
     "summary": "Publish Smart Contract",
-    "description": "Publishes/Deploys a Smart Contract.<br/>Read more about smart contracts on the [official Signum Site](https://signum.network/smartcontracts) and on the [community wiki](https://signum.community/signum-smart-contracts/).<br/>See also [SmartC](https://github.com/deleterium/SmartC/tree/stable/docs) and [SmartJ](https://github.com/signum-network/signum-smartj) ",
-    "tags": [
-      "contract"
-    ],
+    "description": "Publishes/Deploys a Smart Contract.<br/>Read more about smart contracts on the [official Signum Site](https://signum.network/smartcontracts) and on the [community wiki](https://wiki.signum.network/signum-smart-contracts/).<br/>See also [SmartC](https://github.com/deleterium/SmartC/tree/stable/docs) and [SmartJ](https://github.com/signum-network/signum-smartj) ",
+    "tags": ["contract"],
     "parameters": [
       {
         "name": "name",

--- a/openapi/paths/getters/getPeer.json
+++ b/openapi/paths/getters/getPeer.json
@@ -2,9 +2,7 @@
   "get": {
     "summary": "Get Node/Peer Info",
     "description": "Get information about a specific Peer. See also [Get Known Peers/Nodes](#get-/api-requestType-getPeers)",
-    "tags": [
-      "network"
-    ],
+    "tags": ["network"],
     "parameters": [
       {
         "name": "peer",
@@ -41,7 +39,7 @@
                   "type": "string"
                 },
                 "platform": {
-                  "description": "The platform name. Can be any name, but must be a receiver address for the [Signum Network Reward Program](https://signum.community/signum-snr-awards/)",
+                  "description": "The platform name. Can be any name, but must be a receiver address for the [Signum Network Reward Program](https://wiki.signum.network/signum-snr-awards/)",
                   "type": "string"
                 },
                 "version": {
@@ -51,14 +49,14 @@
                 "state": {
                   "description": "The state of the node,<br/><ul><li>0 - Not Connected</li><li>1 - Connected</li><li>2 - Disconnected</li></ul>",
                   "type": "integer",
-                  "enum": [0,1,2]
+                  "enum": [0, 1, 2]
                 },
                 "announcedAddress": {
                   "description": "The announce address of this node, if public",
                   "type": "string"
                 },
                 "shareAddress": {
-                  "description": "Indicator if the address is shared publicly. This is relevant for the [Signum Network Reward Program](https://signum.community/signum-snr-awards/)",
+                  "description": "Indicator if the address is shared publicly. This is relevant for the [Signum Network Reward Program](https://wiki.signum.network/signum-snr-awards/)",
                   "type": "boolean"
                 },
                 "downloadedVolume": {

--- a/openapi/paths/removeCommitment.json
+++ b/openapi/paths/removeCommitment.json
@@ -1,10 +1,8 @@
 {
   "post": {
     "summary": "Remove Commitment",
-    "description": "Remove commitment. The commitment gets unblocked, and will be available for free use. Removing commitment is only possible after 1440 blocks after last mined block.<br/>Read more about mining on the [official Signum Site](https://signum.network/mining) and on the [community wiki](https://signum.community/signum-mining/#commitment).<br/>See also [addCommitment](#get-/api-requestType-addCommitment) ",
-    "tags": [
-      "account", "mining"
-    ],
+    "description": "Remove commitment. The commitment gets unblocked, and will be available for free use. Removing commitment is only possible after 1440 blocks after last mined block.<br/>Read more about mining on the [official Signum Site](https://signum.network/mining) and on the [community wiki](https://wiki.signum.network/signum-mining/#commitment).<br/>See also [addCommitment](#get-/api-requestType-addCommitment) ",
+    "tags": ["account", "mining"],
     "parameters": [
       {
         "$ref": "../parameters/transaction/amountNQT.json"
@@ -65,7 +63,7 @@
       "200": {
         "$ref": "../responses/transaction.json"
       },
-      "500" : {
+      "500": {
         "$ref": "../responses/error.json"
       }
     }

--- a/openapi/paths/setRewardRecipient.json
+++ b/openapi/paths/setRewardRecipient.json
@@ -1,10 +1,8 @@
 {
   "post": {
     "summary": "Set Reward Recipient (Join Pool)",
-    "description": "Sets another account to receive your mining reward. This feature is necessary when you want mine in a pool. The recipient is the address of the pool. <br/>Read more about mining on the [official Signum Site](https://signum.network/mining) and on the [community wiki](https://signum.community/signum-mining)",
-    "tags": [
-      "account", "mining"
-    ],
+    "description": "Sets another account to receive your mining reward. This feature is necessary when you want mine in a pool. The recipient is the address of the pool. <br/>Read more about mining on the [official Signum Site](https://signum.network/mining) and on the [community wiki](https://wiki.signum.network/signum-mining)",
+    "tags": ["account", "mining"],
     "parameters": [
       {
         "$ref": "../parameters/account/account.json"
@@ -35,7 +33,7 @@
       "200": {
         "$ref": "../responses/transaction.json"
       },
-      "500" : {
+      "500": {
         "$ref": "../responses/error.json"
       }
     }

--- a/openapi/signum-api.json
+++ b/openapi/signum-api.json
@@ -526,7 +526,7 @@
     },
     {
       "name": "contract",
-      "description": "All operations related to Smart Contracts. <br/><br/>Signum was the first public block chain that introduced [turing complete](https://en.wikipedia.org/wiki/Turing_completeness) fully programmable Smart Contracts.<br/><br/>The engine comes with some very outstanding features, like <ul><li>Write contracts in [Java](https://github.com/signum-network/signum-smartj)- or [C](https://github.com/deleterium/SmartC/tree/stable/docs)-like Syntax</li><li>Re-usable code aka [Green Contracts](https://github.com/signum-network/SIPs/blob/master/SIP/sip-30.md)</li><li>Self-executing contracts (no external trigger, i.e. transaction required)</li><li>[Full Token Support](https://github.com/signum-network/SIPs/blob/master/SIP/sip-39.md)</li><li>Dynamic Data Storage in form of [Key-Value-Maps](https://github.com/signum-network/SIPs/blob/master/SIP/sip-38.md)</li></ul><br/>Read more about smart contracts on the [official Signum Site](https://signum.network/smartcontracts) and on the [community wiki](https://signum.community/signum-smart-contracts/)."
+      "description": "All operations related to Smart Contracts. <br/><br/>Signum was the first public block chain that introduced [turing complete](https://en.wikipedia.org/wiki/Turing_completeness) fully programmable Smart Contracts.<br/><br/>The engine comes with some very outstanding features, like <ul><li>Write contracts in [Java](https://github.com/signum-network/signum-smartj)- or [C](https://github.com/deleterium/SmartC/tree/stable/docs)-like Syntax</li><li>Re-usable code aka [Green Contracts](https://github.com/signum-network/SIPs/blob/master/SIP/sip-30.md)</li><li>Self-executing contracts (no external trigger, i.e. transaction required)</li><li>[Full Token Support](https://github.com/signum-network/SIPs/blob/master/SIP/sip-39.md)</li><li>Dynamic Data Storage in form of [Key-Value-Maps](https://github.com/signum-network/SIPs/blob/master/SIP/sip-38.md)</li></ul><br/>Read more about smart contracts on the [official Signum Site](https://signum.network/smartcontracts) and on the [community wiki](https://wiki.signum.network/signum-smart-contracts/)."
     },
     {
       "name": "network",
@@ -538,7 +538,7 @@
     },
     {
       "name": "mining",
-      "description": "All mining related methods. Leran more about mining [here](https://signum.network/mining) and also in the [community wiki](https://signum.community/signum-mining/)"
+      "description": "All mining related methods. Leran more about mining [here](https://signum.network/mining) and also in the [community wiki](https://wiki.signum.network/signum-mining/)"
     },
     {
       "name": "utility",

--- a/src/brs/web/api/http/LegacyDocsServlet.java
+++ b/src/brs/web/api/http/LegacyDocsServlet.java
@@ -93,7 +93,7 @@ public class LegacyDocsServlet extends HttpServlet {
       + "           <ul class=\"nav navbar-nav navbar-right\">"
       + "               <li><input type=\"text\" class=\"form-control\" id=\"search\" "
       + "                    placeholder=\"Search\" style=\"margin-top:8px;\"></li>\n"
-      + "               <li><a href=\"https://signum.community/\" target=\"_blank\" style=\"margin-left:20px;\">Community Docs</a></li>"
+      + "               <li><a href=\"https://wiki.signum.network/\" target=\"_blank\" style=\"margin-left:20px;\">Community Docs</a></li>"
       + "               <!-- <li><a href=\"/doc/index.html\" target=\"_blank\" style=\"margin-left:20px;\">Javadoc Index</a></li> -->"
       + "           </ul>"
       + "       </div>"


### PR DESCRIPTION
Fix: https://github.com/signum-network/signum-node/issues/793

Replace any `signum.community` link into `wiki.signum.network`

`signum.community` website is not available anymore.
There is a backup hosted on Github Pages
https://wiki.signum.network/

https://github.com/pir8radio/SignumCommunity