### PR TITLE
ci: label-triggered PR review via official claude-code-action

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,436 +1,60 @@
-name: "PR Review: Claude Analysis"
+name: "PR Review: Claude"
 
-# Two trigger modes:
-# 1. AUTOMATIC: After "PR Size Check" passes (workflow_run)
-# 2. MANUAL: workflow_dispatch with a PR number (bypasses size check)
+# On-request, security-focused PR review via the official Anthropic action.
+# Runs ONLY when the "claude-review" label is added to a pull request, so it
+# never runs automatically (e.g. on Dependabot PRs). Re-add the label to re-run.
 #
-# Runs in the BASE repo context — HAS access to secrets.
+# Adding a label requires write (triage) access, so triggering is implicitly
+# limited to collaborators — no extra author check needed.
+#
+# Auth: pay-as-you-go API billing via the ANTHROPIC_API_KEY repo secret.
+#
+# Note: `pull_request` events do NOT expose secrets to PRs from forks, so the
+# review only works on same-repo (branch) PRs. (pull_request_target would reach
+# forks but runs untrusted code with secret access — avoided for this codebase.)
 
 on:
-  workflow_run:
-    workflows: ["PR Size Check"]
-    types: [completed]
-
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: "PR number to review (overrides size check)"
-        required: true
-        type: number
+  pull_request:
+    types: [labeled]
 
 permissions:
   contents: read
   pull-requests: write
-  issues: write
-  actions: read
 
 jobs:
   review:
     runs-on: ubuntu-latest
-    # For workflow_run: only run if size check passed
-    # For workflow_dispatch: always run
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
-
+    if: github.event.label.name == 'claude-review'
     steps:
-      # ── Resolve PR number from either trigger ──
-
-      - name: Download PR metadata (automatic trigger)
-        if: github.event_name == 'workflow_run'
-        uses: actions/download-artifact@v8
+      - name: Claude review
+        uses: anthropics/claude-code-action@v1
         with:
