### PR TITLE
Replace String-Based Expression with Type-Safe Alternative

### DIFF
--- a/src/brs/db/sql/SqlATStore.java
+++ b/src/brs/db/sql/SqlATStore.java
@@ -175,7 +175,7 @@ public class SqlATStore implements ATStore {
         )
       ).and(
         AT_STATE.FREEZE_WHEN_SAME_BALANCE.isFalse().or(
-          "account_balance.balance - at_state.prev_balance >= at_state.min_activate_amount"
+          ACCOUNT_BALANCE.BALANCE.minus(AT_STATE.PREV_BALANCE).ge(AT_STATE.MIN_ACTIVATE_AMOUNT)
         )
       ).orderBy(
         AT_STATE.PREV_HEIGHT.asc(), AT_STATE.NEXT_HEIGHT.asc(), AT.ID.asc()


### PR DESCRIPTION
### 🔍 Suggested Change: Replace String-Based Expression with Type-Safe Alternative

In the current implementation, the logical condition is passed as a plain string:

```java
AT_STATE.FREEZE_WHEN_SAME_BALANCE.isFalse().or(
  "account_balance.balance - at_state.prev_balance >= at_state.min_activate_amount"
)
```

I suggest replacing it with a type-safe equivalent (e.g., jOOQ-style expression):

```java
AT_STATE.FREEZE_WHEN_SAME_BALANCE.isFalse().or(
  ACCOUNT_BALANCE.BALANCE.minus(AT_STATE.PREV_BALANCE).ge(AT_STATE.MIN_ACTIVATE_AMOUNT)
)
```

---

#### 💡 Rationale from Multiple Perspectives:

- **✅ Type Safety**  
  The type-safe version is validated at compile time, reducing the risk of runtime issues due to typos or invalid field names.

- **🧠 Readability and IDE Support**  
  The structured expression is easier to read and navigate in IDEs (e.g., jumping to field definitions), unlike raw strings.

- **🛠 Maintainability**  
  Refactoring tools can track and update type-safe expressions reliably, whereas string-based queries require manual intervention.

- **🧪 Testability and Stability**  
  Type-safe queries are more resilient to schema changes, which is critical in environments with evolving database models.

---

Unless there are backward compatibility concerns or technical constraints that require the use of string expressions, I believe this change would improve the robustness and maintainability of the code.

**Happy to hear your thoughts — feel free to share any concerns or feedback!** 👀
