### PR TITLE
fix: reverted release workflow and removed manual dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,9 @@
 name: Draft release for Signum Node
 
 on:
-  workflow_dispatch:
-    inputs:
-      release_tag:
-        description: 'Release tag (e.g. v1.8.0)'
-        required: true
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   build-node:
@@ -18,10 +16,10 @@ jobs:
 
       - name: Get version from tag
         id: get_version
-        shell: bash
+        shell: cmd
         run: |
-            echo "VERSION=${{ github.event.inputs.release_tag }}"
-            echo "VERSION=${{ github.event.inputs.release_tag }}" >> $GITHUB_ENV
+          echo VERSION=${{github.ref_name}}
+          echo VERSION=${{github.ref_name}} >> %GITHUB_ENV%
 
       - name: Update Wallets
         shell: bash
@@ -45,8 +43,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.event.inputs.release_tag }}
-          release_name: Signum Node ${{ github.event.inputs.release_tag }}
+          tag_name: ${{ github.ref }}
+          release_name: Signum Node ${{ github.ref }}
           draft: true
           prerelease: false
 


### PR DESCRIPTION
reverts the workflow and removed manual workflow dispatch - we should always go via tags!

As an explanation:

The release git flow is:

1. PRs merge into `develop`
2. `develop` merges into `main`
3. releases are cut by `git checkout main && git tag v<version>` 

<img width="1523" alt="image" src="https://github.com/user-attachments/assets/744bbcc7-411b-44b2-936b-0687d37ef2a7" />
