### PR TITLE
Allow environment variables to override settings

### DIFF
--- a/src/brs/Signum.java
+++ b/src/brs/Signum.java
@@ -16,7 +16,7 @@ import brs.feesuggestions.FeeSuggestionCalculator;
 import brs.fluxcapacitor.FluxCapacitor;
 import brs.fluxcapacitor.FluxCapacitorImpl;
 import brs.peer.Peers;
-import brs.props.CaselessProperties;
+import brs.props.CaseInsensitiveProperties;
 import brs.props.PropertyService;
 import brs.props.PropertyServiceImpl;
 import brs.props.Props;
@@ -127,14 +127,14 @@ public final class Signum {
         logger.info("Initializing Signum Node version {}", VERSION);
 
         logger.info("Configurations from folder {}", confFolder);
-        CaselessProperties defaultProperties = new CaselessProperties();
+        CaseInsensitiveProperties defaultProperties = new CaseInsensitiveProperties();
         try (InputStream is = new FileInputStream(new File(confFolder, DEFAULT_PROPERTIES_NAME))) {
             defaultProperties.load(is);
         } catch (IOException e) {
             throw new RuntimeException("Error loading " + DEFAULT_PROPERTIES_NAME, e);
         }
 
-        CaselessProperties properties = new CaselessProperties(defaultProperties);
+        CaseInsensitiveProperties properties = new CaseInsensitiveProperties(defaultProperties);
         try (InputStream is = new FileInputStream(new File(confFolder, PROPERTIES_NAME))) {
             if (is != null) { // parse if brs.properties was loaded
                 properties.load(is);
@@ -211,7 +211,7 @@ public final class Signum {
         return true;
     }
 
-    public static void init(CaselessProperties customProperties) {
+    public static void init(CaseInsensitiveProperties customProperties) {
         loadWallet(new PropertyServiceImpl(customProperties));
     }
 

--- a/src/brs/props/CaseInsensitiveProperties.java
+++ b/src/brs/props/CaseInsensitiveProperties.java
@@ -8,12 +8,12 @@ import java.util.Properties;
  * Courtesy Jim Yingst
  * https://coderanch.com/t/277128/java/Properties-ignoring-case
  */
-public class CaselessProperties extends Properties {
-    public CaselessProperties() {
+public class CaseInsensitiveProperties extends Properties {
+    public CaseInsensitiveProperties() {
         super();
     }
 
-    public CaselessProperties(CaselessProperties properties) {
+    public CaseInsensitiveProperties(CaseInsensitiveProperties properties) {
         super(properties);
     }
 

--- a/src/brs/props/PropertyServiceImpl.java
+++ b/src/brs/props/PropertyServiceImpl.java
@@ -13,12 +13,12 @@ public class PropertyServiceImpl implements PropertyService {
     private final Logger logger = LoggerFactory.getLogger(Signum.class);
     private static final String LOG_UNDEF_NAME_DEFAULT = "{} using default: >{}<";
 
-    private final CaselessProperties properties;
+    private final CaseInsensitiveProperties properties;
 
     private final List<String> alreadyLoggedProperties = new ArrayList<>();
     private NetworkParameters networkParameters;
 
-    public PropertyServiceImpl(CaselessProperties properties) {
+    public PropertyServiceImpl(CaseInsensitiveProperties properties) {
         this.properties = properties;
     }
 

--- a/test/java/it/common/AbstractIT.java
+++ b/test/java/it/common/AbstractIT.java
@@ -6,7 +6,7 @@ import brs.Signum;
 import brs.common.TestInfrastructure;
 import brs.peer.Peers;
 import brs.peer.ProcessBlock;
-import brs.props.CaselessProperties;
+import brs.props.CaseInsensitiveProperties;
 import brs.props.Props;
 import com.google.gson.JsonObject;
 import java.util.Properties;
@@ -46,8 +46,8 @@ public abstract class AbstractIT {
         Signum.shutdown(true);
     }
 
-    private CaselessProperties testProperties() {
-        final CaselessProperties props = new CaselessProperties();
+    private CaseInsensitiveProperties testProperties() {
+        final CaseInsensitiveProperties props = new CaseInsensitiveProperties();
 
         props.setProperty(Props.DEV_OFFLINE.getName(), "true");
         props.setProperty(Props.NETWORK_NAME.getName(), "Unit tests");


### PR DESCRIPTION
Renaming the CaselessProperties to CaseInsensitiveProperties because it makes more sense.