### PR TITLE
Add devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/java
+{
+	"name": "Java",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/java:1-17-bookworm",
+
+	"features": {
+		"ghcr.io/devcontainers/features/java:1": {
+			"version": "none",
+			"installMaven": "true",
+			"installGradle": "true"
+		}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"vscjava.vscode-java-pack",
+				"shengchen.vscode-checkstyle",
+				"Gruntfuggly.todo-tree",
+				"mhutchie.git-graph"
+			]
+		}
+	}
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "java -version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ target
 *.zip
 *.jar
 
+#ignore everything in here by default, but settings.json is already committed
+#and so will remain tracked
+**/.vscode
+
 /.gradle/
 /build/
 /bin/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "java.format.settings.url": "./eclipse-java-style.xml",
+    "java.format.settings.profile": "SignumStyle",
+    "java.checkstyle.configuration": "${workspaceFolder}/checkstyle.xml",
+    "java.checkstyle.version": "10.13.0",
+    "java.format.onType.enabled": true,
+    "java.format.enabled": true,
+    "editor.detectIndentation": false,
+    "java.import.projectSelection": "automatic"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,33 @@ Please use the following workflow to contribute:
 * Fork the repository
 * Create a branch which accurately describes your fix or feature (prefix branches with `fix/`, `feat/`, `docs/`, etc). 
   * Please use signed commits if you can - you are contributing to the backbone of a cryptocurrency.
+* Format your new source according to the eclipse-java-style.xml and checkstyle.xml files before you make a pull request. 
 * Submit a pull request against `develop`
 
 *Note:* A minimum of 2 approving reviews are required to merge. Squash merges are preferred unless there are very few commits to merge
+
+## GitHub Codespaces and devcontainers
+
+This repository contains a devcontainer definition and workspace settings file for Visual Studio Code (vscode) that will make
+spinning up a fully capable developer machine easy. The devcontainer can be used locally on your own docker desktop installation,
+and is also compatible with GitHub Codespaces. This offers two easy options to get started developing on the core node:
+
+_**IMPORTANT NOTE: Please do not save any of your personal editor settings to the vscode file or devcontainer. VSCode has 3
+separate layers of settings that can be used. Please do not save them to the Workspace option or your pull request may be denied.**_
+
+The devcontainer contains a few pre-installed vscode extensions useful to developing on a remote, container-base image.
+
+The .vscode/settings.json file contains a few workspace settings necessary to enable the checkstyle extension and use
+the eclipse-java-style.xml file by default.
+
+### GitHub Codespaces - Recommended to Start
+The easy way to get started. All you need to do is fork this repository, click on the green Code button, then the Codespaces tab,
+and finally click the + button to launch a new codespace. You can reuse this codespace so long as you don't delete it, but as long
+as you commit and sync your changes with git, you can destroy and rebuild it as often as you'd like. Follow the instructions above to
+actually submit your contributions.
+
+### Local devcontainer
+To use a local devcontainer, you first need docker desktop installed. Once installed, ensure your local copy of vscode has the
+[Remote Development](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) extension
+installed. After that, you can use CTRL-SHIFT-P and type 'Dev Containers' to find the option to reopen your repository in a
+devcontainer. VSCode may prompt you automatically, and you can use that option as well.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 The world's first HDD-mined cryptocurrency using an energy efficient
 and fair Proof-of-Commitment (PoC+) consensus algorithm running since August 2014.
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md)
+
 ## Network Features
 
 - Proof of Commitment - ASIC proof / Energy efficient and sustainable mining


### PR DESCRIPTION
Requesting to add devcontainer and VScode settings file to enable quick and easy deployment of
fully capable development environment via codespaces or docker devcontainers in vscode.

This current version will allow full java development and build, though several of the tests fail, though I believe that to be caused by database connection problems and will solve it as soon as I figure out how. The resulting code passes the GH actions tests when pushed to GitHub without problems.

I believe this will enable more developers to quickly join the team without the slog of setting up an entire environment in which to develop. Installing Java, node, gradle, and all other tools is already handled by this container.

The .gitignore has been updated to ignore all files in the .vscode folder except the currently tracked settings.json, and instructions have been modified to explain that personalized changes to this file will be cause for denial of merge.