### PR TITLE
Tooling quality of life

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,37 +1,49 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/java
 {
-	"name": "Java",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/java:1-17-bookworm",
+  "name": "Java",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/java:1-17-bookworm",
 
-	"features": {
-		"ghcr.io/devcontainers/features/java:1": {
-			"version": "none",
-			"installMaven": "true",
-			"installGradle": "true"
-		}
-	},
-	"customizations": {
-		"vscode": {
-			"extensions": [
-				"vscjava.vscode-java-pack",
-				"shengchen.vscode-checkstyle",
-				"Gruntfuggly.todo-tree",
-				"mhutchie.git-graph"
-			]
-		}
-	}
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "none",
+      "installMaven": "true",
+      "installGradle": "true"
+    },
+    "ghcr.io/itsmechlark/features/1password:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+        "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/nix:1": {
+        "version": "latest"
+    },
+    "ghcr.io/georgofenbeck/features/lazygit-linuxbinary:1": {
+        "version": "latest"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "vscjava.vscode-java-pack",
+        "shengchen.vscode-checkstyle",
+        "Gruntfuggly.todo-tree",
+        "mhutchie.git-graph"
+      ]
+    }
+  }
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "java -version",
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "java -version",
 
-	// Configure tool-specific properties.
-	// "customizations": {},
+  // Configure tool-specific properties.
+  // "customizations": {},
 
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
     "java.format.onType.enabled": true,
     "java.format.enabled": true,
     "editor.detectIndentation": false,
-    "java.import.projectSelection": "automatic"
+    "java.import.projectSelection": "automatic",
+    "workbench.colorTheme": "Default Dark Modern"
 }


### PR DESCRIPTION
Replaces #830.

Set the default theme to dark for the workspace for those who might use devpod with open-vscode IDE.

Add some tooling to the devcontainer to allow for installation of additional packages (nix) and a couple cli tools.

Enable docker-in-docker, allowing users in the devcontainer to build the dockerfile for testing.