-          name: pr-metadata
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: pr-metadata
-
-      - name: Collect PR metadata (manual trigger)
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          mkdir -p pr-metadata
-
-          PR_NUMBER=${{ inputs.pr_number }}
-          echo "Manual review requested for PR #$PR_NUMBER"
-
-          # Fetch PR details via GitHub API
-          gh pr view "$PR_NUMBER" --json number,title,body,author,baseRefName,headRefName,additions,deletions,changedFiles,isCrossRepository > pr_data.json
-
-          python3 << 'PYEOF'
-          import json
-
-          with open("pr_data.json") as f:
-              pr = json.load(f)
-
-          metadata = {
-              "pr_number": pr["number"],
-              "pr_title": pr["title"],
-              "pr_body": pr.get("body", ""),
-              "pr_author": pr["author"]["login"],
-              "base_ref": pr["baseRefName"],
-              "head_ref": pr["headRefName"],
-              "head_sha": "",
-              "is_fork": pr.get("isCrossRepository", False),
-              "file_count": pr["changedFiles"],
-              "additions": pr["additions"],
-              "deletions": pr["deletions"],
-              "protocol_files": [],
-              "manual_override": True,
-          }
-
-          # Detect protocol-frozen files
-          protocol_paths = [
-              "brs/GeneratorImpl.java", "brs/util/MiningPlot.java", "brs/OCLPoC.java",
-              "brs/BlockchainProcessorImpl.java", "brs/BlockchainImpl.java",
-              "brs/services/impl/BlockServiceImpl.java",
-              "brs/TransactionType.java", "brs/Transaction.java", "brs/Attachment.java",
-              "brs/services/impl/TransactionServiceImpl.java", "brs/EconomicClustering.java",
-              "brs/Constants.java", "brs/Genesis.java",
-              "brs/fluxcapacitor/FluxValues.java", "brs/fluxcapacitor/HistoricalMoments.java",
-              "brs/fluxcapacitor/FluxCapacitorImpl.java", "brs/props/Props.java",
-              "brs/crypto/Crypto.java", "brs/crypto/EncryptedData.java",
-              "brs/at/AtController.java", "brs/at/AtMachineProcessor.java",
-              "brs/at/OpCode.java", "brs/at/AtConstants.java",
-              "brs/at/AtApiImpl.java", "brs/at/AtApiController.java", "brs/at/AtApiPlatformImpl.java",
-              "brs/peer/PeerServlet.java", "brs/peer/ProcessBlock.java",
-              "brs/peer/GetCumulativeDifficulty.java",
-          ]
-
-          with open("pr_files.json") as ff:
-              pass  # we'll get files separately below
-
-          with open("pr-metadata/metadata.json", "w") as f:
-              json.dump(metadata, f, indent=2)
-
-          print(f"Metadata collected for PR #{metadata['pr_number']}")
-          PYEOF
-
-          # Get file list and detect protocol files
-          gh pr view "$PR_NUMBER" --json files --jq '.files[].path' > pr_file_list.txt
-
-          python3 << 'PYEOF'
-          import json
-
-          protocol_paths = [
-              "brs/GeneratorImpl.java", "brs/util/MiningPlot.java", "brs/OCLPoC.java",
-              "brs/BlockchainProcessorImpl.java", "brs/BlockchainImpl.java",
-              "brs/services/impl/BlockServiceImpl.java",
-              "brs/TransactionType.java", "brs/Transaction.java", "brs/Attachment.java",
-              "brs/services/impl/TransactionServiceImpl.java", "brs/EconomicClustering.java",
-              "brs/Constants.java", "brs/Genesis.java",
-              "brs/fluxcapacitor/FluxValues.java", "brs/fluxcapacitor/HistoricalMoments.java",
-              "brs/fluxcapacitor/FluxCapacitorImpl.java", "brs/props/Props.java",
-              "brs/crypto/Crypto.java", "brs/crypto/EncryptedData.java",
-              "brs/at/AtController.java", "brs/at/AtMachineProcessor.java",
-              "brs/at/OpCode.java", "brs/at/AtConstants.java",
-              "brs/at/AtApiImpl.java", "brs/at/AtApiController.java", "brs/at/AtApiPlatformImpl.java",
-              "brs/peer/PeerServlet.java", "brs/peer/ProcessBlock.java",
-              "brs/peer/GetCumulativeDifficulty.java",
-          ]
-
-          with open("pr_file_list.txt") as f:
-              files = [line.strip() for line in f if line.strip()]
-
-          touched = [fp for fp in files if any(p in fp for p in protocol_paths)]
-
-          with open("pr-metadata/metadata.json") as f:
-              meta = json.load(f)
-
-          meta["protocol_files"] = touched
-
-          with open("pr-metadata/metadata.json", "w") as f:
-              json.dump(meta, f, indent=2)
-
-          if touched:
-              print(f"Protocol files detected: {touched}")
-          PYEOF
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # ── Common steps (both triggers) ──
-
-      - name: Load metadata
-        id: meta
-        run: |
-          if [ ! -f pr-metadata/metadata.json ]; then
-            echo "::error::No metadata found."
-            echo "skip=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          python3 << 'PYEOF'
-          import json, os
-
-          with open("pr-metadata/metadata.json") as f:
-              meta = json.load(f)
-
-          with open(os.environ["GITHUB_OUTPUT"], "a") as out:
-              out.write(f"pr_number={meta['pr_number']}\n")
-              out.write(f"pr_author={meta['pr_author']}\n")
-              out.write(f"base_ref={meta['base_ref']}\n")
-              out.write(f"file_count={meta['file_count']}\n")
-              out.write(f"skip=false\n")
-
-          manual = meta.get("manual_override", False)
-          trigger = "manual override" if manual else "automatic"
-          print(f"Reviewing PR #{meta['pr_number']} by {meta['pr_author']} ({meta['file_count']} files, +{meta['additions']}) [{trigger}]")
-          PYEOF
-
-      - name: Validate API key
-        if: steps.meta.outputs.skip != 'true'
-        run: |
-          if [ -z "$ANTHROPIC_API_KEY" ]; then
-            echo "::error::ANTHROPIC_API_KEY secret is not set or empty."
-            exit 1
-          fi
-          echo "API key is configured."
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-
-      - name: Checkout base repo (for guidelines only)
-        if: steps.meta.outputs.skip != 'true'
-        uses: actions/checkout@v6
-        with:
-          # Use repo default branch — never trust refs from artifacts or inputs.
-          ref: ${{ github.event.workflow_run.head_repository.default_branch || 'develop' }}
-          persist-credentials: false
-          sparse-checkout: |
-            CLAUDE.md
-            .github/copilot-instructions.md
-          sparse-checkout-cone-mode: false
-
-      - name: Collect diff via GitHub API
-        if: steps.meta.outputs.skip != 'true'
-        run: |
-          PR_NUMBER=${{ steps.meta.outputs.pr_number }}
-
-          gh pr diff "$PR_NUMBER" > pr_diff.txt 2>/dev/null || true
-
-          DIFF_SIZE=$(wc -c < pr_diff.txt)
-          echo "Diff size: $DIFF_SIZE bytes"
-
-          if [ "$DIFF_SIZE" -gt 50000 ]; then
-            echo "Truncating diff from $DIFF_SIZE to 50KB..."
-            head -c 50000 pr_diff.txt > pr_diff_truncated.txt
-            mv pr_diff_truncated.txt pr_diff.txt
-            echo "" >> pr_diff.txt
-            echo "... [DIFF TRUNCATED - Original: ${DIFF_SIZE} bytes. Review may be incomplete.]" >> pr_diff.txt
-          fi
-
-          gh pr view "$PR_NUMBER" --json files --jq '.files[].path' > pr_changed_files.txt
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Prepare guidelines
-        if: steps.meta.outputs.skip != 'true'
-        run: |
-          if [ -f "CLAUDE.md" ]; then
-            head -c 12000 CLAUDE.md > guidelines.txt
-          else
-            echo "No CLAUDE.md found." > guidelines.txt
-          fi
-
-          if [ -f ".github/copilot-instructions.md" ]; then
-            echo "" >> guidelines.txt
-            echo "---" >> guidelines.txt
-            sed -n '/## PR Review: Security/,$p' .github/copilot-instructions.md >> guidelines.txt
-          fi
-
-          head -c 20000 guidelines.txt > guidelines_trimmed.txt
-          mv guidelines_trimmed.txt guidelines.txt
-
-      - name: Build Claude request
-        if: steps.meta.outputs.skip != 'true'
-        run: |
-          python3 << 'PYEOF'
-          import json
-
-          with open("pr-metadata/metadata.json") as f:
-              meta = json.load(f)
-
-          with open("pr_diff.txt") as f:
-              diff = f.read()
-
-          with open("guidelines.txt") as f:
-              guidelines = f.read()
-
-          with open("pr_changed_files.txt") as f:
-              changed_files = f.read().strip()
-
-          manual = meta.get("manual_override", False)
-          size_note = ""
-          if manual:
-              size_note = """
-          NOTE: This review was triggered manually (size check override). The PR exceeds
-          normal size limits. Pay extra attention to the volume of changes and whether
-          the PR should be split into smaller pieces.
-          """
-
-          protocol_note = ""
-          if meta.get("protocol_files"):
-              files_list = "\n".join(f"  - {f}" for f in meta["protocol_files"])
-              protocol_note = f"""
-          ALERT: This PR modifies {len(meta['protocol_files'])} PROTOCOL-FROZEN file(s):
-          {files_list}
-          These changes MUST be rejected unless the PR explicitly references a disclosed CVE being fixed.
-          """
-
-          system_prompt = f"""You are a senior security-focused code reviewer for the Signum Node blockchain project.
-          This is critical cryptocurrency infrastructure. Your primary job is to protect protocol integrity and catch exploitable code.
-
-          CONTEXT:
-          - Java 21 blockchain node (Proof-of-Commitment / PoC+ consensus)
-          - The Signum protocol is STABLE. Changes to consensus, transaction processing, cryptography, smart contracts (AT), or P2P protocol code are NOT permitted unless fixing a disclosed CVE.
-          - Layered architecture: API handlers -> Services -> Stores -> Database (JOOQ/Flyway)
-          - External contributors may submit AI-generated code ("vibe coding") that looks plausible but may contain subtle vulnerabilities or backdoors.
-          {size_note}{protocol_note}
-          REVIEW PRIORITIES (in order):
-          1. PROTOCOL INTEGRITY: Flag ANY changes to protocol-frozen files (consensus, block validation, transaction types, constants, crypto, AT engine, P2P). These require explicit maintainer justification.
-          2. SECURITY: Backdoors, hardcoded accounts/keys, obfuscated logic, overflow/underflow, signature bypass, gas metering bypass, input validation gaps.
-          3. ARCHITECTURE: Layer violations, direct DB access from business logic, missing dependency injection.
-          4. TESTING: New logic without unit tests -> reject.
-          5. CODE QUALITY: Clean code, proper error handling, logging.
-
-          PROJECT GUIDELINES:
-          {guidelines}
-
-          OUTPUT FORMAT (use this exact structure):
-
-          ### Verdict: [APPROVE | REQUEST_CHANGES | COMMENT]
-
-          ### Protocol Impact
-          [List any protocol-frozen files touched. If none, say "No protocol files modified."]
-
-          ### Security Findings
-          [List security issues with WARNING prefix. If none, say "No security issues found."]
-
-          ### Architecture & Quality
-          [Notable findings, good practices, issues]
-
-          ### Action Items
-          [Numbered list of required changes, or "None - ready to merge."]
-
-          Be concise. Use file:line references. Do not pad with generic praise."""
-
-          user_message = f"""Review this Pull Request for Signum Node:
-
-          **PR #{meta['pr_number']}**: {meta['pr_title']}
-          **Author**: {meta['pr_author']}
-          **Target**: {meta['base_ref']} <- {meta['head_ref']}
-          **From fork**: {meta['is_fork']}
-          **Files changed**: {meta['file_count']} (+{meta['additions']}, -{meta['deletions']})
-          **Trigger**: {"Manual override (size check bypassed)" if manual else "Automatic (size check passed)"}
-
-          **Description**:
-          {meta.get('pr_body') or 'No description provided.'}
-
-          **Changed files**:
-          {changed_files}
-
-          **Diff**:
-          ```
-          {diff}
-          ```"""
-
-          request = {
-              "model": "claude-sonnet-4-20250514",
-              "max_tokens": 4096,
-              "system": system_prompt,
-              "messages": [{"role": "user", "content": user_message}]
-          }
-
-          with open("claude_request.json", "w") as f:
-              json.dump(request, f)
-
-          print(f"Request built for PR #{meta['pr_number']} ({meta['file_count']} files, {'manual' if manual else 'auto'})")
-          PYEOF
-
-      - name: Call Claude API
-        if: steps.meta.outputs.skip != 'true'
-        id: claude
-        run: |
-          HTTP_STATUS=$(curl -w "%{http_code}" -s -o claude_response.json \
-            --max-time 60 \
-            -X POST "https://api.anthropic.com/v1/messages" \
-            -H "Content-Type: application/json" \
-            -H "x-api-key: $ANTHROPIC_API_KEY" \
-            -H "anthropic-version: 2023-06-01" \
-            -d @claude_request.json)
-
-          echo "HTTP Status: $HTTP_STATUS"
-
-          if [ "$HTTP_STATUS" != "200" ]; then
-            echo "::error::Claude API returned HTTP $HTTP_STATUS"
-            cat claude_response.json
-            echo "success=false" >> $GITHUB_OUTPUT
-            exit 1
-          fi
-
-          python3 << 'PYEOF'
-          import json, sys
-
-          with open("claude_response.json") as f:
-              data = json.load(f)
-
-          if "content" not in data or len(data["content"]) == 0:
-              print("::error::Empty response from Claude API", file=sys.stderr)
-              sys.exit(1)
-
-          review = data["content"][0]["text"]
-          with open("claude_review.txt", "w") as f:
-              f.write(review)
-
-          print(f"Review generated: {len(review)} chars")
-          PYEOF
-
-          echo "success=true" >> $GITHUB_OUTPUT
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-
-      - name: Post review comment
-        if: steps.claude.outputs.success == 'true'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const fs = require('fs');
-
-            const reviewContent = fs.readFileSync('claude_review.txt', 'utf8').trim();
-            if (!reviewContent) {
-              console.log('Review content is empty, skipping.');
-              return;
-            }
-
-            const meta = JSON.parse(fs.readFileSync('pr-metadata/metadata.json', 'utf8'));
-            const manual = meta.manual_override ? ' (manual override — size check bypassed)' : '';
-
-            const body = [
-              '## Claude AI Code Review',
-              '',
-              reviewContent,
-              '',
-              '---',
-              `*Automated review of ${meta.file_count} changed file(s) (+${meta.additions}, -${meta.deletions})${manual}. Address any security issues before merging.*`,
-            ].join('\n');
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: meta.pr_number,
-              body: body,
-            });
-
-            console.log(`Review posted on PR #${meta.pr_number}`);
-
-      - name: Summary
-        if: always()
-        run: |
-          echo "## Claude PR Review" >> $GITHUB_STEP_SUMMARY
-          echo "- **PR:** #${{ steps.meta.outputs.pr_number || 'unknown' }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Trigger:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **API success:** ${{ steps.claude.outputs.success || 'skipped' }}" >> $GITHUB_STEP_SUMMARY
-
-          if [ -f claude_review.txt ]; then
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### Review" >> $GITHUB_STEP_SUMMARY
-            head -c 2000 claude_review.txt >> $GITHUB_STEP_SUMMARY
-          fi
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          use_sticky_comment: true
+          prompt: |
+            You are a senior security-focused reviewer for Signum Node, the Java
+            reference implementation of the Signum (Proof-of-Commitment) blockchain.
+            This is critical cryptocurrency infrastructure.
+
+            Review ONLY the changes in this pull request. First read CLAUDE.md and
+            .github/CLAUDE_PR_REVIEW.md (if present) and follow the project's review
+            priorities and protocol-frozen-file rules.
+
+            Prioritise, in order:
+            1. Protocol integrity — flag any change to consensus, block/transaction
+               validation, transaction types, constants, crypto, the AT engine, or
+               P2P code. These require explicit maintainer justification (e.g. a
+               disclosed CVE) and should otherwise be challenged.
+            2. Security — overflow/underflow, signature/validation bypass, balance
+               or quantity manipulation, hardcoded secrets, obfuscated logic.
+            3. Consensus safety — new validation rules that could reject historical
+               blocks (chain-split risk) unless gated behind a hard-fork height.
+            4. Tests — new logic without unit tests.
+            5. Code quality and error handling.
+
+            Be concise, cite file:line, and skip generic praise. Post your findings
+            as a single review comment. Do not modify code.
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 20
+            --allowedTools Read,Grep,Glob


