### PR TITLE
Set java server to standard mode by default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
     "java.format.enabled": true,
     "editor.detectIndentation": false,
     "java.import.projectSelection": "automatic",
-    "workbench.colorTheme": "Default Dark Modern"
+    "workbench.colorTheme": "Default Dark Modern",
+    "java.server.launchMode": "Standard"
 }


### PR DESCRIPTION
The java server wasn't loading by default due to updates in the server and some new 'hybrid' mode that wasn't loading the full standard server. This forces to full standard server to be the startup mode, ensuring full java compatibility as soon as loading is complete.