### PR TITLE
AT Execution Time Improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,7 @@
 /tmp
 /temp
 .idea
-brs.log
-brs.log.*
-node.log*
+*.log
 /conf/logging.properties
 /conf/brs.properties
 /conf/node.properties

--- a/conf/node-default.properties
+++ b/conf/node-default.properties
@@ -182,6 +182,12 @@
 
 # node.checkPointHeight = -1
 
+## Number of past blocks for AT processor to load into memory/cache
+## Put -1, if you want to disable the cache, which may slow down AT/smart contract processing significantly
+## Do not put too high values as this may cause significant memory occupation and cause even negative impact on processing times.
+# node.atProcessorCacheBlockCount = 1000
+
+
 #### API SERVER ####
 
 ## Accept http/json API requests.

--- a/src/brs/BlockchainProcessorImpl.java
+++ b/src/brs/BlockchainProcessorImpl.java
@@ -3,10 +3,7 @@ package brs;
 import static brs.Constants.FEE_QUANT_SIP3;
 import static brs.Constants.ONE_SIGNA;
 
-import brs.at.AT;
-import brs.at.AtBlock;
-import brs.at.AtController;
-import brs.at.AtException;
+import brs.at.*;
 import brs.crypto.Crypto;
 import brs.db.BlockDb;
 import brs.db.DerivedTable;
@@ -124,6 +121,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
   private final boolean autoPopOffEnabled;
   private int autoPopOffLastStuckHeight = 0;
   private int autoPopOffNumberOfBlocks = 0;
