### PR TITLE
Fix ambiguous class error

### DIFF
--- a/src/brs/db/sql/SqlIndirectIncomingStore.java
+++ b/src/brs/db/sql/SqlIndirectIncomingStore.java
@@ -7,7 +7,7 @@ import brs.db.store.DerivedTableManager;
 import brs.db.store.IndirectIncomingStore;
 import brs.props.Props;
 import org.jooq.*;
-import org.jooq.exception.DataAccessException;
+import org.jooq.Record;
 
 import java.util.ArrayList;
 import java.util.Collection;


### PR DESCRIPTION
A usage of org.jooq.Record was causing a build error as ambiguous with java's built-in Record type. This change clarifies it, and removes an unused import in the same class.