### PR TITLE
Bump Jetty to 12.1.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,11 +56,11 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:2.0.18'
     implementation 'org.slf4j:slf4j-jdk14:2.0.18'
 
-    implementation 'org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.8'
-    implementation 'org.eclipse.jetty.ee10:jetty-ee10-servlets:12.1.8'
-    implementation 'org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jetty-server:12.1.8'
-    implementation 'org.eclipse.jetty.compression:jetty-compression-server:12.1.8' 
-    implementation 'org.eclipse.jetty.compression:jetty-compression-gzip:12.1.8'   
+    implementation 'org.eclipse.jetty.ee10:jetty-ee10-servlet:12.1.10'
+    implementation 'org.eclipse.jetty.ee10:jetty-ee10-servlets:12.1.10'
+    implementation 'org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jetty-server:12.1.10'
+    implementation 'org.eclipse.jetty.compression:jetty-compression-server:12.1.10' 
+    implementation 'org.eclipse.jetty.compression:jetty-compression-gzip:12.1.10'   
 
     implementation 'com.github.jiconfont:jiconfont:1.0.0'
     implementation 'com.github.jiconfont:jiconfont-swing:1.0.1'


### PR DESCRIPTION
Bumps Jetty `12.1.8` → `12.1.10`.

Fixes #1021 — on Windows the web wallet / API-docs returned 404 for all static files due to Jetty [#15011](https://github.com/jetty/jetty.project/issues/15011) (`PathResource.resolve()` `InvalidPathException` on drive-letter paths), fixed in 12.1.10. Verified on Windows: stock code + 12.1.10 serves the full wallet. No code changes.