+  private ATProcessorCache atProcessorCache = ATProcessorCache.getInstance();
 
   public final void setOclVerify(Boolean b) {
     oclVerify = b;
@@ -1170,6 +1168,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
         stores.rollbackTransaction();
         blockchain.setLastBlock(previousLastBlock);
         downloadCache.resetCache();
+        atProcessorCache.reset();
         throw e;
       } finally {
         stores.endTransaction();
@@ -1301,6 +1300,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
           dbCacheManager.flushCache();
           stores.commitTransaction();
           downloadCache.resetCache();
+          atProcessorCache.reset();;
         } catch (RuntimeException e) {
           stores.rollbackTransaction();
           logger.debug("Error popping off to {}", commonBlock.getHeight(), e);

--- a/src/brs/at/AT.java
+++ b/src/brs/at/AT.java
@@ -79,10 +79,6 @@ public class AT extends AtMachineState {
         pendingFees.put(id, fee);
     }
 
-    public static void addPendingFee(byte[] id, long fee, int blockHeight, long generatorId) {
-        addPendingFee(AtApiHelper.getLong(id), fee, blockHeight, generatorId);
-    }
-
     public static void addPendingTransaction(AtTransaction atTransaction, int blockHeight, long generatorId) {
         long hash = blockHeight + generatorId;
         List<AtTransaction> pendingTransactions = pendingTransactionsMap.get(hash);

--- a/src/brs/at/ATProcessorCache.java
+++ b/src/brs/at/ATProcessorCache.java
@@ -1,0 +1,204 @@
+package brs.at;
+
+import brs.SignumException;
+import brs.Transaction;
+import brs.db.TransactionDb;
+import brs.db.sql.Db;
+import brs.schema.tables.records.TransactionRecord;
+import org.jooq.Result;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static brs.schema.Tables.TRANSACTION;
+
+public final class ATProcessorCache {
+
+  public static class CacheMissException extends Exception {
+  }
+
+  private static final Logger logger = LoggerFactory.getLogger(ATProcessorCache.class);
+
+  private static ATProcessorCache instance;
+  private static final int CostOfOneAT = AtConstants.AT_ID_SIZE + 16;
+  private final LinkedHashMap<Long, ATContext> atMap = new LinkedHashMap<>();
+  private int currentBlockHeight = Integer.MIN_VALUE;
+  private int lowestBlockHeight = Integer.MAX_VALUE;
+  private long minimumActivationAmount = Long.MAX_VALUE;
+
+  public static class ATContext {
+    public byte[] md5;
+    public AT at;
+    public ArrayList<Transaction> transactions = new ArrayList<>();
+  }
+
+  private ATProcessorCache() {
+
+  }
+
+  public int getLowestBlockHeight() {
+    return lowestBlockHeight;
+  }
+
+  public HashMap<Long, ATContext> getAtMap() {
+    return this.atMap;
+  }
+
+  public static ATProcessorCache getInstance() {
+    if (instance == null) {
+      instance = new ATProcessorCache();
+    }
+    return instance;
+  }
+
+  public void reset() {
+    atMap.clear();
+    currentBlockHeight = Integer.MIN_VALUE;
+    lowestBlockHeight = Integer.MAX_VALUE;
+    minimumActivationAmount = Long.MAX_VALUE;
+  }
+
+  public LinkedHashMap<Long, ATContext> load(byte[] ats, int blockHeight) throws AtException {
+
+    this.reset();
+    this.currentBlockHeight = blockHeight;
+    this.lowestBlockHeight = blockHeight - 1000;
+    if (ats == null || ats.length == 0) {
+      return this.atMap;
+    }
+    long startTime = System.nanoTime();
+    parseATBytes(ats);
+    // if this is impacts on db access, we might add a multi AT fetch -> getATs
+    this.atMap.forEach((atId, proxy) -> {
+      AT at = AT.getAT(atId);
+      logger.debug("Cached AT {}", atId);
+      this.minimumActivationAmount = Math.min(this.minimumActivationAmount, at.minActivationAmount());
+      proxy.at = at;
+    });
+    loadRelevantTransactions();
+    long executionTime = (System.nanoTime() - startTime) / 1000000;
+    logger.debug("Cache Duration for {} ATs: {} milliseconds", atMap.size(), executionTime);
+    return this.atMap;
+  }
+
+  private void parseATBytes(byte[] ats) throws AtException {
+    if (ats.length % (CostOfOneAT) != 0) {
+      throw new AtException("ATs must be a multiple of cost of one AT ( " + CostOfOneAT + " )");
+    }
+
+    ByteBuffer b = ByteBuffer.wrap(ats);
+    b.order(ByteOrder.LITTLE_ENDIAN);
+
+    byte[] atId = new byte[AtConstants.AT_ID_SIZE];
+    byte[] md5 = new byte[16];
+
+    while (b.remaining() >= CostOfOneAT) {
+      b.get(atId);
+      b.get(md5);
+      long atIdLong = AtApiHelper.getLong(atId);
+      if (atMap.containsKey(atIdLong)) {
+        throw new AtException("AT included in block multiple times");
+      }
+      ATContext atContext = new ATContext();
+      atContext.md5 = md5.clone();
+      atMap.put(atIdLong, atContext);
+    }
+  }
+
+  // TODO: make this smarter, instead of loading them all
+  private void loadRelevantTransactions() {
+    logger.debug("Loading tx for lo: {}, hi: {}, amount: {}, no ATs: {}", lowestBlockHeight, currentBlockHeight, minimumActivationAmount, getAtMap().size());
+    Result<TransactionRecord> result = Db.useDSLContext(ctx -> {
+      return ctx.selectFrom(TRANSACTION)
+        .where(TRANSACTION.HEIGHT.between(lowestBlockHeight, currentBlockHeight))
+        .and(TRANSACTION.RECIPIENT_ID.in(getAtMap().keySet()))
+        .and(TRANSACTION.AMOUNT.greaterOrEqual(minimumActivationAmount))
+        .orderBy(TRANSACTION.HEIGHT, TRANSACTION.ID)
+        .fetch();
+    });
+    logger.debug("Fetched {} tx", result.size());
+
+    TransactionDb db = Db.getDbsByDatabaseType().getTransactionDb();
+    for (TransactionRecord r : result) {
+      try {
+        ATContext context = this.atMap.get(r.getRecipientId());
+        if (context != null) {
+          Transaction tx = db.loadTransaction(r);
+          context.transactions.add(tx);
+        }
+      } catch (SignumException.ValidationException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  public Long findTransactionId(int startHeight, int endHeight, Long atID, int numOfTx, long minAmount) throws CacheMissException {
+    long startTime = System.nanoTime();
+
+    ATContext atContext = this.atMap.get(atID);
+    if (atContext == null) {
+      logger.debug("AT {} not found", atID);
+      throw new CacheMissException();
+    }
+
+    // can be -1
+    if (startHeight <= 0) {
+      startHeight = atContext.at.getCreationBlockHeight();
+    }
+
+    if (startHeight < lowestBlockHeight || endHeight > currentBlockHeight) {
+      logger.debug("Out of range (start: {}, end: {} - wanted block: {})", lowestBlockHeight, currentBlockHeight, startHeight);
+      throw new CacheMissException();
+    }
+
+    long id = 0;
+    final int finalStartHeight = startHeight;
+    List<Transaction> collected = atContext.transactions.stream()
+      .filter(t ->
+        t.getHeight() >= finalStartHeight &&
+          t.getHeight() < endHeight &&
+          t.getAmountNqt() >= minAmount)
+      .collect(Collectors.toList());
+
+    if (collected.size() > numOfTx) {
+      id = collected.get(numOfTx).getId();
+    }
+
+    long executionTime = (System.nanoTime() - startTime) / 1000000;
+    logger.debug("txId: {} - Duration: {} milliseconds", id, executionTime);
+    return id;
+  }
+
+
+  public int findTransactionHeight(Long transactionId, int height, Long atID, long minAmount) throws CacheMissException {
+    long startTime = System.nanoTime();
+    ATContext atContext = this.atMap.get(atID);
+    if (atContext == null) {
+      logger.debug("AT {} not found", atID);
+      throw new CacheMissException();
+    }
+
+    int count = 0;
+    ArrayList<Transaction> transactions = atContext.transactions;
+    for (Transaction t : transactions) {
+      if (t.getHeight() == height && t.getAmountNqt() >= minAmount) {
+        ++count;
+        if (t.getId() == transactionId) {
+          break;
+        }
+      }
+    }
+
+    long executionTime = (System.nanoTime() - startTime) / 1000000;
+    logger.debug("Cache Hit: {}, Duration: {} milliseconds", count, executionTime);
+    if (count == 0 || count >= transactions.size()) {
+      throw new CacheMissException();
+    }
+    return count;
+  }
+}
+

--- a/src/brs/at/ATProcessorCache.java
+++ b/src/brs/at/ATProcessorCache.java
@@ -1,9 +1,12 @@
 package brs.at;
 
+import brs.Signum;
 import brs.SignumException;
 import brs.Transaction;
 import brs.db.TransactionDb;
 import brs.db.sql.Db;
+import brs.props.PropertyService;
+import brs.props.Props;
 import brs.schema.tables.records.TransactionRecord;
 import org.jooq.Result;
 import org.slf4j.Logger;
@@ -16,6 +19,10 @@ import java.util.stream.Collectors;
 
 import static brs.schema.Tables.TRANSACTION;
 
+/**
+ * This class is used to cache the transactions of past x (Props.BRS_AT_PROCESSOR_CACHE_BLOCK_COUNT) blocks
+ * to reduce database access as much as possible while AT processing.
+ */
 public final class ATProcessorCache {
 
   public static class CacheMissException extends Exception {
@@ -27,65 +34,84 @@ public final class ATProcessorCache {
   private static final int CostOfOneAT = AtConstants.AT_ID_SIZE + 16;
   private final LinkedHashMap<Long, ATContext> atMap = new LinkedHashMap<>();
   private int currentBlockHeight = Integer.MIN_VALUE;
-  private int lowestBlockHeight = Integer.MAX_VALUE;
+  private final ArrayList<Long> currentBlockAtIds = new ArrayList<>();
+  private int startBlockHeight = Integer.MAX_VALUE;
   private long minimumActivationAmount = Long.MAX_VALUE;
+  private final int numberOfBlocksToCache;
+  private int lastLoadedBlockHeight = 0;
 
   public static class ATContext {
     public byte[] md5;
     public AT at;
-    public ArrayList<Transaction> transactions = new ArrayList<>();
+    public LinkedList<Transaction> transactions = new LinkedList<>();
   }
 
-  private ATProcessorCache() {
-
+  private ATProcessorCache(PropertyService propertyService) {
+    this.numberOfBlocksToCache = propertyService.getInt(Props.BRS_AT_PROCESSOR_CACHE_BLOCK_COUNT);
   }
 
-  public int getLowestBlockHeight() {
-    return lowestBlockHeight;
+  public boolean isEnabled() {
+    return numberOfBlocksToCache > 0;
   }
 
   public HashMap<Long, ATContext> getAtMap() {
     return this.atMap;
   }
 
+
   public static ATProcessorCache getInstance() {
     if (instance == null) {
-      instance = new ATProcessorCache();
+      instance = new ATProcessorCache(Signum.getPropertyService());
     }
     return instance;
   }
 
   public void reset() {
+    logger.debug("Resetting AT Processor Cache");
     atMap.clear();
     currentBlockHeight = Integer.MIN_VALUE;
-    lowestBlockHeight = Integer.MAX_VALUE;
+    startBlockHeight = Integer.MAX_VALUE;
     minimumActivationAmount = Long.MAX_VALUE;
+    lastLoadedBlockHeight = 0;
   }
 
-  public LinkedHashMap<Long, ATContext> load(byte[] ats, int blockHeight) throws AtException {
+  public ArrayList<Long> getCurrentBlockAtIds() {
+    return this.currentBlockAtIds;
+  }
 
-    this.reset();
+  public ATContext getATContext(Long atId) {
+    return this.atMap.get(atId);
+  }
+
+  public void loadBlock(byte[] ats, int blockHeight) throws AtException {
     this.currentBlockHeight = blockHeight;
-    this.lowestBlockHeight = blockHeight - 1000;
+    this.startBlockHeight = blockHeight - this.numberOfBlocksToCache;
+    this.currentBlockAtIds.clear();
     if (ats == null || ats.length == 0) {
-      return this.atMap;
+      return;
     }
     long startTime = System.nanoTime();
-    parseATBytes(ats);
-    // if this is impacts on db access, we might add a multi AT fetch -> getATs
-    this.atMap.forEach((atId, proxy) -> {
-      AT at = AT.getAT(atId);
-      logger.debug("Cached AT {}", atId);
-      this.minimumActivationAmount = Math.min(this.minimumActivationAmount, at.minActivationAmount());
-      proxy.at = at;
-    });
-    loadRelevantTransactions();
+    loadAtBytesIntoAtMap(ats);
+    loadATsforBlock(blockHeight);
+    if (isEnabled()) {
+      loadTransactions();
+    }
     long executionTime = (System.nanoTime() - startTime) / 1000000;
-    logger.debug("Cache Duration for {} ATs: {} milliseconds", atMap.size(), executionTime);
-    return this.atMap;
+    logger.debug("Cache Duration: {} milliseconds", executionTime);
   }
 
-  private void parseATBytes(byte[] ats) throws AtException {
+  private void loadATsforBlock(int blockHeight) {
+    logger.debug("Loading {} ATs for block height {}", getCurrentBlockAtIds().size(), blockHeight);
+    Signum.getStores().getAtStore().getATs(getCurrentBlockAtIds()).forEach(at -> {
+      Long atId = AtApiHelper.getLong(at.getId());
+      this.minimumActivationAmount = Math.min(this.minimumActivationAmount, at.minActivationAmount());
+      ATContext atContext = atMap.get(atId);
+      atContext.at = at;
+      logger.debug("Cached AT {}", atId);
+    });
+  }
+
+  private void loadAtBytesIntoAtMap(byte[] ats) throws AtException {
     if (ats.length % (CostOfOneAT) != 0) {
       throw new AtException("ATs must be a multiple of cost of one AT ( " + CostOfOneAT + " )");
     }
@@ -100,22 +126,33 @@ public final class ATProcessorCache {
       b.get(atId);
       b.get(md5);
       long atIdLong = AtApiHelper.getLong(atId);
-      if (atMap.containsKey(atIdLong)) {
-        throw new AtException("AT included in block multiple times");
+      ATContext existingAtContext = atMap.get(atIdLong);
+      if (existingAtContext == null) {
+        ATContext atContext = new ATContext();
+        atContext.md5 = md5.clone();
+        atMap.put(atIdLong, atContext);
+      } else {
+        existingAtContext.md5 = md5.clone();
       }
-      ATContext atContext = new ATContext();
-      atContext.md5 = md5.clone();
-      atMap.put(atIdLong, atContext);
+      this.currentBlockAtIds.add(atIdLong);
     }
   }
 
-  // TODO: make this smarter, instead of loading them all
-  private void loadRelevantTransactions() {
-    logger.debug("Loading tx for lo: {}, hi: {}, amount: {}, no ATs: {}", lowestBlockHeight, currentBlockHeight, minimumActivationAmount, getAtMap().size());
+  private void loadTransactions() {
+    if (lastLoadedBlockHeight == 0) {
+      loadTransactionsFromHeightUntilCurrentBlock(startBlockHeight, false);
+    } else {
+      loadTransactionsFromHeightUntilCurrentBlock(lastLoadedBlockHeight, true);
+    }
+    lastLoadedBlockHeight = currentBlockHeight;
+  }
+
+  private void loadTransactionsPerATs() {
+    logger.debug("Loading tx for lo: {}, hi: {}, amount: {}, no ATs: {}", startBlockHeight, currentBlockHeight, minimumActivationAmount, getAtMap().size());
     Result<TransactionRecord> result = Db.useDSLContext(ctx -> {
       return ctx.selectFrom(TRANSACTION)
-        .where(TRANSACTION.HEIGHT.between(lowestBlockHeight, currentBlockHeight))
-        .and(TRANSACTION.RECIPIENT_ID.in(getAtMap().keySet()))
+        .where(TRANSACTION.HEIGHT.between(startBlockHeight, currentBlockHeight))
+        .and(TRANSACTION.RECIPIENT_ID.in(getCurrentBlockAtIds()))
         .and(TRANSACTION.AMOUNT.greaterOrEqual(minimumActivationAmount))
         .orderBy(TRANSACTION.HEIGHT, TRANSACTION.ID)
         .fetch();
@@ -127,12 +164,71 @@ public final class ATProcessorCache {
       try {
         ATContext context = this.atMap.get(r.getRecipientId());
         if (context != null) {
-          Transaction tx = db.loadTransaction(r);
-          context.transactions.add(tx);
+          context.transactions.add(db.loadTransaction(r));
         }
       } catch (SignumException.ValidationException e) {
         throw new RuntimeException(e);
       }
+    }
+  }
+
+  private void loadTransactionsFromHeightUntilCurrentBlock(int startHeight, boolean shallRemoveOldest) {
+    logger.debug("Loading all tx for heights from {} to {}", startHeight, currentBlockHeight - 1);
+    Result<TransactionRecord> result = Db.useDSLContext(ctx -> {
+      return ctx.selectFrom(TRANSACTION)
+        .where(TRANSACTION.HEIGHT.between(startHeight, currentBlockHeight - 1))
+        .and(TRANSACTION.RECIPIENT_ID.isNotNull())
+        .orderBy(TRANSACTION.HEIGHT, TRANSACTION.ID)
+        .fetch();
+    });
+
+    HashSet<Long> processedRecipients = new HashSet<>();
+    TransactionDb db = Db.getDbsByDatabaseType().getTransactionDb();
+    for (TransactionRecord r : result) {
+      Long recipientId = r.getRecipientId();
+      try {
+        ATContext context = this.atMap.get(recipientId);
+        if (context != null) {
+          //defensive: avoid double adding - maybe not the most elegant way...
+          if (context.transactions.stream().anyMatch(t -> t.getId() == r.getId())) {
+            logger.debug("Doubled Tx ({}) found for Recipient {}", r.getId(), recipientId);
+          } else {
+            context.transactions.add(db.loadTransaction(r));
+          }
+        } else {
+          ATContext newContext = new ATContext();
+          newContext.transactions.add(db.loadTransaction(r));
+          this.atMap.put(recipientId, newContext);
+        }
+        processedRecipients.add(recipientId);
+      } catch (SignumException.ValidationException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    if (shallRemoveOldest) {
+      processedRecipients.forEach(this::pruneTransactionList);
+    }
+
+  }
+
+  private void pruneTransactionList(long recipientId) {
+    ATContext context = this.atMap.get(recipientId);
+    if (context == null || context.transactions.isEmpty()) {
+      return;
+    }
+
+    int minimumHeightToKeep = currentBlockHeight - numberOfBlocksToCache - 1;
+    Transaction oldest = context.transactions.peekFirst();
+    int count = 0;
+    while(!context.transactions.isEmpty() && oldest.getHeight() < minimumHeightToKeep){
+      context.transactions.removeFirst();
+      logger.debug("Removed tx {}", oldest.getId());
+      oldest = context.transactions.peekFirst();
+      ++count;
+    }
+    if(count > 0){
+      logger.debug("Removed {} old transactions lower than height {} for recipient {}", count, minimumHeightToKeep, recipientId);
     }
   }
 
@@ -150,8 +246,8 @@ public final class ATProcessorCache {
       startHeight = atContext.at.getCreationBlockHeight();
     }
 
-    if (startHeight < lowestBlockHeight || endHeight > currentBlockHeight) {
-      logger.debug("Out of range (start: {}, end: {} - wanted block: {})", lowestBlockHeight, currentBlockHeight, startHeight);
+    if (startHeight < startBlockHeight || endHeight > currentBlockHeight) {
+      logger.debug("Out of range (start: {}, end: {} - wanted block: {})", startBlockHeight, currentBlockHeight, startHeight);
       throw new CacheMissException();
     }
 
@@ -161,7 +257,8 @@ public final class ATProcessorCache {
       .filter(t ->
         t.getHeight() >= finalStartHeight &&
           t.getHeight() < endHeight &&
-          t.getAmountNqt() >= minAmount)
+          t.getAmountNqt() >= minAmount
+      )
       .collect(Collectors.toList());
 
     if (collected.size() > numOfTx) {
@@ -182,8 +279,9 @@ public final class ATProcessorCache {
       throw new CacheMissException();
     }
 
+    // TODO: there must be another way how this works. This is very fragile
     int count = 0;
-    ArrayList<Transaction> transactions = atContext.transactions;
+    Collection<Transaction> transactions = atContext.transactions;
     for (Transaction t : transactions) {
       if (t.getHeight() == height && t.getAmountNqt() >= minAmount) {
         ++count;

--- a/src/brs/at/AtApiPlatformImpl.java
+++ b/src/brs/at/AtApiPlatformImpl.java
@@ -36,13 +36,26 @@ public class AtApiPlatformImpl extends AtApiImpl {
     return instance;
   }
 
+  // Version 1 - ok
+  // Pro Block die letzten 500 blocke der aktuell relevanten ATs in den Mem laden - 40 ms
+
+  // Version 2 - 80% ok
+  // Bei start alle tx der letzen 500 Bloecke in den Speicher laden - und (check)  - 400ms (1x)
+  // Jeden weiteren Block inkrementell die neuesten Tx an den Speicher anhaengen (check) - 2m  (Nx)
+  // --> Entferne alte Bloecke (aelter als 500 Bloecke)
+
+
   private static Long findTransaction(int startHeight, int endHeight, Long atID, int numOfTx, long minAmount) {
-    try {
-      return ATProcessorCache.getInstance().findTransactionId(startHeight, endHeight, atID, numOfTx, minAmount);
-    } catch (ATProcessorCache.CacheMissException e) {
-      return Signum.getStores().getAtStore().findTransaction(startHeight, endHeight, atID, numOfTx, minAmount);
+    ATProcessorCache cache = ATProcessorCache.getInstance();
+    if (cache.isEnabled()) {
+      try {
+        return ATProcessorCache.getInstance().findTransactionId(startHeight, endHeight, atID, numOfTx, minAmount);
+      } catch (ATProcessorCache.CacheMissException e) {
+        // no op
+      }
     }
-////
+    return Signum.getStores().getAtStore().findTransaction(startHeight, endHeight, atID, numOfTx, minAmount);
+//
 //    long id = 0;
 //    long idOrig = Signum.getStores().getAtStore().findTransaction(startHeight, endHeight, atID, numOfTx, minAmount);
 //    try {
@@ -56,15 +69,19 @@ public class AtApiPlatformImpl extends AtApiImpl {
 //      logger.error("Cache mismatch: {} x {}", id, idOrig );
 //    }
 //
-//    return id;
+//    return idOrig;
   }
 
   private static int findTransactionHeight(Long transactionId, int height, Long atID, long minAmount) {
-    try {
-      return ATProcessorCache.getInstance().findTransactionHeight(transactionId, height, atID, minAmount);
-    } catch (ATProcessorCache.CacheMissException e) {
-      return Signum.getStores().getAtStore().findTransactionHeight(transactionId, height, atID, minAmount);
+    ATProcessorCache cache = ATProcessorCache.getInstance();
+    if (cache.isEnabled()) {
+      try {
+        return ATProcessorCache.getInstance().findTransactionHeight(transactionId, height, atID, minAmount);
+      } catch (ATProcessorCache.CacheMissException e) {
+        // no op
+      }
     }
+    return Signum.getStores().getAtStore().findTransactionHeight(transactionId, height, atID, minAmount);
 //    int h;
 //    int hOrig =
 //      Signum.getStores().getAtStore().findTransactionHeight(transactionId, height, atID, minAmount);

--- a/src/brs/at/AtApiPlatformImpl.java
+++ b/src/brs/at/AtApiPlatformImpl.java
@@ -24,715 +24,749 @@ import java.util.Arrays;
 
 public class AtApiPlatformImpl extends AtApiImpl {
 
-    private static final Logger logger = LoggerFactory.getLogger(AtApiPlatformImpl.class);
+  private static final Logger logger = LoggerFactory.getLogger(AtApiPlatformImpl.class);
 
-    private static final AtApiPlatformImpl instance = new AtApiPlatformImpl();
+  private static final AtApiPlatformImpl instance = new AtApiPlatformImpl();
 
 
-    private AtApiPlatformImpl() {
+  private AtApiPlatformImpl() {
+  }
+
+  public static AtApiPlatformImpl getInstance() {
+    return instance;
+  }
+
+  private static Long findTransaction(int startHeight, int endHeight, Long atID, int numOfTx, long minAmount) {
+    try {
+      return ATProcessorCache.getInstance().findTransactionId(startHeight, endHeight, atID, numOfTx, minAmount);
+    } catch (ATProcessorCache.CacheMissException e) {
+      return Signum.getStores().getAtStore().findTransaction(startHeight, endHeight, atID, numOfTx, minAmount);
+    }
+////
+//    long id = 0;
+//    long idOrig = Signum.getStores().getAtStore().findTransaction(startHeight, endHeight, atID, numOfTx, minAmount);
+//    try {
+//      id = ATProcessorCache.getInstance().findTransactionId(startHeight, endHeight, atID, numOfTx, minAmount);
+//    } catch (ATProcessorCache.CacheMissException e) {
+//      logger.debug("Cache miss");
+//      id = Signum.getStores().getAtStore().findTransaction(startHeight, endHeight, atID, numOfTx, minAmount);
+//      // no op
+//    }
+//    if(id != idOrig){
+//      logger.error("Cache mismatch: {} x {}", id, idOrig );
+//    }
+//
+//    return id;
+  }
+
+  private static int findTransactionHeight(Long transactionId, int height, Long atID, long minAmount) {
+    try {
+      return ATProcessorCache.getInstance().findTransactionHeight(transactionId, height, atID, minAmount);
+    } catch (ATProcessorCache.CacheMissException e) {
+      return Signum.getStores().getAtStore().findTransactionHeight(transactionId, height, atID, minAmount);
+    }
+//    int h;
+//    int hOrig =
+//      Signum.getStores().getAtStore().findTransactionHeight(transactionId, height, atID, minAmount);
+//    try {
+//      h = ATProcessorCache.getInstance().findTransactionHeight(transactionId, height, atID, minAmount);
+//    } catch (ATProcessorCache.CacheMissException e) {
+//      logger.debug("Cache miss");
+//      h = Signum.getStores().getAtStore().findTransactionHeight(transactionId, height, atID, minAmount);
+//    }
+//    if(h != hOrig){
+//      logger.error("Cache mismatch: {} - {}", h, hOrig );
+//    }
+//
+//    return hOrig;
+  }
+
+  @Override
+  public long getBlockTimestamp(AtMachineState state) {
+    int height = state.getHeight();
+    return AtApiHelper.getLongTimestamp(height, 0);
+  }
+
+  @Override
+  public long getCreationTimestamp(AtMachineState state) {
+    return AtApiHelper.getLongTimestamp(state.getCreationBlockHeight(), 0);
+  }
+
+  @Override
+  public long getLastBlockTimestamp(AtMachineState state) {
+    int height = state.getHeight() - 1;
+    return AtApiHelper.getLongTimestamp(height, 0);
+  }
+
+  @Override
+  public void putLastBlockHashInA(AtMachineState state) {
+    ByteBuffer b = ByteBuffer.allocate(state.getA1().length * 4);
+    b.order(ByteOrder.LITTLE_ENDIAN);
+
+    b.put(Signum.getBlockchain().getBlockAtHeight(state.getHeight() - 1).getBlockHash());
+
+    b.clear();
+
+    byte[] temp = new byte[8];
+
+    b.get(temp, 0, 8);
+    state.setA1(temp);
+
+    b.get(temp, 0, 8);
+    state.setA2(temp);
+
+    b.get(temp, 0, 8);
+    state.setA3(temp);
+
+    b.get(temp, 0, 8);
+    state.setA4(temp);
+  }
+
+  @Override
+  public void aToTxAfterTimestamp(long val, AtMachineState state) {
+
+    int height = AtApiHelper.longToHeight(val);
+    int numOfTx = AtApiHelper.longToNumOfTx(val);
+
+    byte[] b = state.getId();
+    logger.debug("aToTxAfterTimestamp, startHeight: {}, endHeight: {}, numOfTx: {}, minAct: {}", height, state.getHeight(), numOfTx, state.minActivationAmount());
+    long tx = findTransaction(height, state.getHeight(), AtApiHelper.getLong(b), numOfTx, state.minActivationAmount());
+    logger.debug("tx with id {} found", tx);
+    clearA(state);
+    state.setA1(AtApiHelper.getByteArray(tx));
+
+  }
+
+  @Override
+  public long getTypeForTxInA(AtMachineState state) {
+    long txid = AtApiHelper.getLong(state.getA1());
+
+    Transaction tx = Signum.getBlockchain().getTransaction(txid);
+
+    if (tx == null || (tx.getHeight() >= state.getHeight())) {
+      return -1;
     }
 
-    public static AtApiPlatformImpl getInstance() {
-        return instance;
+    if (state.getVersion() >= 3) {
+      return tx.getType().getType();
     }
 
-    private static Long findTransaction(int startHeight, int endHeight, Long atID, int numOfTx, long minAmount) {
-        return Signum.getStores().getAtStore().findTransaction(startHeight, endHeight, atID, numOfTx, minAmount);
+    if (tx.getMessage() != null) {
+      return 1;
     }
 
-    private static int findTransactionHeight(Long transactionId, int height, Long atID, long minAmount) {
-        return Signum.getStores().getAtStore().findTransactionHeight(transactionId, height, atID, minAmount);
+    return 0;
+  }
+
+  @Override
+  public long getAmountForTxInA(AtMachineState state) {
+    long txId = AtApiHelper.getLong(state.getA1());
+
+    Transaction tx = Signum.getBlockchain().getTransaction(txId);
+
+    if (tx == null || (tx.getHeight() >= state.getHeight())) {
+      return -1;
     }
 
-    @Override
-    public long getBlockTimestamp(AtMachineState state) {
-        int height = state.getHeight();
-        return AtApiHelper.getLongTimestamp(height, 0);
-    }
-
-    @Override
-    public long getCreationTimestamp(AtMachineState state) {
-        return AtApiHelper.getLongTimestamp(state.getCreationBlockHeight(), 0);
-    }
-
-    @Override
-    public long getLastBlockTimestamp(AtMachineState state) {
-        int height = state.getHeight() - 1;
-        return AtApiHelper.getLongTimestamp(height, 0);
-    }
-
-    @Override
-    public void putLastBlockHashInA(AtMachineState state) {
-        ByteBuffer b = ByteBuffer.allocate(state.getA1().length * 4);
-        b.order(ByteOrder.LITTLE_ENDIAN);
-
-        b.put(Signum.getBlockchain().getBlockAtHeight(state.getHeight() - 1).getBlockHash());
-
-        b.clear();
-
-        byte[] temp = new byte[8];
-
-        b.get(temp, 0, 8);
-        state.setA1(temp);
-
-        b.get(temp, 0, 8);
-        state.setA2(temp);
-
-        b.get(temp, 0, 8);
-        state.setA3(temp);
-
-        b.get(temp, 0, 8);
-        state.setA4(temp);
-    }
-
-    @Override
-    public void aToTxAfterTimestamp(long val, AtMachineState state) {
-
-        int height = AtApiHelper.longToHeight(val);
-        int numOfTx = AtApiHelper.longToNumOfTx(val);
-
-        byte[] b = state.getId();
-
-        long tx = findTransaction(height, state.getHeight(), AtApiHelper.getLong(b), numOfTx, state.minActivationAmount());
-        logger.debug("tx with id {} found", tx);
-        clearA(state);
-        state.setA1(AtApiHelper.getByteArray(tx));
-
-    }
-
-    @Override
-    public long getTypeForTxInA(AtMachineState state) {
-        long txid = AtApiHelper.getLong(state.getA1());
-
-        Transaction tx = Signum.getBlockchain().getTransaction(txid);
-
-        if (tx == null || (tx.getHeight() >= state.getHeight())) {
-            return -1;
-        }
-
-        if (state.getVersion() >= 3) {
-          return tx.getType().getType();
-        }
-
-        if (tx.getMessage() != null) {
-            return 1;
-        }
-
-        return 0;
-    }
-
-    @Override
-    public long getAmountForTxInA(AtMachineState state) {
-        long txId = AtApiHelper.getLong(state.getA1());
-
-        Transaction tx = Signum.getBlockchain().getTransaction(txId);
-
-        if (tx == null || (tx.getHeight() >= state.getHeight())) {
-            return -1;
-        }
-
-        if (state.getVersion() > 2) {
-          long assetId = AtApiHelper.getLong(state.getA2());
-          if (assetId != 0){
-            if(tx.getAttachment() instanceof Attachment.ColoredCoinsAssetTransfer) {
-              Attachment.ColoredCoinsAssetTransfer assetTransfer = (ColoredCoinsAssetTransfer) tx.getAttachment();
-              if(assetTransfer.getAssetId() == assetId) {
-                return assetTransfer.getQuantityQnt();
-              }
-            }
-            else if(tx.getAttachment() instanceof Attachment.ColoredCoinsAssetMultiTransfer) {
-              Attachment.ColoredCoinsAssetMultiTransfer assetTransfer = (Attachment.ColoredCoinsAssetMultiTransfer) tx.getAttachment();
-              for(int i = 0; i < assetTransfer.getAssetIds().size(); i++){
-                if(assetTransfer.getAssetIds().get(i) == assetId) {
-                  return assetTransfer.getQuantitiesQnt().get(i);
-                }
-              }
-            }
-            return 0L;
-          }
-        }
-        if ((tx.getMessage() == null || Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_2, state.getHeight())) && state.minActivationAmount() <= tx.getAmountNqt()) {
-            return tx.getAmountNqt() - state.minActivationAmount();
-        }
-
-        return 0;
-    }
-
-    @Override
-    public long getMapValueKeysInA(AtMachineState state) {
-      if(state.getVersion() < 3){
-        return 0;
-      }
-      long key1 = AtApiHelper.getLong(state.getA1());
-      long key2 = AtApiHelper.getLong(state.getA2());
-
-      long atId = AtApiHelper.getLong(state.getA3());
-      if(atId == 0L) {
-        atId = AtApiHelper.getLong(state.getId());
-      }
-
-      return state.getMapValue(atId, key1, key2);
-    }
-
-    @Override
-    public void setMapValueKeysInA(AtMachineState state) {
-      if(state.getVersion() < 3){
-        return;
-      }
-      long key1 = AtApiHelper.getLong(state.getA1());
-      long key2 = AtApiHelper.getLong(state.getA2());
-      long value = AtApiHelper.getLong(state.getA4());
-
-      long atId = AtApiHelper.getLong(state.getId());
-
-      state.addMapUpdate(atId, key1, key2, value);
-    }
-
-    @Override
-    public long getTimestampForTxInA(AtMachineState state) {
-        long txId = AtApiHelper.getLong(state.getA1());
-        logger.debug("get timestamp for tx with id {} found", txId);
-        Transaction tx = Signum.getBlockchain().getTransaction(txId);
-
-        if (tx == null || (tx.getHeight() >= state.getHeight())) {
-            return -1;
-        }
-
-        byte[] b = state.getId();
-        int blockHeight = tx.getHeight();
-        int txHeight = findTransactionHeight(txId, blockHeight, AtApiHelper.getLong(b), state.minActivationAmount());
-
-        return AtApiHelper.getLongTimestamp(blockHeight, txHeight);
-    }
-
-    @Override
-    public long getRandomIdForTxInA(AtMachineState state) {
-        long txId = AtApiHelper.getLong(state.getA1());
-
-        Transaction tx = Signum.getBlockchain().getTransaction(txId);
-
-        if (tx == null || (tx.getHeight() >= state.getHeight())) {
-            return -1;
-        }
-
-        int txBlockHeight = tx.getHeight();
-        int blockHeight = state.getHeight();
-
-        if (blockHeight - txBlockHeight < AtConstants.getInstance().blocksForRandom(blockHeight)) { //for tests - for real case 1440
-            state.setWaitForNumberOfBlocks((int) AtConstants.getInstance().blocksForRandom(blockHeight) - (blockHeight - txBlockHeight));
-            state.getMachineState().pc -= 7;
-            state.getMachineState().stopped = true;
-            return 0;
-        }
-
-        MessageDigest digest = Crypto.sha256();
-
-        byte[] senderPublicKey = tx.getSenderPublicKey();
-
-        ByteBuffer bf = ByteBuffer.allocate((Signum.getFluxCapacitor().getValue(FluxValues.SODIUM)) ?
-        		32 + 8 + senderPublicKey.length :
-        		32 + Long.SIZE + senderPublicKey.length);
-        bf.order(ByteOrder.LITTLE_ENDIAN);
-        bf.put(Signum.getBlockchain().getBlockAtHeight(blockHeight - 1).getGenerationSignature());
-        bf.putLong(tx.getId());
-        bf.put(senderPublicKey);
-
-        digest.update(bf.array());
-        byte[] byteRandom = digest.digest();
-
-        return Math.abs(AtApiHelper.getLong(Arrays.copyOfRange(byteRandom, 0, 8)));
-    }
-
-    @Override
-    public long checkSignBWithA(AtMachineState state) {
-        if (state.getVersion() > 2) {
-          long txid = AtApiHelper.getLong(state.getA1());
-          Transaction tx = Signum.getBlockchain().getTransaction(txid);
-          if (tx == null || tx.getHeight() >= state.getHeight() || tx.getMessage() == null) {
-              return 0L;
-          }
-          int page = Math.max(0, (int)AtApiHelper.getLong(state.getA2()));
-
-          long accountId = AtApiHelper.getLong(state.getA3());
-          Account account = Account.getAccount(accountId);
-          if(account == null || account.getPublicKey() == null){
-            return 0L;
-          }
-
-          ByteBuffer message = ByteBuffer.allocate(32);
-          message.order(ByteOrder.LITTLE_ENDIAN);
-
-          message.put(state.getId());
-          message.put(state.getB2());
-          message.put(state.getB3());
-          message.put(state.getB4());
-          message.clear();
-
-          ByteBuffer signature = ByteBuffer.allocate(64);
-          signature.order(ByteOrder.LITTLE_ENDIAN);
-          Appendix.Message txMessage = tx.getMessage();
-          byte[] txMessageBytes = txMessage.getMessageBytes();
-          if (txMessageBytes != null) {
-            int start = page * 8 * 4;
-            for(int i=0; i<64 && start+i < txMessageBytes.length; i++){
-              signature.put(txMessageBytes[start + i]);
-            }
-          }
-          signature.clear();
-
-          boolean verified = Crypto.verify(signature.array(), message.array(), account.getPublicKey(), true);
-
-          return verified ? 1L : 0L;
-        }
-        return 0L;
-    }
-
-    @Override
-    public void messageFromTxInAToB(AtMachineState state) {
-        long txid = AtApiHelper.getLong(state.getA1());
-
-        Transaction tx = Signum.getBlockchain().getTransaction(txid);
-        if (tx != null && tx.getHeight() >= state.getHeight()) {
-            tx = null;
-        }
-        int length = 8 * 4;
-        ByteBuffer b = ByteBuffer.allocate(length);
-        b.order(ByteOrder.LITTLE_ENDIAN);
-        if (tx != null) {
-            Appendix.Message txMessage = tx.getMessage();
-            if (txMessage != null) {
-                byte[] message = txMessage.getMessageBytes();
-                if (state.getVersion() > 2){
-                  // we now accept multiple pages
-                  int page = Math.max(0, (int)AtApiHelper.getLong(state.getA2()));
-                  int start = page * length;
-                  for(int i=0; i<length && start+i < message.length; i++){
-                    b.put(message[start + i]);
-                  }
-                }
-                else if (message.length <= length) {
-                    b.put(message);
-                }
-            }
-        }
-
-        b.clear();
-
-        byte[] temp = new byte[8];
-
-        b.get(temp, 0, 8);
-        state.setB1(temp);
-
-        b.get(temp, 0, 8);
-        state.setB2(temp);
-
-        b.get(temp, 0, 8);
-        state.setB3(temp);
-
-        b.get(temp, 0, 8);
-        state.setB4(temp);
-
-    }
-
-    @Override
-    public void bToAddressOfTxInA(AtMachineState state) {
-        long txId = AtApiHelper.getLong(state.getA1());
-
-        clearB(state);
-
-        Transaction tx = Signum.getBlockchain().getTransaction(txId);
-        if (tx != null && tx.getHeight() >= state.getHeight()) {
-            tx = null;
-        }
-        if (tx != null) {
-            long address = tx.getSenderId();
-            state.setB1(AtApiHelper.getByteArray(address));
-        }
-    }
-
-    @Override
-    public void bToAssetsOfTxInA(AtMachineState state) {
-        long txId = AtApiHelper.getLong(state.getA1());
-
-        clearB(state);
-
-        Transaction tx = Signum.getBlockchain().getTransaction(txId);
-        if (tx != null && tx.getHeight() >= state.getHeight()) {
-            tx = null;
-        }
-        if(tx == null)
-          return;
-
+    if (state.getVersion() > 2) {
+      long assetId = AtApiHelper.getLong(state.getA2());
+      if (assetId != 0) {
         if (tx.getAttachment() instanceof Attachment.ColoredCoinsAssetTransfer) {
-          Attachment.ColoredCoinsAssetTransfer assetTransfer = (Attachment.ColoredCoinsAssetTransfer) tx.getAttachment();
-          state.setB1(AtApiHelper.getByteArray(assetTransfer.getAssetId()));
-        }
-        else if (tx.getAttachment() instanceof Attachment.ColoredCoinsAssetMultiTransfer) {
+          Attachment.ColoredCoinsAssetTransfer assetTransfer = (ColoredCoinsAssetTransfer) tx.getAttachment();
+          if (assetTransfer.getAssetId() == assetId) {
+            return assetTransfer.getQuantityQnt();
+          }
+        } else if (tx.getAttachment() instanceof Attachment.ColoredCoinsAssetMultiTransfer) {
           Attachment.ColoredCoinsAssetMultiTransfer assetTransfer = (Attachment.ColoredCoinsAssetMultiTransfer) tx.getAttachment();
-          if(assetTransfer.getAssetIds().size() > 0){
-            state.setB1(AtApiHelper.getByteArray(assetTransfer.getAssetIds().get(0)));
-          }
-          if(assetTransfer.getAssetIds().size() > 1){
-            state.setB2(AtApiHelper.getByteArray(assetTransfer.getAssetIds().get(1)));
-          }
-          if(assetTransfer.getAssetIds().size() > 2){
-            state.setB3(AtApiHelper.getByteArray(assetTransfer.getAssetIds().get(2)));
-          }
-          if(assetTransfer.getAssetIds().size() > 3){
-            state.setB4(AtApiHelper.getByteArray(assetTransfer.getAssetIds().get(3)));
+          for (int i = 0; i < assetTransfer.getAssetIds().size(); i++) {
+            if (assetTransfer.getAssetIds().get(i) == assetId) {
+              return assetTransfer.getQuantitiesQnt().get(i);
+            }
           }
         }
+        return 0L;
+      }
+    }
+    if ((tx.getMessage() == null || Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_2, state.getHeight())) && state.minActivationAmount() <= tx.getAmountNqt()) {
+      return tx.getAmountNqt() - state.minActivationAmount();
     }
 
-    @Override
-    public void bToAddressOfCreator(AtMachineState state) {
-      long creator = AtApiHelper.getLong(state.getCreator());
-      if (state.getVersion() >= 3) {
-        // we are allowed to ask for the creator of another AT (in B2)
-        long atId = AtApiHelper.getLong(state.getB2());
-        if (atId != 0L) {
-          creator = 0L;
-          // asking for the creator of the given at_id
-          AT at = Signum.getStores().getAtStore().getAT(atId);
-          if (at != null) {
-            creator = AtApiHelper.getLong(at.getCreator());
-          }
+    return 0;
+  }
+
+  @Override
+  public long getMapValueKeysInA(AtMachineState state) {
+    if (state.getVersion() < 3) {
+      return 0;
+    }
+    long key1 = AtApiHelper.getLong(state.getA1());
+    long key2 = AtApiHelper.getLong(state.getA2());
+
+    long atId = AtApiHelper.getLong(state.getA3());
+    if (atId == 0L) {
+      atId = AtApiHelper.getLong(state.getId());
+    }
+
+    return state.getMapValue(atId, key1, key2);
+  }
+
+  @Override
+  public void setMapValueKeysInA(AtMachineState state) {
+    if (state.getVersion() < 3) {
+      return;
+    }
+    long key1 = AtApiHelper.getLong(state.getA1());
+    long key2 = AtApiHelper.getLong(state.getA2());
+    long value = AtApiHelper.getLong(state.getA4());
+
+    long atId = AtApiHelper.getLong(state.getId());
+
+    state.addMapUpdate(atId, key1, key2, value);
+  }
+
+  @Override
+  public long getTimestampForTxInA(AtMachineState state) {
+    long txId = AtApiHelper.getLong(state.getA1());
+    logger.debug("get timestamp for tx with id {} found", txId);
+    // TODO: we might avoid this db access, when using cache here
+    Transaction tx = Signum.getBlockchain().getTransaction(txId);
+
+    if (tx == null || (tx.getHeight() >= state.getHeight())) {
+      return -1;
+    }
+
+    byte[] b = state.getId();
+    int blockHeight = tx.getHeight();
+    int txHeight = findTransactionHeight(txId, blockHeight, AtApiHelper.getLong(b), state.minActivationAmount());
+
+    return AtApiHelper.getLongTimestamp(blockHeight, txHeight);
+  }
+
+  @Override
+  public long getRandomIdForTxInA(AtMachineState state) {
+    long txId = AtApiHelper.getLong(state.getA1());
+
+    Transaction tx = Signum.getBlockchain().getTransaction(txId);
+
+    if (tx == null || (tx.getHeight() >= state.getHeight())) {
+      return -1;
+    }
+
+    int txBlockHeight = tx.getHeight();
+    int blockHeight = state.getHeight();
+
+    if (blockHeight - txBlockHeight < AtConstants.getInstance().blocksForRandom(blockHeight)) { //for tests - for real case 1440
+      state.setWaitForNumberOfBlocks((int) AtConstants.getInstance().blocksForRandom(blockHeight) - (blockHeight - txBlockHeight));
+      state.getMachineState().pc -= 7;
+      state.getMachineState().stopped = true;
+      return 0;
+    }
+
+    MessageDigest digest = Crypto.sha256();
+
+    byte[] senderPublicKey = tx.getSenderPublicKey();
+
+    ByteBuffer bf = ByteBuffer.allocate((Signum.getFluxCapacitor().getValue(FluxValues.SODIUM)) ?
+      32 + 8 + senderPublicKey.length :
+      32 + Long.SIZE + senderPublicKey.length);
+    bf.order(ByteOrder.LITTLE_ENDIAN);
+    bf.put(Signum.getBlockchain().getBlockAtHeight(blockHeight - 1).getGenerationSignature());
+    bf.putLong(tx.getId());
+    bf.put(senderPublicKey);
+
+    digest.update(bf.array());
+    byte[] byteRandom = digest.digest();
+
+    return Math.abs(AtApiHelper.getLong(Arrays.copyOfRange(byteRandom, 0, 8)));
+  }
+
+  @Override
+  public long checkSignBWithA(AtMachineState state) {
+    if (state.getVersion() > 2) {
+      long txid = AtApiHelper.getLong(state.getA1());
+      Transaction tx = Signum.getBlockchain().getTransaction(txid);
+      if (tx == null || tx.getHeight() >= state.getHeight() || tx.getMessage() == null) {
+        return 0L;
+      }
+      int page = Math.max(0, (int) AtApiHelper.getLong(state.getA2()));
+
+      long accountId = AtApiHelper.getLong(state.getA3());
+      Account account = Account.getAccount(accountId);
+      if (account == null || account.getPublicKey() == null) {
+        return 0L;
+      }
+
+      ByteBuffer message = ByteBuffer.allocate(32);
+      message.order(ByteOrder.LITTLE_ENDIAN);
+
+      message.put(state.getId());
+      message.put(state.getB2());
+      message.put(state.getB3());
+      message.put(state.getB4());
+      message.clear();
+
+      ByteBuffer signature = ByteBuffer.allocate(64);
+      signature.order(ByteOrder.LITTLE_ENDIAN);
+      Appendix.Message txMessage = tx.getMessage();
+      byte[] txMessageBytes = txMessage.getMessageBytes();
+      if (txMessageBytes != null) {
+        int start = page * 8 * 4;
+        for (int i = 0; i < 64 && start + i < txMessageBytes.length; i++) {
+          signature.put(txMessageBytes[start + i]);
         }
       }
+      signature.clear();
 
-      clearB(state);
+      boolean verified = Crypto.verify(signature.array(), message.array(), account.getPublicKey(), true);
 
-      state.setB1(AtApiHelper.getByteArray(creator));
+      return verified ? 1L : 0L;
+    }
+    return 0L;
+  }
+
+  @Override
+  public void messageFromTxInAToB(AtMachineState state) {
+    long txid = AtApiHelper.getLong(state.getA1());
+
+    Transaction tx = Signum.getBlockchain().getTransaction(txid);
+    if (tx != null && tx.getHeight() >= state.getHeight()) {
+      tx = null;
+    }
+    int length = 8 * 4;
+    ByteBuffer b = ByteBuffer.allocate(length);
+    b.order(ByteOrder.LITTLE_ENDIAN);
+    if (tx != null) {
+      Appendix.Message txMessage = tx.getMessage();
+      if (txMessage != null) {
+        byte[] message = txMessage.getMessageBytes();
+        if (state.getVersion() > 2) {
+          // we now accept multiple pages
+          int page = Math.max(0, (int) AtApiHelper.getLong(state.getA2()));
+          int start = page * length;
+          for (int i = 0; i < length && start + i < message.length; i++) {
+            b.put(message[start + i]);
+          }
+        } else if (message.length <= length) {
+          b.put(message);
+        }
+      }
     }
 
-    @Override
-    public long getCodeHashId(AtMachineState state) {
-      if (state.getVersion() < 3) {
-        return 0L;
-      }
-      long atId = AtApiHelper.getLong(state.getB2());
-      if(atId == 0L){
-        atId = AtApiHelper.getLong(state.getId());
-      }
-      AT at = Signum.getStores().getAtStore().getAT(atId);
-      if (at != null) {
-        return at.getApCodeHashId();
-      }
-      return 0L;
+    b.clear();
+
+    byte[] temp = new byte[8];
+
+    b.get(temp, 0, 8);
+    state.setB1(temp);
+
+    b.get(temp, 0, 8);
+    state.setB2(temp);
+
+    b.get(temp, 0, 8);
+    state.setB3(temp);
+
+    b.get(temp, 0, 8);
+    state.setB4(temp);
+
+  }
+
+  @Override
+  public void bToAddressOfTxInA(AtMachineState state) {
+    long txId = AtApiHelper.getLong(state.getA1());
+
+    clearB(state);
+
+    Transaction tx = Signum.getBlockchain().getTransaction(txId);
+    if (tx != null && tx.getHeight() >= state.getHeight()) {
+      tx = null;
     }
+    if (tx != null) {
+      long address = tx.getSenderId();
+      state.setB1(AtApiHelper.getByteArray(address));
+    }
+  }
 
-    @Override
-    public long getActivationFee(AtMachineState state) {
-      if (state.getVersion() < 3) {
-        return 0L;
+  @Override
+  public void bToAssetsOfTxInA(AtMachineState state) {
+    long txId = AtApiHelper.getLong(state.getA1());
+
+    clearB(state);
+
+    Transaction tx = Signum.getBlockchain().getTransaction(txId);
+    if (tx != null && tx.getHeight() >= state.getHeight()) {
+      tx = null;
+    }
+    if (tx == null)
+      return;
+
+    if (tx.getAttachment() instanceof Attachment.ColoredCoinsAssetTransfer) {
+      Attachment.ColoredCoinsAssetTransfer assetTransfer = (Attachment.ColoredCoinsAssetTransfer) tx.getAttachment();
+      state.setB1(AtApiHelper.getByteArray(assetTransfer.getAssetId()));
+    } else if (tx.getAttachment() instanceof Attachment.ColoredCoinsAssetMultiTransfer) {
+      Attachment.ColoredCoinsAssetMultiTransfer assetTransfer = (Attachment.ColoredCoinsAssetMultiTransfer) tx.getAttachment();
+      if (assetTransfer.getAssetIds().size() > 0) {
+        state.setB1(AtApiHelper.getByteArray(assetTransfer.getAssetIds().get(0)));
       }
+      if (assetTransfer.getAssetIds().size() > 1) {
+        state.setB2(AtApiHelper.getByteArray(assetTransfer.getAssetIds().get(1)));
+      }
+      if (assetTransfer.getAssetIds().size() > 2) {
+        state.setB3(AtApiHelper.getByteArray(assetTransfer.getAssetIds().get(2)));
+      }
+      if (assetTransfer.getAssetIds().size() > 3) {
+        state.setB4(AtApiHelper.getByteArray(assetTransfer.getAssetIds().get(3)));
+      }
+    }
+  }
 
+  @Override
+  public void bToAddressOfCreator(AtMachineState state) {
+    long creator = AtApiHelper.getLong(state.getCreator());
+    if (state.getVersion() >= 3) {
       // we are allowed to ask for the creator of another AT (in B2)
       long atId = AtApiHelper.getLong(state.getB2());
-      if (atId == 0L) {
-        atId = AtApiHelper.getLong(state.getId());
+      if (atId != 0L) {
+        creator = 0L;
+        // asking for the creator of the given at_id
+        AT at = Signum.getStores().getAtStore().getAT(atId);
+        if (at != null) {
+          creator = AtApiHelper.getLong(at.getCreator());
+        }
       }
-      // asking for the creator of the given at_id
-      AT at = Signum.getStores().getAtStore().getAT(atId);
-      if (at != null) {
-        return at.minActivationAmount();
-      }
+    }
+
+    clearB(state);
+
+    state.setB1(AtApiHelper.getByteArray(creator));
+  }
+
+  @Override
+  public long getCodeHashId(AtMachineState state) {
+    if (state.getVersion() < 3) {
+      return 0L;
+    }
+    long atId = AtApiHelper.getLong(state.getB2());
+    if (atId == 0L) {
+      atId = AtApiHelper.getLong(state.getId());
+    }
+    AT at = Signum.getStores().getAtStore().getAT(atId);
+    if (at != null) {
+      return at.getApCodeHashId();
+    }
+    return 0L;
+  }
+
+  @Override
+  public long getActivationFee(AtMachineState state) {
+    if (state.getVersion() < 3) {
       return 0L;
     }
 
-    @Override
-    public void putLastBlockGenerationSignatureInA(AtMachineState state) {
-        ByteBuffer b = ByteBuffer.allocate(state.getA1().length * 4);
-        b.order(ByteOrder.LITTLE_ENDIAN);
+    // we are allowed to ask for the creator of another AT (in B2)
+    long atId = AtApiHelper.getLong(state.getB2());
+    if (atId == 0L) {
+      atId = AtApiHelper.getLong(state.getId());
+    }
+    // asking for the creator of the given at_id
+    AT at = Signum.getStores().getAtStore().getAT(atId);
+    if (at != null) {
+      return at.minActivationAmount();
+    }
+    return 0L;
+  }
 
-        b.put(Signum.getBlockchain().getBlockAtHeight(state.getHeight() - 1).getGenerationSignature());
+  @Override
+  public void putLastBlockGenerationSignatureInA(AtMachineState state) {
+    ByteBuffer b = ByteBuffer.allocate(state.getA1().length * 4);
+    b.order(ByteOrder.LITTLE_ENDIAN);
 
-        b.clear();
+    b.put(Signum.getBlockchain().getBlockAtHeight(state.getHeight() - 1).getGenerationSignature());
 
-        byte[] temp = new byte[8];
+    b.clear();
 
-        b.get(temp, 0, 8);
-        state.setA1(temp);
+    byte[] temp = new byte[8];
 
-        b.get(temp, 0, 8);
-        state.setA2(temp);
+    b.get(temp, 0, 8);
+    state.setA1(temp);
 
-        b.get(temp, 0, 8);
-        state.setA3(temp);
+    b.get(temp, 0, 8);
+    state.setA2(temp);
 
-        b.get(temp, 0, 8);
-        state.setA4(temp);
+    b.get(temp, 0, 8);
+    state.setA3(temp);
+
+    b.get(temp, 0, 8);
+    state.setA4(temp);
+  }
+
+  @Override
+  public long getCurrentBalance(AtMachineState state) {
+    if (!Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_2, state.getHeight())) {
+      return 0;
     }
 
-    @Override
-    public long getCurrentBalance(AtMachineState state) {
-        if (!Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_2, state.getHeight())) {
-            return 0;
-        }
-
-        if (state.getVersion() >= 3) {
-          long assetId = AtApiHelper.getLong(state.getB2());
-          return state.getgBalance(assetId);
-        }
-
-        return state.getgBalance();
+    if (state.getVersion() >= 3) {
+      long assetId = AtApiHelper.getLong(state.getB2());
+      return state.getgBalance(assetId);
     }
 
-    @Override
-    public long getAccountBalance(AtMachineState state) {
-        if (!Signum.getFluxCapacitor().getValue(FluxValues.PK_FREEZE2, state.getHeight())) {
-            return 0;
-        }
+    return state.getgBalance();
+  }
 
-        long accountId = AtApiHelper.getLong(state.getB1());
-        long assetId = AtApiHelper.getLong(state.getB2());
-
-        if(assetId == 0L){
-          Account.Balance balance = Account.getAccountBalance(accountId);
-          return balance == null ? 0L : balance.getBalanceNqt();
-        }
-        AccountAsset assetBalance = Account.getAccountAssetBalance(accountId, assetId);
-
-        return assetBalance == null ? 0 : assetBalance.getQuantityQnt();
+  @Override
+  public long getAccountBalance(AtMachineState state) {
+    if (!Signum.getFluxCapacitor().getValue(FluxValues.PK_FREEZE2, state.getHeight())) {
+      return 0;
     }
 
-    @Override
-    public long getPreviousBalance(AtMachineState state) {
-        if (!Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_2, state.getHeight())) {
-            return 0;
-        }
+    long accountId = AtApiHelper.getLong(state.getB1());
+    long assetId = AtApiHelper.getLong(state.getB2());
 
-        return state.getpBalance();
+    if (assetId == 0L) {
+      Account.Balance balance = Account.getAccountBalance(accountId);
+      return balance == null ? 0L : balance.getBalanceNqt();
+    }
+    AccountAsset assetBalance = Account.getAccountAssetBalance(accountId, assetId);
+
+    return assetBalance == null ? 0 : assetBalance.getQuantityQnt();
+  }
+
+  @Override
+  public long getPreviousBalance(AtMachineState state) {
+    if (!Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_2, state.getHeight())) {
+      return 0;
     }
 
-    @Override
-    public void sendToAddressInB(long val, AtMachineState state) {
-        if (val < 1)
-            return;
+    return state.getpBalance();
+  }
 
-        if (state.getVersion() > 2) {
-          long assetId = AtApiHelper.getLong(state.getB2());
-          if (assetId != 0L) {
-            long assetBalance = state.getgBalance(assetId);
-            if (val > assetBalance) {
-              val = assetBalance;
-            }
+  @Override
+  public void sendToAddressInB(long val, AtMachineState state) {
+    if (val < 1)
+      return;
 
-            // optional coin amount besides the asset
-            long amount = AtApiHelper.getLong(state.getB3());
-            if (amount > 0L) {
-              long balance = state.getgBalance();
-              if (amount > balance){
-                amount = balance;
-              }
-              state.setgBalance(balance - amount);
-            }
-            else {
-              amount = 0L;
-            }
+    if (state.getVersion() > 2) {
+      long assetId = AtApiHelper.getLong(state.getB2());
+      if (assetId != 0L) {
+        long assetBalance = state.getgBalance(assetId);
+        if (val > assetBalance) {
+          val = assetBalance;
+        }
 
-            AtTransaction tx = new AtTransaction(TransactionType.ColoredCoins.ASSET_TRANSFER,
-                state.getId(), state.getB1().clone(), amount, assetId, val, null);
-            state.addTransaction(tx);
-
-            state.setgBalance(assetId, assetBalance - val);
-            return;
+        // optional coin amount besides the asset
+        long amount = AtApiHelper.getLong(state.getB3());
+        if (amount > 0L) {
+          long balance = state.getgBalance();
+          if (amount > balance) {
+            amount = balance;
           }
-        }
-
-        if (val > state.getgBalance()) {
-          val = state.getgBalance();
-        }
-        AtTransaction tx = new AtTransaction(TransactionType.Payment.ORDINARY, state.getId(), state.getB1().clone(), val, null);
-        state.addTransaction(tx);
-
-        state.setgBalance(state.getgBalance() - val);
-    }
-
-    @Override
-    public void mintAsset(AtMachineState state) {
-      if(state.getVersion() < 3){
-        return;
-      }
-
-      long assetId = AtApiHelper.getLong(state.getB2());
-      long accountId = AtApiHelper.getLong(state.getId());
-      long quantity = AtApiHelper.getLong(state.getB1());
-
-      Asset asset = Signum.getStores().getAssetStore().getAsset(assetId);
-      if (asset == null || asset.getAccountId() != accountId || quantity <= 0L) {
-        // only assets that we have created internally and no burning by mint
-        return;
-      }
-
-      boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, state.getHeight());
-      long circulatingSupply = Signum.getAssetExchange().getAssetCirculatingSupply(asset, false, unconfirmed);
-      long newSupply = circulatingSupply + quantity;
-      if (newSupply > Constants.MAX_ASSET_QUANTITY_QNT) {
-        // do not mint extra to keep the limit
-        return;
-      }
-
-      AtTransaction tx = new AtTransaction(TransactionType.ColoredCoins.ASSET_MINT,
-          state.getId(), null, 0L, assetId, quantity, null);
-      state.addTransaction(tx);
-
-      state.setgBalance(assetId, state.getgBalance(assetId) + quantity);
-    }
-
-    @Override
-    public void distToHolders(AtMachineState state) {
-      if(state.getVersion() < 3){
-        return;
-      }
-
-      long minHolding = AtApiHelper.getLong(state.getB1());
-      long assetId = AtApiHelper.getLong(state.getB2());
-
-      long amount = Math.max(0L, AtApiHelper.getLong(state.getA1()));
-      long assetToDistribute = AtApiHelper.getLong(state.getA3());
-      long quantityToDistribute = 0L;
-
-      Asset asset = Signum.getStores().getAssetStore().getAsset(assetId);
-      if (asset == null) {
-        // asset not found, do nothing
-        return;
-      }
-
-      int maxIndirects = Signum.getPropertyService().getInt(Props.MAX_INDIRECTS_PER_BLOCK);
-      boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, state.getHeight());
-      int holdersCount = Signum.getAssetExchange().getAssetAccountsCount(asset, minHolding, true, unconfirmed);
-      if(holdersCount == 0 || state.getIndirectsCount() + holdersCount > maxIndirects){
-        // no holders to distribute or over the maximum, so do not distribute
-        return;
-      }
-      state.addIndirectsCount(holdersCount);
-
-      if(assetToDistribute !=0 ){
-        quantityToDistribute = Math.max(0L, AtApiHelper.getLong(state.getA4()));
-        if(quantityToDistribute > state.getgBalance(assetToDistribute)){
-          quantityToDistribute = state.getgBalance(assetToDistribute);
-        }
-        state.setgBalance(assetToDistribute, state.getgBalance(assetToDistribute) - quantityToDistribute);
-      }
-      if(amount > state.getgBalance()){
-        amount = state.getgBalance();
-      }
-      state.setgBalance(state.getgBalance() - amount);
-
-      if(amount == 0L && quantityToDistribute == 0L){
-        // nothing to actually distribute
-        return;
-      }
-
-      AtTransaction tx = new AtTransaction(TransactionType.ColoredCoins.ASSET_DISTRIBUTE_TO_HOLDERS,
-          state.getId(), null, amount, assetId, quantityToDistribute, assetToDistribute, minHolding, null);
-      state.addTransaction(tx);
-    }
-
-    @Override
-    public long getAssetHoldersCount(AtMachineState state) {
-      if(state.getVersion() < 3){
-        return 0L;
-      }
-
-      long minHolding = AtApiHelper.getLong(state.getB1());
-      long assetId = AtApiHelper.getLong(state.getB2());
-
-      Asset asset = Signum.getStores().getAssetStore().getAsset(assetId);
-      if (asset == null) {
-        // asset not found, no holders
-        return 0L;
-      }
-
-      boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, state.getHeight());
-      return Signum.getAssetExchange().getAssetAccountsCount(asset, minHolding, true, unconfirmed);
-    }
-
-    @Override
-    public long getAssetCirculating(AtMachineState state) {
-      if(state.getVersion() < 3){
-        return 0L;
-      }
-
-      long assetId = AtApiHelper.getLong(state.getB2());
-
-      Asset asset = Signum.getStores().getAssetStore().getAsset(assetId);
-      if (asset == null) {
-        // asset not found, no supply
-        return 0L;
-      }
-
-      boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, state.getHeight());
-      return Signum.getAssetExchange().getAssetCirculatingSupply(asset, true, unconfirmed);
-    }
-
-    @Override
-    public long issueAsset(AtMachineState state) {
-      if(state.getVersion() < 3){
-        return 0;
-      }
-
-      ByteBuffer b = ByteBuffer.allocate(32);
-      b.order(ByteOrder.LITTLE_ENDIAN);
-      b.put(state.getA1());
-      b.put(state.getA2());
-      b.put(state.getA3());
-      b.put(state.getA4());
-      b.clear();
-
-      long decimals = AtApiHelper.getLong(state.getB1());
-
-      AtTransaction tx = new AtTransaction(TransactionType.ColoredCoins.ASSET_ISSUANCE, state.getId(), null, 0L, 0L, decimals, b.array());
-      state.addTransaction(tx);
-
-      return tx.getAssetId();
-    }
-
-    @Override
-    public void sendAllToAddressInB(AtMachineState state) {
-        AtTransaction tx = new AtTransaction(TransactionType.AutomatedTransactions.AT_PAYMENT, state.getId(), state.getB1().clone(), state.getgBalance(), null);
-        state.addTransaction(tx);
-        state.setgBalance(0L);
-    }
-
-    @Override
-    public void sendOldToAddressInB(AtMachineState state) {
-        if (state.getpBalance() > state.getgBalance()) {
-            AtTransaction tx = new AtTransaction(TransactionType.AutomatedTransactions.AT_PAYMENT, state.getId(), state.getB1(), state.getgBalance(), null);
-            state.addTransaction(tx);
-
-            state.setgBalance(0L);
-            state.setpBalance(0L);
+          state.setgBalance(balance - amount);
         } else {
-            AtTransaction tx = new AtTransaction(TransactionType.AutomatedTransactions.AT_PAYMENT, state.getId(), state.getB1(), state.getpBalance(), null);
-            state.addTransaction(tx);
-
-            state.setgBalance(state.getgBalance() - state.getpBalance());
-            state.setpBalance(0L);
+          amount = 0L;
         }
-    }
 
-    @Override
-    public void sendAToAddressInB(AtMachineState state) {
-        ByteBuffer b = ByteBuffer.allocate(32);
-        b.order(ByteOrder.LITTLE_ENDIAN);
-        b.put(state.getA1());
-        b.put(state.getA2());
-        b.put(state.getA3());
-        b.put(state.getA4());
-        b.clear();
-
-        AtTransaction tx = new AtTransaction(TransactionType.AutomatedTransactions.AT_PAYMENT, state.getId(), state.getB1(), 0L, 0L, 0L, b.array());
+        AtTransaction tx = new AtTransaction(TransactionType.ColoredCoins.ASSET_TRANSFER,
+          state.getId(), state.getB1().clone(), amount, assetId, val, null);
         state.addTransaction(tx);
+
+        state.setgBalance(assetId, assetBalance - val);
+        return;
+      }
     }
 
-    @Override
-    public long addMinutesToTimestamp(long val1, long val2, AtMachineState state) {
-        int height = AtApiHelper.longToHeight(val1);
-        int numOfTx = AtApiHelper.longToNumOfTx(val1);
-        int addHeight = height + (int) (val2 / AtConstants.getInstance().averageBlockMinutes(state.getHeight()));
-
-        return AtApiHelper.getLongTimestamp(addHeight, numOfTx);
+    if (val > state.getgBalance()) {
+      val = state.getgBalance();
     }
+    AtTransaction tx = new AtTransaction(TransactionType.Payment.ORDINARY, state.getId(), state.getB1().clone(), val, null);
+    state.addTransaction(tx);
+
+    state.setgBalance(state.getgBalance() - val);
+  }
+
+  @Override
+  public void mintAsset(AtMachineState state) {
+    if (state.getVersion() < 3) {
+      return;
+    }
+
+    long assetId = AtApiHelper.getLong(state.getB2());
+    long accountId = AtApiHelper.getLong(state.getId());
+    long quantity = AtApiHelper.getLong(state.getB1());
+
+    Asset asset = Signum.getStores().getAssetStore().getAsset(assetId);
+    if (asset == null || asset.getAccountId() != accountId || quantity <= 0L) {
+      // only assets that we have created internally and no burning by mint
+      return;
+    }
+
+    boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, state.getHeight());
+    long circulatingSupply = Signum.getAssetExchange().getAssetCirculatingSupply(asset, false, unconfirmed);
+    long newSupply = circulatingSupply + quantity;
+    if (newSupply > Constants.MAX_ASSET_QUANTITY_QNT) {
+      // do not mint extra to keep the limit
+      return;
+    }
+
+    AtTransaction tx = new AtTransaction(TransactionType.ColoredCoins.ASSET_MINT,
+      state.getId(), null, 0L, assetId, quantity, null);
+    state.addTransaction(tx);
+
+    state.setgBalance(assetId, state.getgBalance(assetId) + quantity);
+  }
+
+  @Override
+  public void distToHolders(AtMachineState state) {
+    if (state.getVersion() < 3) {
+      return;
+    }
+
+    long minHolding = AtApiHelper.getLong(state.getB1());
+    long assetId = AtApiHelper.getLong(state.getB2());
+
+    long amount = Math.max(0L, AtApiHelper.getLong(state.getA1()));
+    long assetToDistribute = AtApiHelper.getLong(state.getA3());
+    long quantityToDistribute = 0L;
+
+    Asset asset = Signum.getStores().getAssetStore().getAsset(assetId);
+    if (asset == null) {
+      // asset not found, do nothing
+      return;
+    }
+
+    int maxIndirects = Signum.getPropertyService().getInt(Props.MAX_INDIRECTS_PER_BLOCK);
+    boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, state.getHeight());
+    int holdersCount = Signum.getAssetExchange().getAssetAccountsCount(asset, minHolding, true, unconfirmed);
+    if (holdersCount == 0 || state.getIndirectsCount() + holdersCount > maxIndirects) {
+      // no holders to distribute or over the maximum, so do not distribute
+      return;
+    }
+    state.addIndirectsCount(holdersCount);
+
+    if (assetToDistribute != 0) {
+      quantityToDistribute = Math.max(0L, AtApiHelper.getLong(state.getA4()));
+      if (quantityToDistribute > state.getgBalance(assetToDistribute)) {
+        quantityToDistribute = state.getgBalance(assetToDistribute);
+      }
+      state.setgBalance(assetToDistribute, state.getgBalance(assetToDistribute) - quantityToDistribute);
+    }
+    if (amount > state.getgBalance()) {
+      amount = state.getgBalance();
+    }
+    state.setgBalance(state.getgBalance() - amount);
+
+    if (amount == 0L && quantityToDistribute == 0L) {
+      // nothing to actually distribute
+      return;
+    }
+
+    AtTransaction tx = new AtTransaction(TransactionType.ColoredCoins.ASSET_DISTRIBUTE_TO_HOLDERS,
+      state.getId(), null, amount, assetId, quantityToDistribute, assetToDistribute, minHolding, null);
+    state.addTransaction(tx);
+  }
+
+  @Override
+  public long getAssetHoldersCount(AtMachineState state) {
+    if (state.getVersion() < 3) {
+      return 0L;
+    }
+
+    long minHolding = AtApiHelper.getLong(state.getB1());
+    long assetId = AtApiHelper.getLong(state.getB2());
+
+    Asset asset = Signum.getStores().getAssetStore().getAsset(assetId);
+    if (asset == null) {
+      // asset not found, no holders
+      return 0L;
+    }
+
+    boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, state.getHeight());
+    return Signum.getAssetExchange().getAssetAccountsCount(asset, minHolding, true, unconfirmed);
+  }
+
+  @Override
+  public long getAssetCirculating(AtMachineState state) {
+    if (state.getVersion() < 3) {
+      return 0L;
+    }
+
+    long assetId = AtApiHelper.getLong(state.getB2());
+
+    Asset asset = Signum.getStores().getAssetStore().getAsset(assetId);
+    if (asset == null) {
+      // asset not found, no supply
+      return 0L;
+    }
+
+    boolean unconfirmed = !Signum.getFluxCapacitor().getValue(FluxValues.DISTRIBUTION_FIX, state.getHeight());
+    return Signum.getAssetExchange().getAssetCirculatingSupply(asset, true, unconfirmed);
+  }
+
+  @Override
+  public long issueAsset(AtMachineState state) {
+    if (state.getVersion() < 3) {
+      return 0;
+    }
+
+    ByteBuffer b = ByteBuffer.allocate(32);
+    b.order(ByteOrder.LITTLE_ENDIAN);
+    b.put(state.getA1());
+    b.put(state.getA2());
+    b.put(state.getA3());
+    b.put(state.getA4());
+    b.clear();
+
+    long decimals = AtApiHelper.getLong(state.getB1());
+
+    AtTransaction tx = new AtTransaction(TransactionType.ColoredCoins.ASSET_ISSUANCE, state.getId(), null, 0L, 0L, decimals, b.array());
+    state.addTransaction(tx);
+
+    return tx.getAssetId();
+  }
+
+  @Override
+  public void sendAllToAddressInB(AtMachineState state) {
+    AtTransaction tx = new AtTransaction(TransactionType.AutomatedTransactions.AT_PAYMENT, state.getId(), state.getB1().clone(), state.getgBalance(), null);
+    state.addTransaction(tx);
+    state.setgBalance(0L);
+  }
+
+  @Override
+  public void sendOldToAddressInB(AtMachineState state) {
+    if (state.getpBalance() > state.getgBalance()) {
+      AtTransaction tx = new AtTransaction(TransactionType.AutomatedTransactions.AT_PAYMENT, state.getId(), state.getB1(), state.getgBalance(), null);
+      state.addTransaction(tx);
+
+      state.setgBalance(0L);
+      state.setpBalance(0L);
+    } else {
+      AtTransaction tx = new AtTransaction(TransactionType.AutomatedTransactions.AT_PAYMENT, state.getId(), state.getB1(), state.getpBalance(), null);
+      state.addTransaction(tx);
+
+      state.setgBalance(state.getgBalance() - state.getpBalance());
+      state.setpBalance(0L);
+    }
+  }
+
+  @Override
+  public void sendAToAddressInB(AtMachineState state) {
+    ByteBuffer b = ByteBuffer.allocate(32);
+    b.order(ByteOrder.LITTLE_ENDIAN);
+    b.put(state.getA1());
+    b.put(state.getA2());
+    b.put(state.getA3());
+    b.put(state.getA4());
+    b.clear();
+
+    AtTransaction tx = new AtTransaction(TransactionType.AutomatedTransactions.AT_PAYMENT, state.getId(), state.getB1(), 0L, 0L, 0L, b.array());
+    state.addTransaction(tx);
+  }
+
+  @Override
+  public long addMinutesToTimestamp(long val1, long val2, AtMachineState state) {
+    int height = AtApiHelper.longToHeight(val1);
+    int numOfTx = AtApiHelper.longToNumOfTx(val1);
+    int addHeight = height + (int) (val2 / AtConstants.getInstance().averageBlockMinutes(state.getHeight()));
+
+    return AtApiHelper.getLongTimestamp(addHeight, numOfTx);
+  }
 }

--- a/src/brs/at/AtController.java
+++ b/src/brs/at/AtController.java
@@ -17,267 +17,267 @@ import java.security.MessageDigest;
 import java.util.*;
 
 public abstract class AtController {
-    private AtController() {
-    }
+  private AtController() {
+  }
 
-    private static final Logger logger = LoggerFactory.getLogger(AtController.class);
+  private static final Logger logger = LoggerFactory.getLogger(AtController.class);
 
-    private static final Logger debugLogger = Signum.getPropertyService().getBoolean(Props.ENABLE_AT_DEBUG_LOG) ? logger : NOPLogger.NOP_LOGGER;
+  private static final Logger debugLogger = Signum.getPropertyService().getBoolean(Props.ENABLE_AT_DEBUG_LOG) ? logger : NOPLogger.NOP_LOGGER;
 
-    private static int runSteps(AtMachineState state) {
-        state.getMachineState().running = true;
-        state.getMachineState().stopped = false;
-        state.getMachineState().finished = false;
-        state.getMachineState().dead = false;
-        state.getMachineState().steps = 0;
+  private static int runSteps(AtMachineState state) {
+    state.getMachineState().running = true;
+    state.getMachineState().stopped = false;
+    state.getMachineState().finished = false;
+    state.getMachineState().dead = false;
+    state.getMachineState().steps = 0;
 
-        AtMachineProcessor processor = new AtMachineProcessor(state, Signum.getPropertyService().getBoolean(Props.ENABLE_AT_DEBUG_LOG));
+    AtMachineProcessor processor = new AtMachineProcessor(state, Signum.getPropertyService().getBoolean(Props.ENABLE_AT_DEBUG_LOG));
 
-        state.setFreeze(false);
+    state.setFreeze(false);
 
-        long stepFee = AtConstants.getInstance().stepFee(state.getVersion());
+    long stepFee = AtConstants.getInstance().stepFee(state.getVersion());
 
-        int numSteps = 0;
+    int numSteps = 0;
 
-        while (state.getMachineState().steps +
-                (numSteps = processor.getNumSteps(state.getApCode().get(state.getMachineState().pc), state.getIndirectsCount()))
-                <= AtConstants.getInstance().maxSteps(state.getHeight())) {
+    while (state.getMachineState().steps +
+      (numSteps = processor.getNumSteps(state.getApCode().get(state.getMachineState().pc), state.getIndirectsCount()))
+      <= AtConstants.getInstance().maxSteps(state.getHeight())) {
 
-            if ((state.getgBalance() < stepFee * numSteps)) {
-                debugLogger.debug("stopped - not enough balance");
-                state.setFreeze(true);
-                return 3;
-            }
+      if ((state.getgBalance() < stepFee * numSteps)) {
+        debugLogger.debug("stopped - not enough balance");
+        state.setFreeze(true);
+        return 3;
+      }
 
-            state.setgBalance(state.getgBalance() - (stepFee * numSteps));
-            state.getMachineState().steps += numSteps;
-            int rc = processor.processOp(false, false);
+      state.setgBalance(state.getgBalance() - (stepFee * numSteps));
+      state.getMachineState().steps += numSteps;
+      int rc = processor.processOp(false, false);
 
-            if (rc >= 0) {
-                if (state.getMachineState().stopped) {
-                    debugLogger.debug("stopped");
-                    state.getMachineState().running = false;
-                    return 2;
-                } else if (state.getMachineState().finished) {
-                    debugLogger.debug("finished");
-                    state.getMachineState().running = false;
-                    return 1;
-                }
-            } else {
-                if (rc == -1)
-                    debugLogger.debug("error: overflow");
-                else if (rc == -2)
-                    debugLogger.debug("error: invalid code");
-                else
-                    debugLogger.debug("unexpected error");
-
-                if (state.getMachineState().jumps.contains(state.getMachineState().err)) {
-                    state.getMachineState().pc = state.getMachineState().err;
-                } else {
-                    state.getMachineState().dead = true;
-                    state.getMachineState().running = false;
-                    return 0;
-                }
-            }
+      if (rc >= 0) {
+        if (state.getMachineState().stopped) {
+          debugLogger.debug("stopped");
+          state.getMachineState().running = false;
+          return 2;
+        } else if (state.getMachineState().finished) {
+          debugLogger.debug("finished");
+          state.getMachineState().running = false;
+          return 1;
         }
+      } else {
+        if (rc == -1)
+          debugLogger.debug("error: overflow");
+        else if (rc == -2)
+          debugLogger.debug("error: invalid code");
+        else
+          debugLogger.debug("unexpected error");
 
-        return 5;
-    }
-
-    public static void resetMachine(AtMachineState state) {
-        state.getMachineState().reset();
-        listCode(state, true, true);
-    }
-
-    private static void listCode(AtMachineState state, boolean disassembly, boolean determineJumps) {
-
-        AtMachineProcessor machineProcessor = new AtMachineProcessor(state, Signum.getPropertyService().getBoolean(Props.ENABLE_AT_DEBUG_LOG));
-
-        int opc = state.getMachineState().pc;
-        int osteps = state.getMachineState().steps;
-
-        state.getApCode().order(ByteOrder.LITTLE_ENDIAN);
-        state.getApData().order(ByteOrder.LITTLE_ENDIAN);
-
-        state.getMachineState().pc = 0;
-        state.getMachineState().opc = opc;
-
-        while (true) {
-
-            int rc = machineProcessor.processOp(disassembly, determineJumps);
-            if (rc <= 0) break;
-
-            state.getMachineState().pc += rc;
-        }
-
-        state.getMachineState().steps = osteps;
-        state.getMachineState().pc = opc;
-    }
-
-    public static int checkCreationBytes(byte[] creation, int height, int minCodePages) throws AtException {
-        if (creation == null)
-            throw new AtException("Creation bytes cannot be null");
-
-        int totalPages;
-        try {
-            ByteBuffer b = ByteBuffer.allocate(creation.length);
-            b.order(ByteOrder.LITTLE_ENDIAN);
-
-            b.put(creation);
-            b.clear();
-
-            AtConstants instance = AtConstants.getInstance();
-
-            short version = b.getShort();
-            if (version > instance.atVersion(height)) {
-                throw new AtException(AtError.INCORRECT_VERSION.getDescription());
-            }
-
-            // Ignore reserved bytes
-            b.getShort(); //future: reserved for future needs
-
-            short codePages = b.getShort();
-            if (codePages > instance.maxMachineCodePages(version) || codePages < minCodePages) {
-                throw new AtException(AtError.INCORRECT_CODE_PAGES.getDescription());
-            }
-
-            short dataPages = b.getShort();
-            if (dataPages > instance.maxMachineDataPages(version) || dataPages < 0) {
-                throw new AtException(AtError.INCORRECT_DATA_PAGES.getDescription());
-            }
-
-            short callStackPages = b.getShort();
-            if (callStackPages > instance.maxMachineCallStackPages(version) || callStackPages < 0) {
-                throw new AtException(AtError.INCORRECT_CALL_PAGES.getDescription());
-            }
-
-            short userStackPages = b.getShort();
-            if (userStackPages > instance.maxMachineUserStackPages(version) || userStackPages < 0) {
-                throw new AtException(AtError.INCORRECT_USER_PAGES.getDescription());
-            }
-
-            // Ignore the minimum activation amount
-            b.getLong();
-
-            int codeLen = getLength(codePages, b);
-            if (codeLen == 0 && codePages == 1 && version > 2) {
-                codeLen = 256;
-            }
-            if (codeLen < minCodePages || codeLen > codePages * 256) {
-                throw new AtException(AtError.INCORRECT_CODE_LENGTH.getDescription());
-            }
-            byte[] code = new byte[codeLen];
-            b.get(code, 0, codeLen);
-
-            int dataLen = getLength(dataPages, b);
-            if (dataLen == 0 && dataPages == 1 && b.capacity() - b.position() == 256 && version > 2) {
-                dataLen = 256;
-            }
-            if (dataLen < 0 || dataLen > dataPages * 256) {
-                throw new AtException(AtError.INCORRECT_DATA_LENGTH.getDescription());
-            }
-            byte[] data = new byte[dataLen];
-            b.get(data, 0, dataLen);
-
-            totalPages = codePages + dataPages + userStackPages + callStackPages;
-
-            if (b.position() != b.capacity()) {
-                throw new AtException(AtError.INCORRECT_CREATION_TX.getDescription());
-            }
-
-            //TODO note: run code in demo mode for checking if is valid
-
-        } catch (BufferUnderflowException e) {
-            throw new AtException(AtError.INCORRECT_CREATION_TX.getDescription());
-        }
-
-        return totalPages;
-    }
-
-    private static int getLength(int nPages, ByteBuffer buffer) throws AtException {
-        int codeLen;
-        if (nPages * 256 < 257) {
-            codeLen = buffer.get();
-            if (codeLen < 0)
-                codeLen += (Byte.MAX_VALUE + 1) * 2;
-        } else if (nPages * 256 < Short.MAX_VALUE + 1) {
-            codeLen = buffer.getShort();
-            if (codeLen < 0)
-                codeLen += (Short.MAX_VALUE + 1) * 2;
-        } else if (nPages * 256 <= Integer.MAX_VALUE) {
-            codeLen = buffer.getInt();
+        if (state.getMachineState().jumps.contains(state.getMachineState().err)) {
+          state.getMachineState().pc = state.getMachineState().err;
         } else {
-            throw new AtException(AtError.INCORRECT_CODE_LENGTH.getDescription());
+          state.getMachineState().dead = true;
+          state.getMachineState().running = false;
+          return 0;
         }
-        return codeLen;
+      }
     }
 
-    public static AtBlock getCurrentBlockATs(int freePayload, int blockHeight, long generatorId, int indirectsCount) {
-        List<Long> orderedATs = AT.getOrderedATs();
-        Iterator<Long> keys = orderedATs.iterator();
+    return 5;
+  }
 
-        List<AT> processedATs = new ArrayList<>();
+  public static void resetMachine(AtMachineState state) {
+    state.getMachineState().reset();
+    listCode(state, true, true);
+  }
 
-        int costOfOneAT = getCostOfOneAT();
-        int payload = 0;
-        long totalFee = 0;
-        long totalAmount = 0;
+  private static void listCode(AtMachineState state, boolean disassembly, boolean determineJumps) {
 
-        while (payload <= freePayload - costOfOneAT && keys.hasNext()) {
-            Long id = keys.next();
-            AT at = AT.getAT(id);
-            at.addIndirectsCount(indirectsCount);
+    AtMachineProcessor machineProcessor = new AtMachineProcessor(state, Signum.getPropertyService().getBoolean(Props.ENABLE_AT_DEBUG_LOG));
 
-            long atAccountBalance = getATAccountBalance(id);
-            long atStateBalance = at.getgBalance();
+    int opc = state.getMachineState().pc;
+    int osteps = state.getMachineState().steps;
 
-            if (at.freezeOnSameBalance() && (atAccountBalance - atStateBalance < at.minActivationAmount())) {
-                continue;
-            }
+    state.getApCode().order(ByteOrder.LITTLE_ENDIAN);
+    state.getApData().order(ByteOrder.LITTLE_ENDIAN);
 
-            if (atAccountBalance >= AtConstants.getInstance().stepFee(at.getVersion())
-                    * AtConstants.getInstance().apiStepMultiplier(at.getVersion())) {
-                try {
-                    at.setgBalance(atAccountBalance);
-                    at.setHeight(blockHeight);
-                    at.clearLists();
-                    at.setWaitForNumberOfBlocks(at.getSleepBetween());
-                    listCode(at, true, true);
-                    runSteps(at);
-                    indirectsCount = at.getIndirectsCount();
+    state.getMachineState().pc = 0;
+    state.getMachineState().opc = opc;
 
-                    long fee = at.getMachineState().steps * AtConstants.getInstance().stepFee(at.getVersion());
-                    if (at.getMachineState().dead) {
-                        fee += at.getgBalance();
-                        at.setgBalance(0L);
-                    }
-                    at.setpBalance(at.getgBalance());
+    while (true) {
 
-                    long amount = makeTransactions(at, blockHeight, generatorId);
-                    if (!Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_4, blockHeight)) {
-                        totalAmount = amount;
-                    } else {
-                        totalAmount += amount;
-                    }
+      int rc = machineProcessor.processOp(disassembly, determineJumps);
+      if (rc <= 0) break;
 
-                    totalFee += fee;
-                    AT.addPendingFee(id, fee, blockHeight, generatorId);
-
-                    payload += costOfOneAT;
-
-                    processedATs.add(at);
-                } catch (Exception e) {
-                    debugLogger.debug("Error handling AT", e);
-                }
-            }
-        }
-
-        byte[] bytesForBlock;
-
-        bytesForBlock = getBlockATBytes(processedATs, payload);
-
-        return new AtBlock(totalFee, totalAmount, bytesForBlock);
+      state.getMachineState().pc += rc;
     }
+
+    state.getMachineState().steps = osteps;
+    state.getMachineState().pc = opc;
+  }
+
+  public static int checkCreationBytes(byte[] creation, int height, int minCodePages) throws AtException {
+    if (creation == null)
+      throw new AtException("Creation bytes cannot be null");
+
+    int totalPages;
+    try {
+      ByteBuffer b = ByteBuffer.allocate(creation.length);
+      b.order(ByteOrder.LITTLE_ENDIAN);
+
+      b.put(creation);
+      b.clear();
+
+      AtConstants instance = AtConstants.getInstance();
+
+      short version = b.getShort();
+      if (version > instance.atVersion(height)) {
+        throw new AtException(AtError.INCORRECT_VERSION.getDescription());
+      }
+
+      // Ignore reserved bytes
+      b.getShort(); //future: reserved for future needs
+
+      short codePages = b.getShort();
+      if (codePages > instance.maxMachineCodePages(version) || codePages < minCodePages) {
+        throw new AtException(AtError.INCORRECT_CODE_PAGES.getDescription());
+      }
+
+      short dataPages = b.getShort();
+      if (dataPages > instance.maxMachineDataPages(version) || dataPages < 0) {
+        throw new AtException(AtError.INCORRECT_DATA_PAGES.getDescription());
+      }
+
+      short callStackPages = b.getShort();
+      if (callStackPages > instance.maxMachineCallStackPages(version) || callStackPages < 0) {
+        throw new AtException(AtError.INCORRECT_CALL_PAGES.getDescription());
+      }
+
+      short userStackPages = b.getShort();
+      if (userStackPages > instance.maxMachineUserStackPages(version) || userStackPages < 0) {
+        throw new AtException(AtError.INCORRECT_USER_PAGES.getDescription());
+      }
+
+      // Ignore the minimum activation amount
+      b.getLong();
+
+      int codeLen = getLength(codePages, b);
+      if (codeLen == 0 && codePages == 1 && version > 2) {
+        codeLen = 256;
+      }
+      if (codeLen < minCodePages || codeLen > codePages * 256) {
+        throw new AtException(AtError.INCORRECT_CODE_LENGTH.getDescription());
+      }
+      byte[] code = new byte[codeLen];
+      b.get(code, 0, codeLen);
+
+      int dataLen = getLength(dataPages, b);
+      if (dataLen == 0 && dataPages == 1 && b.capacity() - b.position() == 256 && version > 2) {
+        dataLen = 256;
+      }
+      if (dataLen < 0 || dataLen > dataPages * 256) {
+        throw new AtException(AtError.INCORRECT_DATA_LENGTH.getDescription());
+      }
+      byte[] data = new byte[dataLen];
+      b.get(data, 0, dataLen);
+
+      totalPages = codePages + dataPages + userStackPages + callStackPages;
+
+      if (b.position() != b.capacity()) {
+        throw new AtException(AtError.INCORRECT_CREATION_TX.getDescription());
+      }
+
+      //TODO note: run code in demo mode for checking if is valid
+
+    } catch (BufferUnderflowException e) {
+      throw new AtException(AtError.INCORRECT_CREATION_TX.getDescription());
+    }
+
+    return totalPages;
+  }
+
+  private static int getLength(int nPages, ByteBuffer buffer) throws AtException {
+    int codeLen;
+    if (nPages * 256 < 257) {
+      codeLen = buffer.get();
+      if (codeLen < 0)
+        codeLen += (Byte.MAX_VALUE + 1) * 2;
+    } else if (nPages * 256 < Short.MAX_VALUE + 1) {
+      codeLen = buffer.getShort();
+      if (codeLen < 0)
+        codeLen += (Short.MAX_VALUE + 1) * 2;
+    } else if (nPages * 256 <= Integer.MAX_VALUE) {
+      codeLen = buffer.getInt();
+    } else {
+      throw new AtException(AtError.INCORRECT_CODE_LENGTH.getDescription());
+    }
+    return codeLen;
+  }
+
+  public static AtBlock getCurrentBlockATs(int freePayload, int blockHeight, long generatorId, int indirectsCount) {
+    List<Long> orderedATs = AT.getOrderedATs();
+    Iterator<Long> keys = orderedATs.iterator();
+
+    List<AT> processedATs = new ArrayList<>();
+
+    int costOfOneAT = getCostOfOneAT();
+    int payload = 0;
+    long totalFee = 0;
+    long totalAmount = 0;
+
+    while (payload <= freePayload - costOfOneAT && keys.hasNext()) {
+      Long id = keys.next();
+      AT at = AT.getAT(id);
+      at.addIndirectsCount(indirectsCount);
+
+      long atAccountBalance = getATAccountBalance(id);
+      long atStateBalance = at.getgBalance();
+
+      if (at.freezeOnSameBalance() && (atAccountBalance - atStateBalance < at.minActivationAmount())) {
+        continue;
+      }
+
+      if (atAccountBalance >= AtConstants.getInstance().stepFee(at.getVersion())
+        * AtConstants.getInstance().apiStepMultiplier(at.getVersion())) {
+        try {
+          at.setgBalance(atAccountBalance);
+          at.setHeight(blockHeight);
+          at.clearLists();
+          at.setWaitForNumberOfBlocks(at.getSleepBetween());
+          listCode(at, true, true);
+          runSteps(at);
+          indirectsCount = at.getIndirectsCount();
+
+          long fee = at.getMachineState().steps * AtConstants.getInstance().stepFee(at.getVersion());
+          if (at.getMachineState().dead) {
+            fee += at.getgBalance();
+            at.setgBalance(0L);
+          }
+          at.setpBalance(at.getgBalance());
+
+          long amount = makeTransactions(at, blockHeight, generatorId);
+          if (!Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_4, blockHeight)) {
+            totalAmount = amount;
+          } else {
+            totalAmount += amount;
+          }
+
+          totalFee += fee;
+          AT.addPendingFee(id, fee, blockHeight, generatorId);
+
+          payload += costOfOneAT;
+
+          processedATs.add(at);
+        } catch (Exception e) {
+          debugLogger.debug("Error handling AT", e);
+        }
+      }
+    }
+
+    byte[] bytesForBlock;
+
+    bytesForBlock = getBlockATBytes(processedATs, payload);
+
+    return new AtBlock(totalFee, totalAmount, bytesForBlock);
+  }
 
   //##### TODO:
   //    1. Gather all ats first
@@ -286,192 +286,193 @@ public abstract class AtController {
   //    4. Instead of SqlATStore in findTransaction, use a CachedATStore
 
 
-    public static AtBlock validateATsOriginal(byte[] blockATs, int blockHeight, long generatorId) throws AtException {
-        if (blockATs == null) {
-            return new AtBlock(0, 0, null);
-        }
-
-        LinkedHashMap<Long, byte[]> ats = getATsFromBlock(blockATs);
-        // TODO: here is a point where we could load all the required ATs, as we know their ids already.... or even before.
-        List<AT> processedATs = new ArrayList<>();
-
-        long totalFee = 0;
-        MessageDigest digest = Crypto.md5();
-        byte[] md5;
-        long totalAmount = 0;
-
-        for (Map.Entry<Long, byte[]> entry : ats.entrySet()) {
-            long atIdLong = entry.getKey();
-            byte[] receivedMd5 = entry.getValue();
-            // TODO: see if we can prefetch the AT -> we know this all before... reduce DB access as much as a possible
-            AT at = AT.getAT(atIdLong);
-            logger.debug("Running AT {}", Convert.toUnsignedLong(atIdLong));
-            try {
-                at.clearLists();
-                at.setHeight(blockHeight);
-                at.setWaitForNumberOfBlocks(at.getSleepBetween());
-
-                long atAccountBalance = getATAccountBalance(atIdLong);
-                if (atAccountBalance < AtConstants.getInstance().stepFee(at.getVersion())
-                        * AtConstants.getInstance().apiStepMultiplier(at.getVersion())) {
-                    throw new AtException("AT has insufficient balance to run");
-                }
-
-                if (at.freezeOnSameBalance() && (atAccountBalance - at.getgBalance() < at.minActivationAmount())) {
-                    throw new AtException("AT should be frozen due to unchanged balance");
-                }
-
-                if (at.nextHeight() > blockHeight) {
-                    throw new AtException("AT not allowed to run again yet");
-                }
-
-                at.setgBalance(atAccountBalance);
-
-                listCode(at, true, true);
-
-                runSteps(at);
-
-                long fee = at.getMachineState().steps * AtConstants.getInstance().stepFee(at.getVersion());
-                if (at.getMachineState().dead) {
-                    fee += at.getgBalance();
-                    at.setgBalance(0L);
-                }
-                at.setpBalance(at.getgBalance());
-
-                if (!Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_4, blockHeight)) {
-                    totalAmount = makeTransactions(at, blockHeight, generatorId);
-                } else {
-                    totalAmount += makeTransactions(at, blockHeight, generatorId);
-                }
-
-                totalFee += fee;
-                AT.addPendingFee(atIdLong, fee, blockHeight, generatorId);
-
-                processedATs.add(at);
-
-                md5 = digest.digest(at.getBytes());
-                if (!Arrays.equals(md5, receivedMd5)) {
-                    logger.error("MD5 mismatch for AT {}", Convert.toUnsignedLong(atIdLong));
-                    throw new AtException("Calculated md5 and received md5 are not matching");
-                }
-            } catch (Exception e) {
-                debugLogger.debug("ATs error", e);
-                throw new AtException("ATs error. Block rejected", e);
-            }
-            logger.debug("Finished running AT {}", Convert.toUnsignedLong(atIdLong));
-        }
-
-        for (AT at : processedATs) {
-            at.saveState();
-        }
-        AT.saveMapUpdates(blockHeight, generatorId);
-        return new AtBlock(totalFee, totalAmount, new byte[1]);
+  public static AtBlock validateATsOriginal(byte[] blockATs, int blockHeight, long generatorId) throws AtException {
+    if (blockATs == null) {
+      return new AtBlock(0, 0, null);
     }
 
+    LinkedHashMap<Long, byte[]> ats = getATsFromBlock(blockATs);
+    List<AT> processedATs = new ArrayList<>();
 
-    public static AtBlock validateATs(byte[] blockATs, int blockHeight, long generatorId) throws AtException {
-        if (blockATs == null) {
-            return new AtBlock(0, 0, null);
-        }
-        LinkedHashMap<Long, ATProcessorCache.ATContext> atMap = ATProcessorCache.getInstance().load(blockATs, blockHeight);
-        List<AT> processedATs = new ArrayList<>();
+    long totalFee = 0;
+    MessageDigest digest = Crypto.md5();
+    byte[] md5;
+    long totalAmount = 0;
 
-        long totalFee = 0;
-        MessageDigest digest = Crypto.md5();
-        byte[] md5;
-        long totalAmount = 0;
+    for (Map.Entry<Long, byte[]> entry : ats.entrySet()) {
+      long atIdLong = entry.getKey();
+      byte[] receivedMd5 = entry.getValue();
+      AT at = AT.getAT(atIdLong);
+      logger.debug("Running AT {}", Convert.toUnsignedLong(atIdLong));
+      try {
+        at.clearLists();
+        at.setHeight(blockHeight);
+        at.setWaitForNumberOfBlocks(at.getSleepBetween());
 
-        for (Map.Entry<Long, ATProcessorCache.ATContext> entry : atMap.entrySet()) {
-            long atIdLong = entry.getKey();
-            ATProcessorCache.ATContext atContext = entry.getValue();
-            byte[] receivedMd5 = atContext.md5;
-            AT at = atContext.at;
-            logger.debug("Running AT {}", Convert.toUnsignedLong(atIdLong));
-            try {
-                at.clearLists();
-                at.setHeight(blockHeight);
-                at.setWaitForNumberOfBlocks(at.getSleepBetween());
-
-                long atAccountBalance = getATAccountBalance(atIdLong);
-                if (atAccountBalance < AtConstants.getInstance().stepFee(at.getVersion())
-                        * AtConstants.getInstance().apiStepMultiplier(at.getVersion())) {
-                    throw new AtException("AT has insufficient balance to run");
-                }
-
-                if (at.freezeOnSameBalance() && (atAccountBalance - at.getgBalance() < at.minActivationAmount())) {
-                    throw new AtException("AT should be frozen due to unchanged balance");
-                }
-
-                if (at.nextHeight() > blockHeight) {
-                    throw new AtException("AT not allowed to run again yet");
-                }
-
-                at.setgBalance(atAccountBalance);
-
-                listCode(at, true, true);
-
-                runSteps(at);
-
-                long fee = at.getMachineState().steps * AtConstants.getInstance().stepFee(at.getVersion());
-                if (at.getMachineState().dead) {
-                    fee += at.getgBalance();
-                    at.setgBalance(0L);
-                }
-                at.setpBalance(at.getgBalance());
-
-                if (!Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_4, blockHeight)) {
-                    totalAmount = makeTransactions(at, blockHeight, generatorId);
-                } else {
-                    totalAmount += makeTransactions(at, blockHeight, generatorId);
-                }
-
-                totalFee += fee;
-                AT.addPendingFee(atIdLong, fee, blockHeight, generatorId);
-
-                processedATs.add(at);
-
-                md5 = digest.digest(at.getBytes());
-                if (!Arrays.equals(md5, receivedMd5)) {
-                    logger.error("MD5 mismatch for AT {}", Convert.toUnsignedLong(atIdLong));
-                    throw new AtException("Calculated md5 and received md5 are not matching");
-                }
-            } catch (Exception e) {
-                debugLogger.debug("ATs error", e);
-                throw new AtException("ATs error. Block rejected", e);
-            }
-            logger.debug("Finished running AT {}", Convert.toUnsignedLong(atIdLong));
+        long atAccountBalance = getATAccountBalance(atIdLong);
+        if (atAccountBalance < AtConstants.getInstance().stepFee(at.getVersion())
+          * AtConstants.getInstance().apiStepMultiplier(at.getVersion())) {
+          throw new AtException("AT has insufficient balance to run");
         }
 
-        processedATs.forEach(AT::saveState);
-        AT.saveMapUpdates(blockHeight, generatorId);
-        ATProcessorCache.getInstance().reset();
-        return new AtBlock(totalFee, totalAmount, new byte[1]);
+        if (at.freezeOnSameBalance() && (atAccountBalance - at.getgBalance() < at.minActivationAmount())) {
+          throw new AtException("AT should be frozen due to unchanged balance");
+        }
+
+        if (at.nextHeight() > blockHeight) {
+          throw new AtException("AT not allowed to run again yet");
+        }
+
+        at.setgBalance(atAccountBalance);
+
+        listCode(at, true, true);
+
+        runSteps(at);
+
+        long fee = at.getMachineState().steps * AtConstants.getInstance().stepFee(at.getVersion());
+        if (at.getMachineState().dead) {
+          fee += at.getgBalance();
+          at.setgBalance(0L);
+        }
+        at.setpBalance(at.getgBalance());
+
+        if (!Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_4, blockHeight)) {
+          totalAmount = makeTransactions(at, blockHeight, generatorId);
+        } else {
+          totalAmount += makeTransactions(at, blockHeight, generatorId);
+        }
+
+        totalFee += fee;
+        AT.addPendingFee(atIdLong, fee, blockHeight, generatorId);
+
+        processedATs.add(at);
+
+        md5 = digest.digest(at.getBytes());
+        if (!Arrays.equals(md5, receivedMd5)) {
+          logger.error("MD5 mismatch for AT {}", Convert.toUnsignedLong(atIdLong));
+          throw new AtException("Calculated md5 and received md5 are not matching");
+        }
+      } catch (Exception e) {
+        debugLogger.debug("ATs error", e);
+        throw new AtException("ATs error. Block rejected", e);
+      }
+      logger.debug("Finished running AT {}", Convert.toUnsignedLong(atIdLong));
     }
 
-    private static LinkedHashMap<Long, byte[]> getATsFromBlock(byte[] blockATs) throws AtException {
-        if (blockATs.length > 0 && blockATs.length % (getCostOfOneAT()) != 0) {
-            throw new AtException("blockATs must be a multiple of cost of one AT ( " + getCostOfOneAT() + " )");
+    for (AT at : processedATs) {
+      at.saveState();
+    }
+    AT.saveMapUpdates(blockHeight, generatorId);
+    return new AtBlock(totalFee, totalAmount, new byte[1]);
+  }
+
+
+  public static AtBlock validateATs(byte[] blockATs, int blockHeight, long generatorId) throws AtException {
+    if (blockATs == null) {
+      return new AtBlock(0, 0, null);
+    }
+    ATProcessorCache atProcessorCache = ATProcessorCache.getInstance();
+    atProcessorCache.loadBlock(blockATs, blockHeight);
+    List<AT> processedATs = new ArrayList<>();
+    long totalFee = 0;
+    MessageDigest digest = Crypto.md5();
+    byte[] md5;
+    long totalAmount = 0;
+
+    for(Long atIdLong: atProcessorCache.getCurrentBlockAtIds() ){
+      ATProcessorCache.ATContext atContext = atProcessorCache.getATContext(atIdLong);
+      if(atContext==null){
+        continue;
+      }
+
+      AT at = atContext.at;
+      byte[] receivedMd5 = atContext.md5;
+
+      logger.debug("Running AT {}", Convert.toUnsignedLong(atIdLong));
+      try {
+        at.clearLists();
+        at.setHeight(blockHeight);
+        at.setWaitForNumberOfBlocks(at.getSleepBetween());
+
+        long atAccountBalance = getATAccountBalance(atIdLong);
+        if (atAccountBalance < AtConstants.getInstance().stepFee(at.getVersion())
+          * AtConstants.getInstance().apiStepMultiplier(at.getVersion())) {
+          throw new AtException("AT has insufficient balance to run");
         }
 
-        ByteBuffer b = ByteBuffer.wrap(blockATs);
-        b.order(ByteOrder.LITTLE_ENDIAN);
-
-        byte[] temp = new byte[AtConstants.AT_ID_SIZE];
-
-        LinkedHashMap<Long, byte[]> ats = new LinkedHashMap<>();
-
-      byte[] atId = new byte[AtConstants.AT_ID_SIZE];
-      byte[] md5 = new byte[16];
-
-      while (b.remaining() >= AtConstants.AT_ID_SIZE + 16) {
-        b.get(atId);
-        b.get(md5);
-        long atIdLong = AtApiHelper.getLong(atId);
-        if (ats.containsKey(atIdLong)) {
-          throw new AtException("AT included in block multiple times");
+        if (at.freezeOnSameBalance() && (atAccountBalance - at.getgBalance() < at.minActivationAmount())) {
+          throw new AtException("AT should be frozen due to unchanged balance");
         }
 
-        ats.put(atIdLong, md5.clone());
+        if (at.nextHeight() > blockHeight) {
+          throw new AtException("AT not allowed to run again yet");
+        }
+
+        at.setgBalance(atAccountBalance);
+
+        listCode(at, true, true);
+
+        runSteps(at);
+
+        long fee = at.getMachineState().steps * AtConstants.getInstance().stepFee(at.getVersion());
+        if (at.getMachineState().dead) {
+          fee += at.getgBalance();
+          at.setgBalance(0L);
+        }
+        at.setpBalance(at.getgBalance());
+
+        if (!Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_4, blockHeight)) {
+          totalAmount = makeTransactions(at, blockHeight, generatorId);
+        } else {
+          totalAmount += makeTransactions(at, blockHeight, generatorId);
+        }
+
+        totalFee += fee;
+        AT.addPendingFee(atIdLong, fee, blockHeight, generatorId);
+
+        processedATs.add(at);
+
+        md5 = digest.digest(at.getBytes());
+        if (!Arrays.equals(md5, receivedMd5)) {
+          logger.error("MD5 mismatch for AT {}", Convert.toUnsignedLong(atIdLong));
+          throw new AtException("Calculated md5 and received md5 are not matching");
+        }
+      } catch (Exception e) {
+        debugLogger.debug("ATs error", e);
+        throw new AtException("ATs error. Block rejected", e);
+      }
+      logger.debug("Finished running AT {}", Convert.toUnsignedLong(atIdLong));
+    }
+
+    processedATs.forEach(AT::saveState);
+    AT.saveMapUpdates(blockHeight, generatorId);
+    return new AtBlock(totalFee, totalAmount, new byte[1]);
+  }
+
+  private static LinkedHashMap<Long, byte[]> getATsFromBlock(byte[] blockATs) throws AtException {
+    if (blockATs.length > 0 && blockATs.length % (getCostOfOneAT()) != 0) {
+      throw new AtException("blockATs must be a multiple of cost of one AT ( " + getCostOfOneAT() + " )");
+    }
+
+    ByteBuffer b = ByteBuffer.wrap(blockATs);
+    b.order(ByteOrder.LITTLE_ENDIAN);
+
+    byte[] temp = new byte[AtConstants.AT_ID_SIZE];
+
+    LinkedHashMap<Long, byte[]> ats = new LinkedHashMap<>();
+
+    byte[] atId = new byte[AtConstants.AT_ID_SIZE];
+    byte[] md5 = new byte[16];
+
+    while (b.remaining() >= AtConstants.AT_ID_SIZE + 16) {
+      b.get(atId);
+      b.get(md5);
+      long atIdLong = AtApiHelper.getLong(atId);
+      if (ats.containsKey(atIdLong)) {
+        throw new AtException("AT included in block multiple times");
+      }
+
+      ats.put(atIdLong, md5.clone());
 //        while (b.position() < b.capacity()) {
 //            b.get(temp, 0, temp.length);
 //            byte[] md5 = new byte[16];
@@ -483,68 +484,68 @@ public abstract class AtController {
 //                throw new AtException("AT included in block multiple times");
 //            }
 //            ats.put(atId, md5);
-        }
-
-        if (b.remaining() != 0) {
-            throw new AtException("bytebuffer not matching");
-        }
-
-        return ats;
     }
 
-    private static byte[] getBlockATBytes(List<AT> processedATs, int payload) {
-        if (payload <= 0) {
-            return null;
-        }
-
-        ByteBuffer b = ByteBuffer.allocate(payload);
-        b.order(ByteOrder.LITTLE_ENDIAN);
-
-        MessageDigest digest = Crypto.md5();
-        for (AT at : processedATs) {
-            b.put(at.getId());
-            digest.update(at.getBytes());
-            b.put(digest.digest());
-        }
-
-        return b.array();
+    if (b.remaining() != 0) {
+      throw new AtException("bytebuffer not matching");
     }
 
-    private static int getCostOfOneAT() {
-        return AtConstants.AT_ID_SIZE + 16;
+    return ats;
+  }
+
+  private static byte[] getBlockATBytes(List<AT> processedATs, int payload) {
+    if (payload <= 0) {
+      return null;
     }
 
-    //platform based implementations
-    //platform based
-    private static long makeTransactions(AT at, int blockHeight, long generatorId) throws AtException {
-        long totalAmount = 0;
-        if (!Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_4, at.getHeight())) {
-            for (AtTransaction tx : at.getTransactions()) {
-                if (AT.findPendingTransaction(tx.getRecipientId(), blockHeight, generatorId)) {
-                    throw new AtException("Conflicting transaction found");
-                }
-            }
-        }
-        for (AtTransaction tx : at.getTransactions()) {
-            totalAmount += tx.getAmount();
-            AT.addPendingTransaction(tx, blockHeight, generatorId);
-            if (logger.isDebugEnabled()) {
-                logger.debug("Transaction to {}, amount {}", tx.getRecipientId() == null ? 0L : Convert.toUnsignedLong(AtApiHelper.getLong(tx.getRecipientId())), tx.getAmount());
-            }
-        }
-        AT.addMapUpdates(at.getMapUpdates(), blockHeight, generatorId);
+    ByteBuffer b = ByteBuffer.allocate(payload);
+    b.order(ByteOrder.LITTLE_ENDIAN);
 
-        return totalAmount;
+    MessageDigest digest = Crypto.md5();
+    for (AT at : processedATs) {
+      b.put(at.getId());
+      digest.update(at.getBytes());
+      b.put(digest.digest());
     }
 
-    //platform based
-    private static long getATAccountBalance(Long id) {
-        Account.Balance atAccount = Account.getAccountBalance(id);
+    return b.array();
+  }
 
-        if (atAccount != null) {
-            return atAccount.getBalanceNqt();
+  private static int getCostOfOneAT() {
+    return AtConstants.AT_ID_SIZE + 16;
+  }
+
+  //platform based implementations
+  //platform based
+  private static long makeTransactions(AT at, int blockHeight, long generatorId) throws AtException {
+    long totalAmount = 0;
+    if (!Signum.getFluxCapacitor().getValue(FluxValues.AT_FIX_BLOCK_4, at.getHeight())) {
+      for (AtTransaction tx : at.getTransactions()) {
+        if (AT.findPendingTransaction(tx.getRecipientId(), blockHeight, generatorId)) {
+          throw new AtException("Conflicting transaction found");
         }
-
-        return 0;
+      }
     }
+    for (AtTransaction tx : at.getTransactions()) {
+      totalAmount += tx.getAmount();
+      AT.addPendingTransaction(tx, blockHeight, generatorId);
+      if (logger.isDebugEnabled()) {
+        logger.debug("Transaction to {}, amount {}", tx.getRecipientId() == null ? 0L : Convert.toUnsignedLong(AtApiHelper.getLong(tx.getRecipientId())), tx.getAmount());
+      }
+    }
+    AT.addMapUpdates(at.getMapUpdates(), blockHeight, generatorId);
+
+    return totalAmount;
+  }
+
+  //platform based
+  private static long getATAccountBalance(Long id) {
+    Account.Balance atAccount = Account.getAccountBalance(id);
+
+    if (atAccount != null) {
+      return atAccount.getBalanceNqt();
+    }
+
+    return 0;
+  }
 }

--- a/src/brs/db/sql/SqlATStore.java
+++ b/src/brs/db/sql/SqlATStore.java
@@ -1,13 +1,9 @@
 package brs.db.sql;
 
-import brs.Attachment;
-import brs.Signum;
+import brs.*;
 import brs.Transaction;
-import brs.at.AT;
+import brs.at.*;
 import brs.at.AT.AtMapEntry;
-import brs.at.AtApiHelper;
-import brs.at.AtConstants;
-import brs.at.AtMachineState;
 import brs.db.SignumKey;
 import brs.db.VersionedEntityTable;
 import brs.db.store.ATStore;
@@ -19,35 +15,37 @@ import brs.util.CollectionWithIndex;
 import org.jooq.*;
 import org.jooq.Record;
 import org.jooq.exception.DataAccessException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 
 import static brs.schema.Tables.*;
 
 public class SqlATStore implements ATStore {
+  private static final Logger logger = LoggerFactory.getLogger(SqlATStore.class);
 
   private final SignumKey.LongKeyFactory<brs.at.AT> atDbKeyFactory = new DbKey.LongKeyFactory<brs.at.AT>(AT.ID) {
-      @Override
-      public SignumKey newKey(brs.at.AT at) {
-        return at.dbKey;
-      }
-    };
+    @Override
+    public SignumKey newKey(brs.at.AT at) {
+      return at.dbKey;
+    }
+  };
   private final VersionedEntityTable<brs.at.AT> atTable;
 
   private final SignumKey.LongKeyFactory<brs.at.AT.ATState> atStateDbKeyFactory = new DbKey.LongKeyFactory<brs.at.AT.ATState>(AT_STATE.AT_ID) {
-      @Override
-      public SignumKey newKey(brs.at.AT.ATState atState) {
-        return atState.dbKey;
-      }
-    };
+    @Override
+    public SignumKey newKey(brs.at.AT.ATState atState) {
+      return atState.dbKey;
+    }
+  };
 
   private final VersionedEntityTable<brs.at.AT.ATState> atStateTable;
 
 
-  private final DbKey.LinkKey3Factory<brs.at.AT.AtMapEntry> atMapKeyFactory = new DbKey.LinkKey3Factory<brs.at.AT.AtMapEntry>("at_id", "key1", "key2"){
+  private final DbKey.LinkKey3Factory<brs.at.AT.AtMapEntry> atMapKeyFactory = new DbKey.LinkKey3Factory<brs.at.AT.AtMapEntry>("at_id", "key1", "key2") {
     @Override
     public SignumKey newKey(brs.at.AT.AtMapEntry atDb) {
       return newKey(atDb.getAtId(), atDb.getKey1(), atDb.getKey2());
@@ -55,6 +53,7 @@ public class SqlATStore implements ATStore {
   };
 
   private final VersionedEntityTable<brs.at.AT.AtMapEntry> atMapTable;
+
 
   public SqlATStore(DerivedTableManager derivedTableManager) {
     atTable = new VersionedEntitySqlTable<brs.at.AT>("at", brs.schema.Tables.AT, atDbKeyFactory, derivedTableManager) {
@@ -121,15 +120,15 @@ public class SqlATStore implements ATStore {
 
   private void saveATState(DSLContext ctx, brs.at.AT.ATState atState) {
     ctx.insertInto(
-      AT_STATE, AT_STATE.AT_ID, AT_STATE.STATE, AT_STATE.PREV_HEIGHT, AT_STATE.NEXT_HEIGHT, AT_STATE.SLEEP_BETWEEN, AT_STATE.PREV_BALANCE, AT_STATE.FREEZE_WHEN_SAME_BALANCE, AT_STATE.MIN_ACTIVATE_AMOUNT, AT_STATE.HEIGHT, AT_STATE.LATEST)
-            .values(atState.getATId(), brs.at.AT.compressState(atState.getState()), atState.getPrevHeight(), atState.getNextHeight(), atState.getSleepBetween(), atState.getPrevBalance(), atState.getFreezeWhenSameBalance(), atState.getMinActivationAmount(), Signum.getBlockchain().getHeight(), true)
-            .execute();
+        AT_STATE, AT_STATE.AT_ID, AT_STATE.STATE, AT_STATE.PREV_HEIGHT, AT_STATE.NEXT_HEIGHT, AT_STATE.SLEEP_BETWEEN, AT_STATE.PREV_BALANCE, AT_STATE.FREEZE_WHEN_SAME_BALANCE, AT_STATE.MIN_ACTIVATE_AMOUNT, AT_STATE.HEIGHT, AT_STATE.LATEST)
+      .values(atState.getATId(), brs.at.AT.compressState(atState.getState()), atState.getPrevHeight(), atState.getNextHeight(), atState.getSleepBetween(), atState.getPrevBalance(), atState.getFreezeWhenSameBalance(), atState.getMinActivationAmount(), Signum.getBlockchain().getHeight(), true)
+      .execute();
   }
 
   private void saveATMapEntry(DSLContext ctx, brs.at.AT.AtMapEntry atEntry) {
     ctx.insertInto(AT_MAP, AT_MAP.AT_ID, AT_MAP.KEY1, AT_MAP.KEY2, AT_MAP.VALUE, AT_STATE.HEIGHT, AT_STATE.LATEST)
-            .values(atEntry.getAtId(), atEntry.getKey1(), atEntry.getKey2(), atEntry.getValue(), Signum.getBlockchain().getHeight(), true)
-            .execute();
+      .values(atEntry.getAtId(), atEntry.getKey1(), atEntry.getKey2(), atEntry.getValue(), Signum.getBlockchain().getHeight(), true)
+      .execute();
   }
 
   private void saveAT(DSLContext ctx, brs.at.AT at) {
@@ -159,26 +158,26 @@ public class SqlATStore implements ATStore {
     return Db.useDSLContext(ctx -> {
       AtConstants atConstants = AtConstants.getInstance();
       return ctx.selectFrom(
-              AT.join(AT_STATE).on(AT.ID.eq(AT_STATE.AT_ID)).join(ACCOUNT_BALANCE).on(AT.ID.eq(ACCOUNT_BALANCE.ID))
+        AT.join(AT_STATE).on(AT.ID.eq(AT_STATE.AT_ID)).join(ACCOUNT_BALANCE).on(AT.ID.eq(ACCOUNT_BALANCE.ID))
       ).where(
-              AT.LATEST.isTrue()
+        AT.LATEST.isTrue()
       ).and(
-              AT_STATE.LATEST.isTrue()
+        AT_STATE.LATEST.isTrue()
       ).and(
-              ACCOUNT_BALANCE.LATEST.isTrue()
+        ACCOUNT_BALANCE.LATEST.isTrue()
       ).and(
-              AT_STATE.NEXT_HEIGHT.lessOrEqual(Signum.getBlockchain().getHeight() + 1)
+        AT_STATE.NEXT_HEIGHT.lessOrEqual(Signum.getBlockchain().getHeight() + 1)
       ).and(
         ACCOUNT_BALANCE.BALANCE.greaterOrEqual(
-                atConstants.stepFee(atConstants.atVersion(Signum.getBlockchain().getHeight()))
-                              * atConstants.apiStepMultiplier(atConstants.atVersion(Signum.getBlockchain().getHeight()))
-              )
+          atConstants.stepFee(atConstants.atVersion(Signum.getBlockchain().getHeight()))
+            * atConstants.apiStepMultiplier(atConstants.atVersion(Signum.getBlockchain().getHeight()))
+        )
       ).and(
-              AT_STATE.FREEZE_WHEN_SAME_BALANCE.isFalse().or(
-                      "account_balance.balance - at_state.prev_balance >= at_state.min_activate_amount"
-              )
+        AT_STATE.FREEZE_WHEN_SAME_BALANCE.isFalse().or(
+          "account_balance.balance - at_state.prev_balance >= at_state.min_activate_amount"
+        )
       ).orderBy(
-              AT_STATE.PREV_HEIGHT.asc(), AT_STATE.NEXT_HEIGHT.asc(), AT.ID.asc()
+        AT_STATE.PREV_HEIGHT.asc(), AT_STATE.NEXT_HEIGHT.asc(), AT.ID.asc()
       ).fetch().getValues(AT.ID);
     });
   }
@@ -192,12 +191,11 @@ public class SqlATStore implements ATStore {
   public brs.at.AT getAT(Long id, int height) {
     return Db.useDSLContext(ctx -> {
       SelectJoinStep<Record> select = ctx.select(AT.fields()).select(AT_STATE.fields()).from(AT.join(AT_STATE)
-          .on(AT.ID.eq(AT_STATE.AT_ID)));
+        .on(AT.ID.eq(AT_STATE.AT_ID)));
       ResultQuery<Record> where = null;
-      if(height > 0) {
+      if (height > 0) {
         where = select.where(AT_STATE.HEIGHT.le(height)).and(AT.ID.eq(id)).orderBy(AT_STATE.HEIGHT.desc()).maxRows(1);
-      }
-      else {
+      } else {
         where = select.where(AT.LATEST.isTrue()).and(AT_STATE.LATEST.isTrue()).and(AT.ID.eq(id));
       }
       Record record = where.fetchOne();
@@ -220,7 +218,7 @@ public class SqlATStore implements ATStore {
   @Override
   public long getMapValue(long atId, long key1, long key2) {
     AtMapEntry entry = getMapValueEntry(atId, key1, key2);
-    if(entry == null)
+    if (entry == null)
       return 0;
     return entry.getValue();
   }
@@ -229,8 +227,8 @@ public class SqlATStore implements ATStore {
   public CollectionWithIndex<AtMapEntry> getMapValues(long atId, long key1, Long value, int from, int to) {
     Result<Record> result = Db.useDSLContext(ctx -> {
       SelectConditionStep<Record> request = ctx.select(AT_MAP.fields()).from(AT_MAP).where(AT_MAP.LATEST.isTrue()).and(AT_MAP.AT_ID.eq(atId))
-          .and(AT_MAP.KEY1.eq(key1));
-      if(value != null) {
+        .and(AT_MAP.KEY1.eq(key1));
+      if (value != null) {
         request = request.and(AT_MAP.VALUE.eq(value));
       }
       SelectQuery<Record> query = request.orderBy(AT_MAP.HEIGHT.desc()).getQuery();
@@ -238,24 +236,24 @@ public class SqlATStore implements ATStore {
       return query.fetch();
     });
 
-    ArrayList<brs.at.AT.AtMapEntry> list = new ArrayList<AT.AtMapEntry>();
-    for(Record r : result) {
+    ArrayList<brs.at.AT.AtMapEntry> list = new ArrayList<>();
+    for (Record r : result) {
       list.add(new brs.at.AT.AtMapEntry(atId, key1, r.get(AT_MAP.KEY2), r.get(AT_MAP.VALUE)));
     }
 
-    return new CollectionWithIndex<AtMapEntry>(list, from, to) ;
+    return new CollectionWithIndex<>(list, from, to);
   }
 
   private brs.at.AT createAT(AtRecord at, AtStateRecord atState, int height) {
     byte[] code = brs.at.AT.decompressState(at.getApCode());
     long codeHashId = at.getApCodeHashId();
     int codeSize = at.getCsize();
-    if(code == null) {
+    if (code == null) {
       // Check the creation transaction for the reference code
       Transaction atCreationTransaction = Signum.getBlockchain().getTransaction(at.getId());
       Transaction transaction = Signum.getBlockchain().getTransactionByFullHash(atCreationTransaction.getReferencedTransactionFullHash());
-      if(transaction!=null && transaction.getAttachment() instanceof Attachment.AutomatedTransactionsCreation) {
-        Attachment.AutomatedTransactionsCreation atCreationAttachment = (Attachment.AutomatedTransactionsCreation)transaction.getAttachment();
+      if (transaction != null && transaction.getAttachment() instanceof Attachment.AutomatedTransactionsCreation) {
+        Attachment.AutomatedTransactionsCreation atCreationAttachment = (Attachment.AutomatedTransactionsCreation) transaction.getAttachment();
         AtMachineState atCreation = new AtMachineState(null, null, atCreationAttachment.getCreationBytes(), 0);
         code = atCreation.getApCodeBytes();
         codeSize = atCreation.getcSize();
@@ -263,19 +261,19 @@ public class SqlATStore implements ATStore {
       }
     }
     return new AT(AtApiHelper.getByteArray(at.getId()), AtApiHelper.getByteArray(at.getCreatorId()), at.getName(), at.getDescription(), at.getVersion(),
-            height,
-            brs.at.AT.decompressState(atState.getState()), codeSize, at.getDsize(), at.getCUserStackBytes(), at.getCCallStackBytes(), at.getCreationHeight(), atState.getSleepBetween(), atState.getNextHeight(),
-            atState.getFreezeWhenSameBalance(), atState.getMinActivateAmount(), code, codeHashId);
+      height,
+      brs.at.AT.decompressState(atState.getState()), codeSize, at.getDsize(), at.getCUserStackBytes(), at.getCCallStackBytes(), at.getCreationHeight(), atState.getSleepBetween(), atState.getNextHeight(),
+      atState.getFreezeWhenSameBalance(), atState.getMinActivateAmount(), code, codeHashId);
   }
 
   @Override
   public List<Long> getATsIssuedBy(Long accountId, Long codeHashId, int from, int to) {
     return Db.useDSLContext(ctx -> {
       SelectConditionStep<Record1<Long>> request = ctx.select(AT.ID).from(AT).where(AT.LATEST.isTrue());
-      if(accountId != null) {
+      if (accountId != null) {
         request = request.and(AT.CREATOR_ID.eq(accountId));
       }
-      if(codeHashId != null){
+      if (codeHashId != null) {
         request = request.and(AT.AP_CODE_HASH_ID.eq(codeHashId));
       }
       SelectQuery<Record1<Long>> query = request.orderBy(AT.CREATION_HEIGHT.desc(), AT.ID.asc()).getQuery();
@@ -289,7 +287,7 @@ public class SqlATStore implements ATStore {
   public Collection<Long> getAllATIds(Long codeHashId) {
     return Db.useDSLContext(ctx -> {
       SelectConditionStep<AtRecord> request = ctx.selectFrom(AT).where(AT.LATEST.isTrue());
-      if(codeHashId != null)
+      if (codeHashId != null)
         request = request.and(AT.AP_CODE_HASH_ID.eq(codeHashId));
       return request.fetch().getValues(AT.ID);
     });
@@ -320,20 +318,23 @@ public class SqlATStore implements ATStore {
     return atStateTable;
   }
 
+
   @Override
   public Long findTransaction(int startHeight, int endHeight, Long atID, int numOfTx, long minActivationAmount) {
     return Db.useDSLContext(ctx -> {
-      SelectQuery<Record1<Long>> query = ctx.select(TRANSACTION.ID).from(TRANSACTION).where(
-        TRANSACTION.HEIGHT.between(startHeight, endHeight - 1)
-      ).and(
-        TRANSACTION.RECIPIENT_ID.eq(atID)
-      ).and(
-        TRANSACTION.AMOUNT.greaterOrEqual(minActivationAmount)
-      ).orderBy(
-        TRANSACTION.HEIGHT, TRANSACTION.ID
-      ).getQuery();
+      long startTime = System.nanoTime();
+
+      SelectQuery<Record1<Long>> query = ctx.select(TRANSACTION.ID)
+        .from(TRANSACTION)
+        .where(TRANSACTION.HEIGHT.between(startHeight, endHeight - 1))
+        .and(TRANSACTION.RECIPIENT_ID.eq(atID))
+        .and(TRANSACTION.AMOUNT.greaterOrEqual(minActivationAmount))
+        .orderBy(TRANSACTION.HEIGHT, TRANSACTION.ID)
+        .getQuery();
       DbUtils.applyLimits(query, numOfTx, numOfTx + 1);
       Result<Record1<Long>> result = query.fetch();
+      long executionTime = (System.nanoTime() - startTime) / 1000000;
+      logger.debug("Find Duration: {} milliseconds", executionTime);
       return result.isEmpty() ? 0L : result.get(0).value1();
     });
   }
@@ -341,21 +342,25 @@ public class SqlATStore implements ATStore {
   @Override
   public int findTransactionHeight(Long transactionId, int height, Long atID, long minActivationAmount) {
     return Db.useDSLContext(ctx -> {
+      long startTime = System.nanoTime();
       try {
-        Iterator<Record1<Long>> fetch = ctx.select(TRANSACTION.ID)
-                .from(TRANSACTION)
-                .where(TRANSACTION.HEIGHT.eq(height))
-                .and(TRANSACTION.RECIPIENT_ID.eq(atID))
-                .and(TRANSACTION.AMOUNT.greaterOrEqual(minActivationAmount))
-                .orderBy(TRANSACTION.HEIGHT, TRANSACTION.ID)
-                .fetch()
-                .iterator();
+        List<Long> transactionIds = ctx.select(TRANSACTION.ID)
+          .from(TRANSACTION)
+          .where(TRANSACTION.HEIGHT.eq(height))
+          .and(TRANSACTION.RECIPIENT_ID.eq(atID))
+          .and(TRANSACTION.AMOUNT.greaterOrEqual(minActivationAmount))
+          .orderBy(TRANSACTION.HEIGHT, TRANSACTION.ID)
+          .fetchInto(Long.class);
+
         int counter = 0;
-        while (fetch.hasNext()) {
+        for (Long currentTransactionId : transactionIds) {
           counter++;
-          long currentTransactionId = fetch.next().value1();
-          if (currentTransactionId == transactionId) break;
+          if (currentTransactionId.equals(transactionId)) {
+            break;
+          }
         }
+        long executionTime = (System.nanoTime() - startTime) / 1000000;
+        logger.debug("Find Duration: {} milliseconds", executionTime);
         return counter;
       } catch (DataAccessException e) {
         throw new RuntimeException(e.toString(), e);
@@ -363,17 +368,44 @@ public class SqlATStore implements ATStore {
     });
   }
 
+
+//  Previous version
+//  @Override
+//  public int findTransactionHeight(Long transactionId, int height, Long atID, long minActivationAmount) {
+//    return Db.useDSLContext(ctx -> {
+//      try {
+//        Iterator<Record1<Long>> fetch = ctx.select(TRANSACTION.ID)
+//                .from(TRANSACTION)
+//                .where(TRANSACTION.HEIGHT.eq(height))
+//                .and(TRANSACTION.RECIPIENT_ID.eq(atID))
+//                .and(TRANSACTION.AMOUNT.greaterOrEqual(minActivationAmount))
+//                .orderBy(TRANSACTION.HEIGHT, TRANSACTION.ID)
+//                .fetch()
+//                .iterator();
+//        int counter = 0;
+//        while (fetch.hasNext()) {
+//          counter++;
+//          long currentTransactionId = fetch.next().value1();
+//          if (currentTransactionId == transactionId) break;
+//        }
+//        return counter;
+//      } catch (DataAccessException e) {
+//        throw new RuntimeException(e.toString(), e);
+//      }
+//    });
+//  }
+
   class SqlATState extends brs.at.AT.ATState {
     private SqlATState(Record record) {
       super(
-            record.get(AT_STATE.AT_ID),
-            record.get(AT_STATE.STATE),
-            record.get(AT_STATE.NEXT_HEIGHT),
-            record.get(AT_STATE.SLEEP_BETWEEN),
-            record.get(AT_STATE.PREV_BALANCE),
-            record.get(AT_STATE.FREEZE_WHEN_SAME_BALANCE),
-            record.get(AT_STATE.MIN_ACTIVATE_AMOUNT)
-            );
+        record.get(AT_STATE.AT_ID),
+        record.get(AT_STATE.STATE),
+        record.get(AT_STATE.NEXT_HEIGHT),
+        record.get(AT_STATE.SLEEP_BETWEEN),
+        record.get(AT_STATE.PREV_BALANCE),
+        record.get(AT_STATE.FREEZE_WHEN_SAME_BALANCE),
+        record.get(AT_STATE.MIN_ACTIVATE_AMOUNT)
+      );
     }
   }
 

--- a/src/brs/db/store/ATStore.java
+++ b/src/brs/db/store/ATStore.java
@@ -1,5 +1,6 @@
 package brs.db.store;
 
+import brs.Transaction;
 import brs.at.AT;
 import brs.at.AT.AtMapEntry;
 import brs.db.SignumKey;
@@ -37,7 +38,7 @@ public interface ATStore {
 
   int findTransactionHeight(Long transactionId, int height, Long atID, long minAmount);
 
-  public AtMapEntry getMapValueEntry(long atId, long key1, long key2);
+  AtMapEntry getMapValueEntry(long atId, long key1, long key2);
 
   long getMapValue(long atId, long key1, long key2);
 

--- a/src/brs/db/store/ATStore.java
+++ b/src/brs/db/store/ATStore.java
@@ -1,6 +1,5 @@
 package brs.db.store;
 
-import brs.Transaction;
 import brs.at.AT;
 import brs.at.AT.AtMapEntry;
 import brs.db.SignumKey;
@@ -19,6 +18,8 @@ public interface ATStore {
   AT getAT(Long id);
 
   AT getAT(Long id, int height);
+
+  Collection<AT> getATs(Collection<Long> ids);
 
   List<Long> getATsIssuedBy(Long accountId, Long codeHashId, int from, int to);
 

--- a/src/brs/props/Props.java
+++ b/src/brs/props/Props.java
@@ -124,6 +124,7 @@ public class Props {
   public static final Prop<String> DB_SQLITE_JOURNAL_MODE = new Prop<>("DB.SqliteJournalMode", "WAL");
 
   public static final Prop<Integer> BRS_BLOCK_CACHE_MB = new Prop<>("node.blockCacheMB", 40);
+  public static final Prop<Integer> BRS_AT_PROCESSOR_CACHE_BLOCK_COUNT = new Prop<>("node.atProcessorCacheBlockCount", 1000);
 
   // P2P options
   public static final Prop<Integer> P2P_PORT = new Prop<>("P2P.Port", 8123);


### PR DESCRIPTION
Improving AT Processing performance by dramatically reducing data base access while steps execution. 
Necessary data is being loaded (incrementally) from database into memory on each blocks beginning.
This tackles two observed problems:

 1. While processing 47% of time was spent on AT execution
 
![image](https://github.com/signum-network/signum-node/assets/3920663/927d7043-e571-4021-b1d3-41824ecb9718)
 
 2. A steady decline of synchronization performance (scalability issues)

![image](https://github.com/signum-network/signum-node/assets/3920663/eca24f19-3778-4662-9a89-675d7f8b0993)


This solution reduces time spent on AT execution to only 7% and keeps block sync speed stable

![image](https://github.com/signum-network/signum-node/assets/3920663/e48e10a4-0c71-46e1-98da-e6dd074e46a9)
