### PR TITLE
chore: downgrade Jetty to v12.1.8 for UI compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,11 +56,11 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:2.0.18'
     implementation 'org.slf4j:slf4j-jdk14:2.0.18'
 
-    implementation 'org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.9'
-    implementation 'org.eclipse.jetty.ee10:jetty-ee10-servlets:12.1.9'
-    implementation 'org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jetty-server:12.1.9'
-    implementation 'org.eclipse.jetty.compression:jetty-compression-server:12.1.9' 
-    implementation 'org.eclipse.jetty.compression:jetty-compression-gzip:12.1.9'   
+    implementation 'org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.8'
+    implementation 'org.eclipse.jetty.ee10:jetty-ee10-servlets:12.1.8'
+    implementation 'org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jetty-server:12.1.8'
+    implementation 'org.eclipse.jetty.compression:jetty-compression-server:12.1.8' 
+    implementation 'org.eclipse.jetty.compression:jetty-compression-gzip:12.1.8'   
 
     implementation 'com.github.jiconfont:jiconfont:1.0.0'
     implementation 'com.github.jiconfont:jiconfont-swing:1.0.1'

--- a/src/brs/BlockchainProcessorImpl.java
+++ b/src/brs/BlockchainProcessorImpl.java
@@ -1019,7 +1019,9 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
                             for (int i = myPoppedOffBlocks.size() - 1; i >= 0; i--) {
                                 Block block = myPoppedOffBlocks.remove(i);
                                 try {
-                                    blockService.preVerify(block, blockchain.getLastBlock());
+                                    if (!block.isVerified()) {
+                                        blockService.preVerify(block, blockchain.getLastBlock());
+                                    }
                                     pushBlock(block);
                                 } catch (InterruptedException e) {
                                     Thread.currentThread().interrupt();
@@ -2206,7 +2208,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
                 if (block.getId() == 0L || blockDb.hasBlock(block.getId())) {
                     throw new BlockNotAcceptedException("Duplicate block or invalid id for block " + block.getHeight());
                 }
-                if (!blockService.verifyGenerationSignature(block)) {
+                if (!block.isVerified() && !blockService.verifyGenerationSignature(block)) {
                     throw new BlockNotAcceptedException(
                             "Generation signature verification failed for block " + block.getHeight());
                 }

--- a/src/brs/BlockchainProcessorImpl.java
+++ b/src/brs/BlockchainProcessorImpl.java
@@ -2316,7 +2316,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
                             "Total amount or fee don't match transaction totals for block " + block.getHeight());
                 }
 
-                if (block.getVersion() >= 4 && Signum.getFluxCapacitor().getValue(FluxValues.SMART_FEES, block.getHeight())) {
+                if (Signum.getFluxCapacitor().getValue(FluxValues.SMART_FEES, block.getHeight())) {
                     long calculatedTotalFeeCashBackNqt = 0;
                     for (Transaction transaction : transactions) {
                         calculatedTotalFeeCashBackNqt = Convert.safeAdd(calculatedTotalFeeCashBackNqt,
@@ -2480,18 +2480,16 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
         }
         atTimeNanos = atEndTime > 0 ? atEndTime - atStartTime : 0;
 
-        long calculatedAtAmount = atBlock.getTotalAmount();
-        long calculatedAtFee = atBlock.getTotalFees();
-        long calculatedSubscriptionFee = 0;
+        long calculatedRemainingAmount = 0;
+        long calculatedRemainingFee = 0;
+        calculatedRemainingAmount += atBlock.getTotalAmount();
+        calculatedRemainingFee += atBlock.getTotalFees();
 
         start = System.nanoTime();
         if (subscriptionService.isEnabled()) {
-            calculatedSubscriptionFee = subscriptionService.applyUnconfirmed(block.getTimestamp(), block.getHeight());
+            calculatedRemainingFee += subscriptionService.applyUnconfirmed(block.getTimestamp(), block.getHeight());
         }
         subscriptionTimeNanos = (System.nanoTime() - start);
-
-        long calculatedRemainingAmount = (block.getVersion() >= 4) ? calculatedAtAmount : 0L;
-        long calculatedRemainingFee = (block.getVersion() >= 4) ? Convert.safeAdd(calculatedAtFee, calculatedSubscriptionFee) : 0L;
 
         if (remainingAmount != null && remainingAmount != calculatedRemainingAmount) {
             throw new BlockNotAcceptedException(
@@ -2501,7 +2499,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
             throw new BlockNotAcceptedException(
                     "Calculated remaining fee doesn't add up for block " + block.getHeight());
         }
-         if (block.getVersion() >= 4 && Signum.getFluxCapacitor().getValue(FluxValues.SMART_FEES, block.getHeight())) {
+        if (Signum.getFluxCapacitor().getValue(FluxValues.SMART_FEES, block.getHeight())) {
             if (calculatedRemainingFee != block.getTotalFeeBurntNqt()) {
                 throw new BlockNotAcceptedException(
                         "Total fee burnt doesn't match AT and subscription totals for block " + block.getHeight());
@@ -3011,8 +3009,8 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
                 if (subscriptionService.isEnabled()) {
                     subscriptionService.clearRemovals();
                     long subscriptionFeeNqt = subscriptionService.calculateFees(blockTimestamp, blockHeight);
-                    if (getBlockVersion() >= 4 && Signum.getFluxCapacitor().getValue(FluxValues.SMART_FEES, blockHeight)) {
-                        totalFeeNqt = Convert.safeAdd(totalFeeNqt, subscriptionFeeNqt);
+                    totalFeeNqt = Convert.safeAdd(totalFeeNqt, subscriptionFeeNqt);
+                    if (Signum.getFluxCapacitor().getValue(FluxValues.SMART_FEES, blockHeight)) {
                         totalFeeBurntNqt = Convert.safeAdd(totalFeeBurntNqt, subscriptionFeeNqt);
                     }
                 }
@@ -3033,11 +3031,11 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
             // digesting AT Bytes
             if (byteAts != null) {
                 payloadSize -= byteAts.length;
-                if (getBlockVersion() >= 4 && Signum.getFluxCapacitor().getValue(FluxValues.SMART_FEES, blockHeight)) {
-                    totalFeeNqt = Convert.safeAdd(totalFeeNqt, atBlock.getTotalFees());
+                totalFeeNqt = Convert.safeAdd(totalFeeNqt, atBlock.getTotalFees());
+                if (Signum.getFluxCapacitor().getValue(FluxValues.SMART_FEES, blockHeight)) {
                     totalFeeBurntNqt = Convert.safeAdd(totalFeeBurntNqt, atBlock.getTotalFees());
-                    totalAmountNqt = Convert.safeAdd(totalAmountNqt, atBlock.getTotalAmount());
                 }
+                totalAmountNqt = Convert.safeAdd(totalAmountNqt, atBlock.getTotalAmount());
             }
 
             // ATs for block

--- a/src/brs/BlockchainProcessorImpl.java
+++ b/src/brs/BlockchainProcessorImpl.java
@@ -2499,7 +2499,7 @@ public final class BlockchainProcessorImpl implements BlockchainProcessor {
             throw new BlockNotAcceptedException(
                     "Calculated remaining fee doesn't add up for block " + block.getHeight());
         }
-        if (Signum.getFluxCapacitor().getValue(FluxValues.SMART_FEES, block.getHeight())) {
+        if (block.getVersion() >= 4 && Signum.getFluxCapacitor().getValue(FluxValues.SMART_FEES, block.getHeight())) {
             if (calculatedRemainingFee != block.getTotalFeeBurntNqt()) {
                 throw new BlockNotAcceptedException(
                         "Total fee burnt doesn't match AT and subscription totals for block " + block.getHeight());


### PR DESCRIPTION
Summary

This PR downgrades the Jetty server dependencies from version 12.1.9 to 12.1.8 This change is necessary because the recent upgrade to Jetty 12 caused the node's local web interfaces (including the Wallet UI and OpenAPI documentation) to become inaccessible or fail to load static resources.