### PR TITLE
Remove unused javax.annotation dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,6 @@ dependencies {
     implementation 'org.eclipse.jetty.ee10:jetty-ee10-servlets:12.1.1'
     implementation 'org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jetty-server:12.1.1'
 
-    implementation 'javax.annotation:javax.annotation-api:1.3.2'
     implementation 'com.github.jiconfont:jiconfont:1.0.0'
     implementation 'com.github.jiconfont:jiconfont-swing:1.0.1'
     implementation 'com.github.jiconfont:jiconfont-font_awesome:4.7.0.1'

--- a/nix-deps.json
+++ b/nix-deps.json
@@ -390,10 +390,6 @@
    "jar": "sha256-KH87bQYACC4LYCZdfeMr5APufXJpNpyXGNlCQwW4nZU=",
    "pom": "sha256-a8ZtvFdI35maxgtrNF6qYrWlAqEGkJYW/SNPTEDvx4k="
   },
-  "javax/annotation#javax.annotation-api/1.3.2": {
-   "jar": "sha256-4EulGVvNVV3JVlD3zGFNFR5LzVLSmhC4qiGX86uJq5s=",
-   "pom": "sha256-RqSiUcpAbnjkhT16K66DKChEpJkoUUOe6aHyNxbwa5c="
-  },
   "javax/inject#javax.inject/1": {
    "jar": "sha256-kcdwRKUMSBY2wy2Rb9ickRinIZU5BFLIEGUID5V95/8=",
    "pom": "sha256-lD4SsQBieARjj6KFgFoKt4imgCZlMeZQkh6/5GIai/o="


### PR DESCRIPTION
## Summary
- Remove the unused javax.annotation dependency from the Gradle build
- Drop the matching entry from the Nix dependency lock file

Follow up on #934