### PR TITLE
Case insensitive properties file

### DIFF
--- a/src/brs/Signum.java
+++ b/src/brs/Signum.java
@@ -16,6 +16,7 @@ import brs.feesuggestions.FeeSuggestionCalculator;
 import brs.fluxcapacitor.FluxCapacitor;
 import brs.fluxcapacitor.FluxCapacitorImpl;
 import brs.peer.Peers;
+import brs.props.CaselessProperties;
 import brs.props.PropertyService;
 import brs.props.PropertyServiceImpl;
 import brs.props.Props;
@@ -126,14 +127,14 @@ public final class Signum {
         logger.info("Initializing Signum Node version {}", VERSION);
 
         logger.info("Configurations from folder {}", confFolder);
-        Properties defaultProperties = new Properties();
+        CaselessProperties defaultProperties = new CaselessProperties();
         try (InputStream is = new FileInputStream(new File(confFolder, DEFAULT_PROPERTIES_NAME))) {
             defaultProperties.load(is);
         } catch (IOException e) {
             throw new RuntimeException("Error loading " + DEFAULT_PROPERTIES_NAME, e);
         }
 
-        Properties properties = new Properties(defaultProperties);
+        CaselessProperties properties = new CaselessProperties(defaultProperties);
         try (InputStream is = new FileInputStream(new File(confFolder, PROPERTIES_NAME))) {
             if (is != null) { // parse if brs.properties was loaded
                 properties.load(is);
@@ -210,7 +211,7 @@ public final class Signum {
         return true;
     }
 
-    public static void init(Properties customProperties) {
+    public static void init(CaselessProperties customProperties) {
         loadWallet(new PropertyServiceImpl(customProperties));
     }
 

--- a/src/brs/props/CaselessProperties.java
+++ b/src/brs/props/CaselessProperties.java
@@ -5,10 +5,10 @@ import java.util.Properties;
 /**
  * Overrides {@link java.util.Properties} to make all the keys lowercase,
  * thus making the config file keys case-insensitve.
- * Courtesy Jim Yingst https://coderanch.com/t/277128/java/Properties-ignoring-case
+ * Courtesy Jim Yingst
+ * https://coderanch.com/t/277128/java/Properties-ignoring-case
  */
 public class CaselessProperties extends Properties {
-
     public CaselessProperties() {
         super();
     }

--- a/src/brs/props/CaselessProperties.java
+++ b/src/brs/props/CaselessProperties.java
@@ -1,0 +1,34 @@
+package brs.props;
+
+import java.util.Properties;
+
+/**
+ * Overrides {@link java.util.Properties} to make all the keys lowercase,
+ * thus making the config file keys case-insensitve.
+ * Courtesy Jim Yingst https://coderanch.com/t/277128/java/Properties-ignoring-case
+ */
+public class CaselessProperties extends Properties {
+
+    public CaselessProperties() {
+        super();
+    }
+
+    public CaselessProperties(CaselessProperties properties) {
+        super(properties);
+    }
+
+    public Object put(Object key, Object value) {
+        String lowercase = ((String) key).toLowerCase();
+        return super.put(lowercase, value);
+    }
+
+    public String getProperty(String key) {
+        String lowercase = key.toLowerCase();
+        return super.getProperty(lowercase);
+    }
+
+    public String getProperty(String key, String defaultValue) {
+        String lowercase = key.toLowerCase();
+        return super.getProperty(lowercase, defaultValue);
+    }
+}

--- a/src/brs/props/PropertyServiceImpl.java
+++ b/src/brs/props/PropertyServiceImpl.java
@@ -1,143 +1,147 @@
 package brs.props;
 
 import brs.Signum;
-import signum.net.NetworkParameters;
-
+import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import signum.net.NetworkParameters;
 
-import java.util.*;
-
+// TODO: Remove this and add proper javadoc
+@SuppressWarnings("checkstyle:MissingJavadocTypeCheck")
 public class PropertyServiceImpl implements PropertyService {
 
-  private final Logger logger = LoggerFactory.getLogger(Signum.class);
-  private static final String LOG_UNDEF_NAME_DEFAULT = "{} using default: >{}<";
+    private final Logger logger = LoggerFactory.getLogger(Signum.class);
+    private static final String LOG_UNDEF_NAME_DEFAULT = "{} using default: >{}<";
 
-  private final Properties properties;
+    private final Properties properties;
 
-  private final List<String> alreadyLoggedProperties = new ArrayList<>();
-  private NetworkParameters networkParameters;
+    private final List<String> alreadyLoggedProperties = new ArrayList<>();
+    private NetworkParameters networkParameters;
 
-  public PropertyServiceImpl(Properties properties) {
-    this.properties = properties;
-  }
-  
-  private String getProperty(String name) {
-    String value = properties.getProperty(name);
-    
-    // so we have precedence for user set values
-    if(value==null && networkParameters!=null) {
-      value = networkParameters.getProperty(name);
-    }
-    return value;
-  }
-  
-
-  @Override
-  public Boolean getBoolean(String name, boolean assume) {
-    String value = getProperty(name);
-
-    if (value != null) {
-      if (value.matches("(?i)^1|active|true|yes|on$")) {
-        logOnce(name, true, "{} = 'true'", name);
-        return true;
-      }
-
-      if (value.matches("(?i)^0|false|no|off$")) {
-        logOnce(name, true, "{} = 'false'", name);
-        return false;
-      }
+    public PropertyServiceImpl(Properties properties) {
+        this.properties = properties;
     }
 
-    if(logger.isDebugEnabled()) {
-      logOnce(name, false, LOG_UNDEF_NAME_DEFAULT, name, assume);
+    private String getProperty(String name) {
+        String value = properties.getProperty(name);
+
+        // so we have precedence for user set values
+        if (value == null && networkParameters != null) {
+            value = networkParameters.getProperty(name);
+        }
+        return value;
     }
-    return assume;
-  }
 
-  @Override
-  public Boolean getBoolean(Prop<Boolean> prop) {
-    return getBoolean(prop.name, prop.defaultValue);
-  }
+    @Override
+    public Boolean getBoolean(String name, boolean assume) {
+        String value = getProperty(name);
 
-  @Override
-  public int getInt(Prop<Integer> prop) {
-    String value = getProperty(prop.name);
-    if (value != null && ! value.isEmpty()) {
-      try {
-        int radix = 10;
+        if (value != null) {
+            if (value.matches("(?i)^1|active|true|yes|on$")) {
+                logOnce(name, true, "{} = 'true'", name);
+                return true;
+            }
 
-        if (value != null && value.matches("(?i)^0x.+$")) {
-          value = value.replaceFirst("^0x", "");
-          radix = 16;
-        } else if (value != null && value.matches("(?i)^0b[01]+$")) {
-          value = value.replaceFirst("^0b", "");
-          radix = 2;
+            if (value.matches("(?i)^0|false|no|off$")) {
+                logOnce(name, true, "{} = 'false'", name);
+                return false;
+            }
         }
 
-        int result = Integer.parseInt(value, radix);
-        logOnce(prop.name, true, "{} = '{}'", prop.name, result);
-        return result;
-      } catch (NumberFormatException e) {
-        logOnce(prop.name, false, LOG_UNDEF_NAME_DEFAULT, prop.name, prop.defaultValue);
+        if (logger.isDebugEnabled()) {
+            logOnce(name, false, LOG_UNDEF_NAME_DEFAULT, name, assume);
+        }
+        return assume;
+    }
+
+    @Override
+    public Boolean getBoolean(Prop<Boolean> prop) {
+        return getBoolean(prop.name, prop.defaultValue);
+    }
+
+    @Override
+    public int getInt(Prop<Integer> prop) {
+        String value = getProperty(prop.name);
+        if (value != null && !value.isEmpty()) {
+            try {
+                int radix = 10;
+
+                if (value != null && value.matches("(?i)^0x.+$")) {
+                    value = value.replaceFirst("^0x", "");
+                    radix = 16;
+                } else if (value != null && value.matches("(?i)^0b[01]+$")) {
+                    value = value.replaceFirst("^0b", "");
+                    radix = 2;
+                }
+
+                int result = Integer.parseInt(value, radix);
+                logOnce(prop.name, true, "{} = '{}'", prop.name, result);
+                return result;
+            } catch (NumberFormatException e) {
+                logOnce(prop.name, false, LOG_UNDEF_NAME_DEFAULT, prop.name, prop.defaultValue);
+                return prop.defaultValue;
+            }
+        }
+
+        if (logger.isDebugEnabled()) {
+            logOnce(prop.name, false, LOG_UNDEF_NAME_DEFAULT, prop.name, prop.defaultValue);
+        }
         return prop.defaultValue;
-      }
-    }
-    
-    if(logger.isDebugEnabled()) {
-      logOnce(prop.name, false, LOG_UNDEF_NAME_DEFAULT, prop.name, prop.defaultValue);
-    }
-    return prop.defaultValue;
 
-  }
-
-  @Override
-  public String getString(Prop<String> prop) {
-    String value = getProperty(prop.name);
-    if (value != null && ! value.isEmpty()) {
-      logOnce(prop.name, true, prop.name + " = \"" + value + "\"");
-      return value;
     }
 
-    if(logger.isDebugEnabled()) {
-      logOnce(prop.name, false, LOG_UNDEF_NAME_DEFAULT, prop.name, prop.defaultValue);
+    @Override
+    public String getString(Prop<String> prop) {
+        String value = getProperty(prop.name);
+        if (value != null && !value.isEmpty()) {
+            logOnce(prop.name, true, prop.name + " = \"" + value + "\"");
+            return value;
+        }
+
+        if (logger.isDebugEnabled()) {
+            logOnce(prop.name, false, LOG_UNDEF_NAME_DEFAULT, prop.name, prop.defaultValue);
+        }
+
+        return prop.defaultValue;
     }
 
-    return prop.defaultValue;
-  }
-
-  @Override
-  public List<String> getStringList(Prop<String> name) {
-    String value = getString(name);
-    if (value == null || value.isEmpty()) {
-      return new ArrayList<>();
+    @Override
+    public List<String> getStringList(Prop<String> name) {
+        String value = getString(name);
+        if (value == null || value.isEmpty()) {
+            return new ArrayList<>();
+        }
+        List<String> result = new ArrayList<>();
+        for (String s : value.split(";")) {
+            s = s.trim();
+            if (!s.isEmpty()) {
+                result.add(s);
+            }
+        }
+        return result;
     }
-    List<String> result = new ArrayList<>();
-    for (String s : value.split(";")) {
-      s = s.trim();
-      if (!s.isEmpty()) {
-        result.add(s);
-      }
+
+    private void logOnce(
+            String propertyName,
+            boolean debugLevel,
+            String logText,
+            Object... arguments) {
+        if (Objects.equals(propertyName, Props.SOLO_MINING_PASSPHRASES.getName())) {
+            return;
+        }
+        if (!this.alreadyLoggedProperties.contains(propertyName)) {
+            if (debugLevel) {
+                this.logger.debug(logText, arguments);
+            } else {
+                this.logger.info(logText, arguments);
+            }
+            this.alreadyLoggedProperties.add(propertyName);
+        }
     }
-    return result;
-  }
 
-  private void logOnce(String propertyName, boolean debugLevel, String logText, Object... arguments) {
-    if (Objects.equals(propertyName, Props.SOLO_MINING_PASSPHRASES.getName())) return;
-    if (!this.alreadyLoggedProperties.contains(propertyName)) {
-      if (debugLevel) {
-        this.logger.debug(logText, arguments);
-      } else {
-        this.logger.info(logText, arguments);
-      }
-      this.alreadyLoggedProperties.add(propertyName);
+    @Override
+    public void setNetworkParameters(NetworkParameters params) {
+        this.networkParameters = params;
     }
-  }
-
-
-  @Override
-  public void setNetworkParameters(NetworkParameters params) {
-    this.networkParameters = params;
-  }
 
 }

--- a/src/brs/props/PropertyServiceImpl.java
+++ b/src/brs/props/PropertyServiceImpl.java
@@ -13,12 +13,12 @@ public class PropertyServiceImpl implements PropertyService {
     private final Logger logger = LoggerFactory.getLogger(Signum.class);
     private static final String LOG_UNDEF_NAME_DEFAULT = "{} using default: >{}<";
 
-    private final Properties properties;
+    private final CaselessProperties properties;
 
     private final List<String> alreadyLoggedProperties = new ArrayList<>();
     private NetworkParameters networkParameters;
 
-    public PropertyServiceImpl(Properties properties) {
+    public PropertyServiceImpl(CaselessProperties properties) {
         this.properties = properties;
     }
 

--- a/test/java/it/common/AbstractIT.java
+++ b/test/java/it/common/AbstractIT.java
@@ -6,6 +6,7 @@ import brs.Signum;
 import brs.common.TestInfrastructure;
 import brs.peer.Peers;
 import brs.peer.ProcessBlock;
+import brs.props.CaselessProperties;
 import brs.props.Props;
 import com.google.gson.JsonObject;
 import java.util.Properties;
@@ -45,8 +46,8 @@ public abstract class AbstractIT {
         Signum.shutdown(true);
     }
 
-    private Properties testProperties() {
-        final Properties props = new Properties();
+    private CaselessProperties testProperties() {
+        final CaselessProperties props = new CaselessProperties();
 
         props.setProperty(Props.DEV_OFFLINE.getName(), "true");
         props.setProperty(Props.NETWORK_NAME.getName(), "Unit tests");

--- a/test/java/it/common/AbstractIT.java
+++ b/test/java/it/common/AbstractIT.java
@@ -1,11 +1,14 @@
 package it.common;
 
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
 import brs.Signum;
 import brs.common.TestInfrastructure;
 import brs.peer.Peers;
 import brs.peer.ProcessBlock;
 import brs.props.Props;
 import com.google.gson.JsonObject;
+import java.util.Properties;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -13,54 +16,57 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.Properties;
-
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
+// TODO: Remove this and add javadoc and rename type
+@SuppressWarnings({
+    "checkstyle:MissingJavadocTypeCheck",
+    "checkstyle:AbbreviationAsWordInNameCheck" })
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(Peers.class)
 @PowerMockIgnore("javax.net.ssl.*")
 public abstract class AbstractIT {
 
-  private ProcessBlock processBlock;
+    private ProcessBlock processBlock;
 
-  protected APISender apiSender = new APISender();
+    protected APISender apiSender = new APISender();
 
-  @Before
-  public void setUp() {
-    mockStatic(Peers.class);
-    Signum.init(testProperties());
+    //TODO: Remove suppression and add javadoc
+    @SuppressWarnings("checkstyle:MissingJavadocMethodCheck")
+    @Before
+    public void setUp() {
+        mockStatic(Peers.class);
+        Signum.init(testProperties());
 
-    processBlock = new ProcessBlock(Signum.getBlockchain(), Signum.getBlockchainProcessor());
-  }
+        processBlock = new ProcessBlock(Signum.getBlockchain(), Signum.getBlockchainProcessor());
+    }
 
-  @After
-  public void shutdown() {
-    Signum.shutdown(true);
-  }
+    @After
+    public void shutdown() {
+        Signum.shutdown(true);
+    }
 
-  private Properties testProperties() {
-    final Properties props = new Properties();
+    private Properties testProperties() {
+        final Properties props = new Properties();
 
-    props.setProperty(Props.DEV_OFFLINE.getName(), "true");
-    props.setProperty(Props.NETWORK_NAME.getName(), "Unit tests");
-    props.setProperty(Props.DB_URL.getName(), TestInfrastructure.IN_MEMORY_DB_URL);
-    props.setProperty(Props.DB_CONNECTIONS.getName(), "1");
+        props.setProperty(Props.DEV_OFFLINE.getName(), "true");
+        props.setProperty(Props.NETWORK_NAME.getName(), "Unit tests");
+        props.setProperty(Props.DB_URL.getName(), TestInfrastructure.IN_MEMORY_DB_URL);
+        props.setProperty(Props.DB_CONNECTIONS.getName(), "1");
 
-    props.setProperty(Props.API_SERVER.getName(), "on");
-    props.setProperty(Props.API_LISTEN.getName(), "127.0.0.1");
-    props.setProperty(Props.API_PORT.getName(),   "" + TestInfrastructure.TEST_API_PORT);
-    props.setProperty(Props.API_ALLOWED.getName(),   "*");
-    props.setProperty(Props.API_UI_DIR.getName(), "html/ui");
+        props.setProperty(Props.API_SERVER.getName(), "on");
+        props.setProperty(Props.API_LISTEN.getName(), "127.0.0.1");
+        props.setProperty(Props.API_PORT.getName(), "" + TestInfrastructure.TEST_API_PORT);
+        props.setProperty(Props.API_ALLOWED.getName(), "*");
+        props.setProperty(Props.API_UI_DIR.getName(), "html/ui");
 
-    return props;
-  }
+        return props;
+    }
 
-  public void processBlock(JsonObject jsonFirstBlock) {
-    processBlock.processRequest(jsonFirstBlock, null);
-  }
+    public void processBlock(JsonObject jsonFirstBlock) {
+        processBlock.processRequest(jsonFirstBlock, null);
+    }
 
-  public void rollback(int height) {
-    Signum.getBlockchainProcessor().popOffTo(0);
-  }
+    public void rollback(int height) {
+        Signum.getBlockchainProcessor().popOffTo(0);
+    }
 }


### PR DESCRIPTION
This change adds a derived class `CaselessProperties` and replaces all uses of `java.util.Properties` with the new class. This allows the node to be case-insensitive when loading properties files.

There are a lot of line changes muddying the file and making it difficult to read all the changes. This is because I formatted the files according to the new style requirements as I worked on them. I have separated the work into separate commits, so the final commit in this PR is the actual implementation of the new class, while the first commit actually adds the new class.  You can view the commits directly to see the actual code changes. The formatting happens in its own, separate commit.

Code for the CaselessProperties class found here.
[https://coderanch.com/t/277128/java/Properties-ignoring-case](https://coderanch.com/t/277128/java/Properties-ignoring-case)