### PR TITLE
Silence SQLITE_BUSY and SQLITE_BUSY_SNAPSHOT exceptions and stack traces

### DIFF
--- a/src/brs/BlockchainProcessorImpl.java
+++ b/src/brs/BlockchainProcessorImpl.java
@@ -703,8 +703,12 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
             break;
           }
         } catch (Exception exception) {
-          exception.printStackTrace();
-          logger.error("Uncaught exception in blockImporterThread", exception);
+          if (exception.toString().contains("[SQLITE_BUSY]") || exception.toString().contains("[SQLITE_BUSY_SNAPSHOT]")) {
+            logger.warn("SQLite deadlock, trying again later");
+          } else {
+            exception.printStackTrace();
+            logger.error("Uncaught exception in blockImporterThread", exception);
+          }
         }
       }
     };


### PR DESCRIPTION
This proposition silences the SQLite deadlock stacktraces from the output, replacing them with a single warning line.

rationale:
I don't really like putting SQLite specific code into a function which is supposed to be independent of any specific database.
But I dislike even more having uncaught stack traces in a production software console output :) ... and this is the simplest way I could think of silencing those annoying stack traces.

Up to you to take this or not !

Transforms a full trace like this:
```
[SEVERE] 2024-11-25 21:35:06 brs.BlockchainProcessorImpl - Uncaught exception in blockImporterThread
org.jooq.exception.DataAccessException: SQL [insert into block (id, version, timestamp, previous_block_id, total_amount, total_fee, total_fee_cash_back, total_fee_burnt, payload_length, generator_public_key, previous_block_hash, cumulative_difficulty, base_target, height, generation_signature, block_signature, payload_hash, generator_id, nonce, ats) values (6839774921415713529, 3, 22191351, 548729464182861846, 202142608840, 900000000, 0, 0, 1584, X'B993ECC9FCDC7DFDD21599E2E6A41C1F2721123DDA6F19FDA14ACA366789AA27', X'16F068568A7A9D07061233BE338263C1B2AC88669A7A720A4E557FBE737FD23B', X'0AE0ECEF1C505A29', 1604205, 91690, X'D9F8E454394196282C83CAC1E67C8ED7E09F710BE891C8AF3640FC530CD329A6', X'60F46804E910BA0D20300E1A2537C3E56F9A47C0879F5981A5814FF6D185C20D639FBE88373FE263C42EA2C5139401CA10841C3B5365B26112413E2A13655271', X'EAED9DCEACE310E96090A0CB5B43A1B3B638A95C630744B34FE3DA6139B52DA6', 6130201924976703704, 82002897, null)]; [SQLITE_BUSY_SNAPSHOT] Another database connection has already written to the database (database is locked)
	at org.jooq_3.16.23.SQLITE.debug(Unknown Source)
	at org.jooq.impl.Tools.translate(Tools.java:3130)
	at org.jooq.impl.DefaultExecuteContext.sqlException(DefaultExecuteContext.java:727)
	at org.jooq.impl.AbstractQuery.execute(AbstractQuery.java:343)
	at org.jooq.impl.AbstractDelegatingQuery.execute(AbstractDelegatingQuery.java:115)
	at brs.db.sql.SqlBlockDb.saveBlock(SqlBlockDb.java:138)
	at brs.db.sql.SqlBlockchainStore.lambda$addBlock$16(SqlBlockchainStore.java:376)
	at brs.db.sql.Db.useDSLContext(Db.java:132)
	at brs.db.sql.SqlBlockchainStore.addBlock(SqlBlockchainStore.java:375)
	at brs.BlockchainProcessorImpl.addBlock(BlockchainProcessorImpl.java:906)
	at brs.BlockchainProcessorImpl.pushBlock(BlockchainProcessorImpl.java:1145)
	at brs.BlockchainProcessorImpl.lambda$new$5(BlockchainProcessorImpl.java:696)
	at brs.util.ThreadPool.lambda$start$0(ThreadPool.java:104)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: org.sqlite.SQLiteException: [SQLITE_BUSY_SNAPSHOT] Another database connection has already written to the database (database is locked)
	at org.sqlite.core.DB.newSQLException(DB.java:1179)
	at org.sqlite.core.DB.newSQLException(DB.java:1190)
	at org.sqlite.core.DB.execute(DB.java:985)
	at org.sqlite.core.CoreStatement.exec(CoreStatement.java:91)
	at org.sqlite.jdbc3.JDBC3Statement.lambda$execute$0(JDBC3Statement.java:55)
	at org.sqlite.jdbc3.JDBC3Statement.withConnectionTimeout(JDBC3Statement.java:454)
	at org.sqlite.jdbc3.JDBC3Statement.execute(JDBC3Statement.java:43)
	at com.zaxxer.hikari.pool.ProxyStatement.execute(ProxyStatement.java:94)
	at com.zaxxer.hikari.pool.HikariProxyStatement.execute(HikariProxyStatement.java)
	at org.jooq.tools.jdbc.DefaultStatement.execute(DefaultStatement.java:102)
	at org.jooq.impl.SettingsEnabledPreparedStatement.execute(SettingsEnabledPreparedStatement.java:227)
	at org.jooq.impl.AbstractQuery.execute(AbstractQuery.java:428)
	at org.jooq.impl.AbstractDMLQuery.execute(AbstractDMLQuery.java:961)
	at org.jooq.impl.AbstractQuery.execute(AbstractQuery.java:329)
	... 15 more
```

into a simple warning line like this:
```
[WARNING] 2024-11-26 23:07:50 brs.BlockchainProcessorImpl - SQLite deadlock, trying again later
```
