### PR TITLE
fix: ensure heartbeat resumes after executing withHeartbeatPaused

### DIFF
--- a/src/brs/web/api/ws/BlockchainEventNotifier.java
+++ b/src/brs/web/api/ws/BlockchainEventNotifier.java
@@ -50,8 +50,11 @@ public class BlockchainEventNotifier {
 
   private void withHeartbeatPaused(Runnable fn) {
     heartbeat.pause();
-    fn.run();
-    heartbeat.resume();
+    try {
+        fn.run();
+    } finally {
+        heartbeat.resume();
+    }
   }
 
   private void sendToAll(Consumer<WebSocketConnection> fn) {


### PR DESCRIPTION
Sometimes when fn.run() executes an exception may happen and the heartbeat is not resumed causing the websockets to disconnect, and no ping/pong to keep the connection alive. 