### PR TITLE
Enabling editor.formatOnSave specifically for Java files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,8 @@
     "editor.detectIndentation": false,
     "java.import.projectSelection": "automatic",
     "workbench.colorTheme": "Default Dark Modern",
-    "java.server.launchMode": "Standard"
+    "java.server.launchMode": "Standard",
+    "[java]": {
+        "editor.formatOnSave": true
+    }
 }


### PR DESCRIPTION
The project already defines a common Java formatting style via eclipse-java-style.xml. 

**By enabling editor.formatOnSave specifically for Java files, we ensure that this formatting is automatically applied whenever a file is saved.**

This helps:

> Maintain consistent code style across all contributors.
> 
> Eliminate unformatted or inconsistently formatted code.
> 
> Reduce formatting-related diffs and merge conflicts.
> 
> Improve developer experience with zero manual steps.

It's a small but effective improvement that reinforces the project's formatting standards automatically.