### PR TITLE
Add a config property for the max number of rows to insert in SQL statements

### DIFF
--- a/conf/node-default.properties
+++ b/conf/node-default.properties
@@ -332,7 +332,7 @@
 ## Maximum number of rows to be inserted in a single SQL statement.
 ## Defaults to 1000, should be ok in most situations.
 ## May be fine tuned according to your DBMS or to your machine performances.
-## Warning: a high value (> 19000 rows) is known to generate queries too big for an SQLite backend
+## Warning: a high value (> 15000 rows) is known to generate queries too big for an SQLite backend
 
 # DB.InsertBatchMaxSize = 1000
 

--- a/conf/node-default.properties
+++ b/conf/node-default.properties
@@ -278,14 +278,12 @@
 # API.ServerEnforcePOST = yes
 
 ## Your keystore file and password, required if uiSSL or apiSSL are enabled.
-
 # API.SSL_keyStorePath     = keystore
 # API.SSL_keyStorePassword = password
 
 ## If you use https://certbot.eff.org/ to issue your certificate, provide below the path for your keys.
 ## BRS will automatically create the keystore file using the password above and will reload it weekly.
 ## Make sure you configure certbot to renew your certificate automatically so you don't need to worry about it.
-## Note, you need 'openssl' on your path for this to work, most Linux distributions have it already.
 
 # API.SSL_letsencryptPath = /etc/letsencrypt/live/yourdomain.com
 
@@ -330,11 +328,11 @@
 # DB.LockTimeout = 60
 
 ## Maximum number of rows to be inserted in a single SQL statement.
-## Defaults to 1000, should be ok in most situations.
+## Defaults to 10000, should be ok in most situations.
 ## May be fine tuned according to your DBMS or to your machine performances.
 ## Warning: a high value (> 15000 rows) is known to generate queries too big for an SQLite backend
 
-# DB.InsertBatchMaxSize = 1000
+# DB.InsertBatchMaxSize = 10000
 
 ### GPU Acceleration
 

--- a/conf/node-default.properties
+++ b/conf/node-default.properties
@@ -284,7 +284,6 @@
 ## If you use https://certbot.eff.org/ to issue your certificate, provide below the path for your keys.
 ## BRS will automatically create the keystore file using the password above and will reload it weekly.
 ## Make sure you configure certbot to renew your certificate automatically so you don't need to worry about it.
-
 # API.SSL_letsencryptPath = /etc/letsencrypt/live/yourdomain.com
 
 #### DATABASE ####

--- a/conf/node-default.properties
+++ b/conf/node-default.properties
@@ -278,12 +278,15 @@
 # API.ServerEnforcePOST = yes
 
 ## Your keystore file and password, required if uiSSL or apiSSL are enabled.
+
 # API.SSL_keyStorePath     = keystore
 # API.SSL_keyStorePassword = password
 
 ## If you use https://certbot.eff.org/ to issue your certificate, provide below the path for your keys.
 ## BRS will automatically create the keystore file using the password above and will reload it weekly.
 ## Make sure you configure certbot to renew your certificate automatically so you don't need to worry about it.
+## Note, you need 'openssl' on your path for this to work, most Linux distributions have it already.
+
 # API.SSL_letsencryptPath = /etc/letsencrypt/live/yourdomain.com
 
 #### DATABASE ####
@@ -325,6 +328,13 @@
 ## Database default lock timeout in seconds.
 
 # DB.LockTimeout = 60
+
+## Maximum number of rows to be inserted in a single SQL statement.
+## Defaults to 1000, should be ok in most situations.
+## May be fine tuned according to your DBMS or to your machine performances.
+## Warning: a high value (> 19000 rows) is known to generate queries too big for an SQLite backend
+
+# DB.InsertBatchMaxSize = 1000
 
 ### GPU Acceleration
 

--- a/src/brs/db/sql/SqlAccountStore.java
+++ b/src/brs/db/sql/SqlAccountStore.java
@@ -57,6 +57,8 @@ public class SqlAccountStore implements AccountStore {
     }
   };
 
+  private static final Integer InsertMaxBatchSize = Signum.getPropertyService().getInt(Props.DB_INSERT_BATCH_MAX_SIZE);
+
   private static final Set<String> PK_CHECKS = Collections
     .unmodifiableSet(new HashSet<>(Signum.getPropertyService().getStringList(Props.BRS_PK_CHECKS)));
 
@@ -186,7 +188,7 @@ public class SqlAccountStore implements AccountStore {
               balance.getBalanceNqt(), balance.getUnconfirmedBalanceNqt(),
               balance.getForgedBalanceNqt(), true));
 
