### PR TITLE
Bugfix/privkey

### DIFF
--- a/src/brs/web/server/AbstractServerConnectorBuilder.java
+++ b/src/brs/web/server/AbstractServerConnectorBuilder.java
@@ -106,7 +106,7 @@ public abstract class AbstractServerConnectorBuilder {
           PEMKeyPair pemKeyPair = (PEMKeyPair) keyObject;
           privateKeyInfo = pemKeyPair.getPrivateKeyInfo();
       } else {
-          throw new IllegalArgumentException("Unexpected key object type: " + keyObject.getClass().getName());
+          throw new IllegalArgumentException("PEMParser: unexpected Private key object type: " + keyObject.getClass().getName());
       }
 
       KeyFactory keyFactory = KeyFactory.getInstance("RSA", "BC");


### PR DESCRIPTION
Fix a problem with how the private key is parsed when dealing with a letsencrypt SSL cert.

With some private key formats, the PEMParser may return both the Private and the Public keys, in the form of a PEMKeyPair class, and with other key formats, it returns only the Private key in the form of a PrivateKeyInfo class.

However, the current code of signum-node expects only a PrivateKeyInfo class, and fails on a cast when the PEMParser returns a PEMKeyPair, with the following error:

`[SEVERE] 2025-02-10 09:46:22 brs.web.server.AbstractServerConnectorBuilder - class org.bouncycastle.openssl.PEMKeyPair cannot be cast to class org.bouncycastle.asn1.pkcs.PrivateKeyInfo`

The proposed fix handle both cases.