### PR TITLE
chore: downgrade Jetty to v12.1.8 for UI compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,11 +56,11 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:2.0.18'
     implementation 'org.slf4j:slf4j-jdk14:2.0.18'
 
-    implementation 'org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.9'
-    implementation 'org.eclipse.jetty.ee10:jetty-ee10-servlets:12.1.9'
-    implementation 'org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jetty-server:12.1.9'
-    implementation 'org.eclipse.jetty.compression:jetty-compression-server:12.1.9' 
-    implementation 'org.eclipse.jetty.compression:jetty-compression-gzip:12.1.9'   
+    implementation 'org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.8'
+    implementation 'org.eclipse.jetty.ee10:jetty-ee10-servlets:12.1.8'
+    implementation 'org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jetty-server:12.1.8'
+    implementation 'org.eclipse.jetty.compression:jetty-compression-server:12.1.8' 
+    implementation 'org.eclipse.jetty.compression:jetty-compression-gzip:12.1.8'   
 
     implementation 'com.github.jiconfont:jiconfont:1.0.0'
     implementation 'com.github.jiconfont:jiconfont-swing:1.0.1'


### PR DESCRIPTION
Summary

This PR downgrades the Jetty server dependencies from version 12.1.9 to 12.1.8 This change is necessary because the recent upgrade to Jetty 12.1.9 caused the node's local web interfaces (including the Wallet UI and OpenAPI documentation) to become inaccessible or fail to load static resources.