### PR TITLE
Update dockerhub gh action to push a single image

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -17,9 +17,9 @@ on: workflow_dispatch
 #    types: [released]
 
 jobs:
-  publish-h2-image:
+  publish-image:
     environment: dockerhub-publish
-    name: Push h2 db Docker image to Docker Hub
+    name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -37,48 +37,15 @@ jobs:
         with:
           images: ${{ secrets.DOCKERHUB_REPO }}
           tags: |
-            type=semver,pattern={{version}}-h2
-            type=raw,value=latest-h2
+            type=semver,pattern={{version}}
+            type=raw,value=latest
           flavor: |
             latest=false
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:
-          file: './docker/mainnet/h2/Dockerfile'
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-  publish-maria-image:
-    environment: dockerhub-publish
-    name: Push mariadb Docker image to Docker Hub
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@v4
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ secrets.DOCKERHUB_REPO }}
-          tags: |
-            type=semver,pattern={{version}}-maria
-            type=raw,value=latest-maria
-          flavor: |
-            latest=false
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v2
-        with:
-          file: './docker/mainnet/mariadb/Dockerfile'
+          file: './Dockerfile'
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
I removed the second image publish and modified the first to build and push a single image to dockerhub using the Dockerfile in the main folder. Give it a try and see if it works, and if it does, consider uncommenting the "on release" option.