-          if(rows.size() >= Signum.getPropertyService().getInt(Props.DB_INSERT_BATCH_MAX_SIZE)){
+          if(rows.size() >= InsertMaxBatchSize){
             ctx.insertInto(ACCOUNT_BALANCE, ACCOUNT_BALANCE.ID, ACCOUNT_BALANCE.HEIGHT,
                 ACCOUNT_BALANCE.BALANCE, ACCOUNT_BALANCE.UNCONFIRMED_BALANCE,
                 ACCOUNT_BALANCE.FORGED_BALANCE, ACCOUNT.LATEST)

--- a/src/brs/db/sql/SqlAccountStore.java
+++ b/src/brs/db/sql/SqlAccountStore.java
@@ -186,7 +186,7 @@ public class SqlAccountStore implements AccountStore {
               balance.getBalanceNqt(), balance.getUnconfirmedBalanceNqt(),
               balance.getForgedBalanceNqt(), true));
 
-          if(rows.size() >= 250000){
+          if(rows.size() >= Signum.getPropertyService().getInt(Props.DB_INSERT_BATCH_MAX_SIZE)){
             ctx.insertInto(ACCOUNT_BALANCE, ACCOUNT_BALANCE.ID, ACCOUNT_BALANCE.HEIGHT,
                 ACCOUNT_BALANCE.BALANCE, ACCOUNT_BALANCE.UNCONFIRMED_BALANCE,
                 ACCOUNT_BALANCE.FORGED_BALANCE, ACCOUNT.LATEST)

--- a/src/brs/db/sql/SqlIndirectIncomingStore.java
+++ b/src/brs/db/sql/SqlIndirectIncomingStore.java
@@ -22,6 +22,8 @@ public class SqlIndirectIncomingStore implements IndirectIncomingStore {
   private final EntitySqlTable<IndirectIncoming> indirectIncomingTable;
   private final SignumKey.LinkKeyFactory<IndirectIncoming> indirectIncomingDbKeyFactory;
 
+  private static final Integer InsertMaxBatchSize = Signum.getPropertyService().getInt(Props.DB_INSERT_BATCH_MAX_SIZE);
+
   public SqlIndirectIncomingStore(DerivedTableManager derivedTableManager) {
     indirectIncomingDbKeyFactory = new DbKey.LinkKeyFactory<IndirectIncoming>("account_id", "transaction_id") {
       @Override
@@ -62,7 +64,7 @@ public class SqlIndirectIncomingStore implements IndirectIncomingStore {
         while (iterator.hasNext()) {
           List<Record5<Long, Long, Long, Long, Integer>> rows = new ArrayList<>();
           // break into batches
-          for (int i = 0; i < Signum.getPropertyService().getInt(Props.DB_INSERT_BATCH_MAX_SIZE) && iterator.hasNext(); i++) {
+          for (int i = 0; i < InsertMaxBatchSize && iterator.hasNext(); i++) {
             IndirectIncoming indirectIncoming = iterator.next();
             rows.add(ctx.newRecord(INDIRECT_INCOMING.ACCOUNT_ID,
               INDIRECT_INCOMING.TRANSACTION_ID,

--- a/src/brs/db/sql/SqlIndirectIncomingStore.java
+++ b/src/brs/db/sql/SqlIndirectIncomingStore.java
@@ -1,9 +1,11 @@
 package brs.db.sql;
 
+import brs.Signum;
 import brs.IndirectIncoming;
 import brs.db.SignumKey;
 import brs.db.store.DerivedTableManager;
 import brs.db.store.IndirectIncomingStore;
+import brs.props.Props;
 import org.jooq.*;
 import org.jooq.exception.DataAccessException;
 
@@ -60,7 +62,7 @@ public class SqlIndirectIncomingStore implements IndirectIncomingStore {
         while (iterator.hasNext()) {
           List<Record5<Long, Long, Long, Long, Integer>> rows = new ArrayList<>();
           // break into batches
-          for (int i = 0; i < 250000 && iterator.hasNext(); i++) {
+          for (int i = 0; i < Signum.getPropertyService().getInt(Props.DB_INSERT_BATCH_MAX_SIZE) && iterator.hasNext(); i++) {
             IndirectIncoming indirectIncoming = iterator.next();
             rows.add(ctx.newRecord(INDIRECT_INCOMING.ACCOUNT_ID,
               INDIRECT_INCOMING.TRANSACTION_ID,

--- a/src/brs/props/Props.java
+++ b/src/brs/props/Props.java
@@ -128,7 +128,7 @@ public class Props {
   public static final Prop<Integer> BRS_BLOCK_CACHE_MB = new Prop<>("node.blockCacheMB", 40);
   public static final Prop<Integer> BRS_AT_PROCESSOR_CACHE_BLOCK_COUNT = new Prop<>("node.atProcessorCacheBlockCount", 1000);
 
-  public static final Prop<Integer> DB_INSERT_BATCH_MAX_SIZE = new Prop<>("DB.InsertBatchMaxSize", 1000);
+  public static final Prop<Integer> DB_INSERT_BATCH_MAX_SIZE = new Prop<>("DB.InsertBatchMaxSize", 10000);
 
   // P2P options
   public static final Prop<Integer> P2P_PORT = new Prop<>("P2P.Port", 8123);

--- a/src/brs/props/Props.java
+++ b/src/brs/props/Props.java
@@ -128,6 +128,8 @@ public class Props {
   public static final Prop<Integer> BRS_BLOCK_CACHE_MB = new Prop<>("node.blockCacheMB", 40);
   public static final Prop<Integer> BRS_AT_PROCESSOR_CACHE_BLOCK_COUNT = new Prop<>("node.atProcessorCacheBlockCount", 1000);
 
+  public static final Prop<Integer> DB_INSERT_BATCH_MAX_SIZE = new Prop<>("DB.InsertBatchMaxSize", 1000);
+
   // P2P options
   public static final Prop<Integer> P2P_PORT = new Prop<>("P2P.Port", 8123);
   public static final Prop<String> P2P_MY_PLATFORM = new Prop<>("P2P.myPlatform", "PC");


### PR DESCRIPTION
Add a "DB.InsertBatchMaxSize" with a default of 1000 to the node properties.

This property is used in two places known to generate very big SQL statements that exceed the maximum of certain DBMS, especially SQLite.

Fixes signum-network/signum-node#824