### PR TITLE
fix: reject negative escrow amount; clean up dead multi-same-out check

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -27,6 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.label.name == 'claude-review'
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: Claude review
         uses: anthropics/claude-code-action@v1
         with:

--- a/src/brs/TransactionType.java
+++ b/src/brs/TransactionType.java
@@ -520,10 +520,11 @@ public abstract class TransactionType {
           throw new SignumException.NotCurrentlyValidException("Multi Same Out Payments are not allowed before the Pre POC2 block");
         }
 
-        Attachment.PaymentMultiSameOutCreation attachment = (Attachment.PaymentMultiSameOutCreation) transaction.getAttachment();
-        if (attachment.getRecipients().size() < 2 && (transaction.getAmountNqt() % attachment.getRecipients().size() == 0 ) ) {
-          throw new SignumException.NotValidException("Invalid multi out payment");
-        }
+        // Recipient count (2..MAX_MULTI_SAME_OUT_RECIPIENTS) is already enforced when the
+        // attachment is parsed. The per-recipient share is floor(amountNqt / recipients), so any
+        // indivisible remainder is burned (never minted). Divisibility is intentionally NOT
+        // enforced here: tightening this consensus rule would reject historically-accepted
+        // transactions on resync.
       }
 
       @Override
@@ -2976,6 +2977,9 @@ public abstract class TransactionType {
       @Override
       protected void validateAttachment(Transaction transaction) throws SignumException.ValidationException {
         Attachment.AdvancedPaymentEscrowCreation attachment = (Attachment.AdvancedPaymentEscrowCreation) transaction.getAttachment();
+        if (attachment.getAmountNqt() < 0L) {
+          throw new SignumException.NotValidException("Escrow amount cannot be negative: " + JSON.toJsonString(attachment.getJsonObject()));
+        }
         Long totalAmountNQT = Convert.safeAdd(attachment.getAmountNqt(), transaction.getFeeNqt());
         if (transaction.getSenderId() == transaction.getRecipientId()) {
           throw new SignumException.NotValidException("Escrow must have different sender and recipient");

--- a/test/java/brs/TransactionTypeEscrowTest.java
+++ b/test/java/brs/TransactionTypeEscrowTest.java
@@ -1,0 +1,81 @@
+package brs;
+
+import brs.assetexchange.AssetExchange;
+import brs.common.QuickMocker;
+import brs.fluxcapacitor.FluxCapacitor;
+import brs.services.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.MockedStatic;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(JUnit4.class)
+public class TransactionTypeEscrowTest {
+
+    private static final long SENDER_ID = 1L;
+    private static final long RECIPIENT_ID = 3L;
+    private static final long SIGNER_ID = 2L;
+    private static final int CURRENT_HEIGHT = 1_000_000;
+
+    private EscrowService mockEscrowService;
+    private FluxCapacitor mockFluxCapacitor;
+
+    @Before
+    public void setUp() {
+        mockEscrowService = mock(EscrowService.class);
+        when(mockEscrowService.isEnabled()).thenReturn(true);
+        mockFluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities();
+
+        TransactionType.init(
+            mock(Blockchain.class),
+            mockFluxCapacitor,
+            mock(AccountService.class),
+            mock(DGSGoodsStoreService.class),
+            mock(AliasService.class),
+            mock(AssetExchange.class),
+            mock(SubscriptionService.class),
+            mockEscrowService
+        );
+    }
+
+    private Transaction transactionWith(Attachment attachment, long amountNqt) {
+        Transaction transaction = mock(Transaction.class);
+        when(transaction.getAttachment()).thenReturn(attachment);
+        when(transaction.getSenderId()).thenReturn(SENDER_ID);
+        when(transaction.getRecipientId()).thenReturn(RECIPIENT_ID);
+        when(transaction.getAmountNqt()).thenReturn(amountNqt);
+        when(transaction.getFeeNqt()).thenReturn(Constants.ONE_SIGNA);
+        return transaction;
+    }
+
+    private Attachment.AdvancedPaymentEscrowCreation escrowCreation(long amountNqt) throws SignumException.NotValidException {
+        return new Attachment.AdvancedPaymentEscrowCreation(
+            amountNqt, 100, Escrow.DecisionType.REFUND, 1,
+            Collections.singletonList(SIGNER_ID), CURRENT_HEIGHT);
+    }
+
+    @Test(expected = SignumException.NotValidException.class)
+    public void validateAttachment_givenNegativeEscrowAmount_throwsNotValidException() throws SignumException.ValidationException {
+        try (MockedStatic<Signum> signumMock = mockStatic(Signum.class)) {
+            signumMock.when(Signum::getFluxCapacitor).thenReturn(mockFluxCapacitor);
+
+            Transaction transaction = transactionWith(escrowCreation(-100L), 0L);
+            TransactionType.AdvancedPayment.ESCROW_CREATION.validateAttachment(transaction);
+        }
+    }
+
+    @Test
+    public void validateAttachment_givenNonNegativeEscrowAmount_passes() throws SignumException.ValidationException {
+        try (MockedStatic<Signum> signumMock = mockStatic(Signum.class)) {
+            signumMock.when(Signum::getFluxCapacitor).thenReturn(mockFluxCapacitor);
+
+            Transaction transaction = transactionWith(escrowCreation(100L), 0L);
+            TransactionType.AdvancedPayment.ESCROW_CREATION.validateAttachment(transaction);
+        }
+    }
+}

--- a/test/java/brs/TransactionTypeMultiSameOutTest.java
+++ b/test/java/brs/TransactionTypeMultiSameOutTest.java
@@ -1,0 +1,62 @@
+package brs;
+
+import brs.assetexchange.AssetExchange;
+import brs.common.QuickMocker;
+import brs.fluxcapacitor.FluxCapacitor;
+import brs.fluxcapacitor.FluxValues;
+import brs.services.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.MockedStatic;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(JUnit4.class)
+public class TransactionTypeMultiSameOutTest {
+
+    private static final int CURRENT_HEIGHT = 1_000_000;
+
+    private FluxCapacitor mockFluxCapacitor;
+
+    @Before
+    public void setUp() {
+        mockFluxCapacitor = QuickMocker.fluxCapacitorEnabledFunctionalities(FluxValues.PRE_POC2);
+        TransactionType.init(
+            mock(Blockchain.class),
+            mockFluxCapacitor,
+            mock(AccountService.class),
+            mock(DGSGoodsStoreService.class),
+            mock(AliasService.class),
+            mock(AssetExchange.class),
+            mock(SubscriptionService.class),
+            mock(EscrowService.class)
+        );
+    }
+
+    /**
+     * Consensus characterization: a multi-same-out whose amount is NOT evenly divisible by the
+     * recipient count is, and must remain, valid. The per-recipient share is floor(amount/n), so
+     * the indivisible remainder is burned (never minted). Tightening this into a rejection would
+     * reject historically-accepted transactions on resync, so it is intentionally allowed.
+     */
+    @Test
+    public void validateAttachment_givenAmountNotDivisibleByRecipients_passes() throws SignumException.ValidationException {
+        try (MockedStatic<Signum> signumMock = mockStatic(Signum.class)) {
+            signumMock.when(Signum::getFluxCapacitor).thenReturn(mockFluxCapacitor);
+
+            Attachment.PaymentMultiSameOutCreation attachment =
+                new Attachment.PaymentMultiSameOutCreation(Arrays.asList(10L, 11L, 12L), CURRENT_HEIGHT);
+
+            Transaction transaction = mock(Transaction.class);
+            when(transaction.getAttachment()).thenReturn(attachment);
+            when(transaction.getHeight()).thenReturn(CURRENT_HEIGHT);
+            when(transaction.getAmountNqt()).thenReturn(100L); // 100 % 3 != 0
+
+            TransactionType.Payment.MULTI_SAME_OUT.validateAttachment(transaction);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two value-validation hardening changes found during a focused security review of integer-overflow / negative-value / value-minting risks. Both are in `TransactionType.java` and are consistent with the negative-value guards added in #1028.

### 1. Reject negative escrow amount (defense-in-depth)
`ESCROW_CREATION.validateAttachment` only checked the *aggregate* `amount + fee + signers·ONE_SIGNA` against `[0, MAX_BALANCE]`, so a small negative `amountNqt` (read raw via `buffer.getLong()`) could pass. It is **not** a mint — the negative nets to zero when the escrow is settled at its mandatory deadline action — but it is an illegal value that should be rejected at validation on every ingress path (API, raw broadcast, peer relay, block acceptance). Now guarded explicitly, mirroring the commitment / distribute-to-holders guards from #1028.

### 2. Remove dead/misleading `MULTI_SAME_OUT` check
The existing `if (size < 2 && amount % size == 0)` check is dead (recipient count is already bounded to `2..MAX` at parse time) and misleadingly looks like a divisibility check. Enforcing divisibility was **rejected as unsafe**: `validateAttachment` runs during block acceptance, and non-divisible multi-same-out transactions have been accepted on mainnet historically, so rejecting them would break resync (chain split) with no security benefit (the per-recipient share is `floor(amount/n)`, so the remainder is burned, never minted). The dead check is removed and the intentional behavior is documented.

## Tests
- `TransactionTypeEscrowTest` — negative amount rejected, non-negative passes (written test-first, watched fail before the fix).
- `TransactionTypeMultiSameOutTest` — characterization test locking in that a non-divisible amount stays valid, to prevent a future accidental consensus break.

Full unit + `chain.*` integration suite passes locally.

## Reviewer note (consensus)
Change #1 tightens a consensus validation. As with the #1028 guards, it assumes no historical mainnet escrow ever carried a negative `amountNqt`. Escrow is an old feature, so a quick chain scan to confirm this is worthwhile before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)