### PR DESCRIPTION
## What

Replaces the broken hand-rolled `pr-review.yml` (curl → Anthropic API) with the official **`anthropics/claude-code-action@v1`**.

## Why

The previous workflow never worked:
- The "checkout base repo" step ran `actions/checkout` (default `clean: true`), which **wiped the generated `pr-metadata/metadata.json`** before the request-builder step read it → `FileNotFoundError`.
- It pinned `claude-sonnet-4-20250514`, a model ID that **retired 2026-06-15** → the API call would 404 anyway.
- Plus a dead `open("pr_files.json")` and suspicious action major versions.

## How it works now

- **On-request only:** runs when the **`claude-review`** label is added to a PR. It never runs automatically — so Dependabot and routine PRs stay quiet. Re-add the label to re-run.
- Adding a label requires write/triage access, so triggering is implicitly limited to collaborators (no extra author check needed).
- Curated **security/protocol-focused** review prompt (follows `CLAUDE.md` + `.github/CLAUDE_PR_REVIEW.md`), **read-only** tools (`Read,Grep,Glob`), single sticky comment, `claude-sonnet-4-6`.
- Auth via the existing `ANTHROPIC_API_KEY` secret. `pr-size-check.yml` is unchanged.

## Setup note

Create the `claude-review` label in the repo (Labels → New label) so it can be applied.

## Limitation

`pull_request` events don't expose secrets to PRs from **forks**, so the review only runs on same-repo (branch) PRs. `pull_request_target` would reach forks but runs untrusted code with secret access — deliberately avoided for this codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)