### PR TITLE
Fix critical, high, and a few other CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ RUN mkdir -p /requirements \
   && ldd /jre/bin/java | awk 'NF == 4 { system("cp --parents " $3 " /requirements") }'
 
 # Prepare final image
-FROM alpine:3.20
+FROM alpine:3.22
 LABEL name="Signum Node"
 LABEL description="This is the official Signum Node image"
 LABEL credits="gittrekt,damccull,ohager"


### PR DESCRIPTION
The current docker image and build.gradle both contain some critical and high CVEs. These were found by enabling Docker Scout on dockerhub. These are container related so this should go out as a hotfix immediately by pushing a new container and probably get a version bump.

This PR fixes the following CVEs by simply updating the published Alpine version:

### Critical Severity
* https://scout.docker.com/vulnerabilities/id/CVE-2025-0665

### High Severity
* https://scout.docker.com/vulnerabilities/id/CVE-2025-0725
* https://scout.docker.com/vulnerabilities/id/CVE-2023-4759
* https://scout.docker.com/vulnerabilities/id/CVE-2025-31115
* https://scout.docker.com/vulnerabilities/id/CVE-2025-26519
* https://scout.docker.com/vulnerabilities/id/CVE-2024-56171
* https://scout.docker.com/vulnerabilities/id/CVE-2025-24928
* https://scout.docker.com/vulnerabilities/id/CVE-2025-40775
* https://scout.docker.com/vulnerabilities/id/CVE-2024-12705
* https://scout.docker.com/vulnerabilities/id/CVE-2024-11187
* https://scout.docker.com/vulnerabilities/id/CVE-2024-8176

### Medium Severity
* https://scout.docker.com/vulnerabilities/id/CVE-2025-4949
* https://scout.docker.com/vulnerabilities/id/CVE-2024-12797
* https://scout.docker.com/vulnerabilities/id/CVE-2025-32414
* https://scout.docker.com/vulnerabilities/id/CVE-2024-13176

### Low Severity
* https://scout.docker.com/vulnerabilities/id/CVE-2024-50349
* https://scout.docker.com/vulnerabilities/id/CVE-2024-52006
* https://scout.docker.com/vulnerabilities/id/CVE-2025-32415
* https://scout.docker.com/vulnerabilities/id/CVE-2025-27113
* https://scout.docker.com/vulnerabilities/id/CVE-2025-0167

# Additional Vulnerabilities
There are 3 more medium severity vulnerabilities detected that will code changes in how we use the jetty http server that I was unable to fix this time around. These are NOT container based but vulnerabilities in the java code itself.

Again, these are NOT fixed, but need to be. I don't know that I will have time over the next couple weeks to dig into these but I'll possibly be able to look in July.

* https://scout.docker.com/vulnerabilities/id/CVE-2024-6763
* https://scout.docker.com/vulnerabilities/id/CVE-2018-20200
* https://scout.docker.com/vulnerabilities/id/CVE-2023-3635