### PR TITLE
feat: consistent tag-driven release flow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -3,6 +3,11 @@ name: Auto-tag release on main
 # Runs only after the build+test workflow ("Build Signum Node") finishes on main.
 # This makes the tag a *hard* guarantee that main's build and tests were green,
 # rather than relying on the promotion always being a clean merge of tested code.
+#
+# This is a privileged context (workflow_run has write access and secrets), so it
+# deliberately does NOT check out the repository. It reads the version and creates
+# the tag entirely through the GitHub API, so no repository code is ever placed on
+# the runner or executed.
 on:
   workflow_run:
     workflows: ["Build Signum Node"]
@@ -10,7 +15,7 @@ on:
       - completed
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   auto-tag:
@@ -21,37 +26,44 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main'
+    env:
+      # The PAT is required so the created tag triggers the downstream
+      # release.yml / dockerhub.yml workflows (a tag from GITHUB_TOKEN would not).
+      GH_TOKEN: ${{ secrets.RELEASE_TAG_PAT }}
+      REPO: ${{ github.repository }}
+      SHA: ${{ github.event.workflow_run.head_sha }}
     steps:
-      - name: Checkout the built commit (full history + tags)
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha }}
-          token: ${{ secrets.RELEASE_TAG_PAT }}
-
-      - name: Read version from gradle.properties
+      - name: Read version from gradle.properties at the built commit
         id: ver
         shell: bash
         run: |
-          VERSION=$(grep -E '^version=' gradle.properties | head -1 | cut -d= -f2 | tr -d '[:space:]')
+          CONTENT=$(gh api "repos/$REPO/contents/gradle.properties?ref=$SHA" \
+            -H "Accept: application/vnd.github.raw")
+          VERSION=$(printf '%s\n' "$CONTENT" | grep -E '^version=' | head -1 | cut -d= -f2 | tr -d '[:space:]')
+          if [ -z "$VERSION" ]; then
+            echo "Could not read version from gradle.properties at $SHA" >&2
+            exit 1
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Version on main is $VERSION (commit ${{ github.event.workflow_run.head_sha }})"
+          echo "Version at $SHA is $VERSION"
 
-      - name: Create and push tag if missing
+      - name: Create tag if missing
         shell: bash
         run: |
           VERSION="${{ steps.ver.outputs.version }}"
           TAG="v$VERSION"
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
+          if gh api "repos/$REPO/git/ref/tags/$TAG" >/dev/null 2>&1; then
             echo "Tag $TAG already exists; nothing to do."
             exit 0
           fi
-          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q "$TAG"; then
-            echo "Tag $TAG already exists on origin; nothing to do."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" -m "Release $TAG"
-          git push origin "$TAG"
-          echo "Created and pushed $TAG"
+          # Create an annotated tag object pointing at the built commit, then the ref.
+          TAG_SHA=$(gh api "repos/$REPO/git/tags" \
+            -f tag="$TAG" \
+            -f message="Release $TAG" \
+            -f object="$SHA" \
+            -f type="commit" \
+            --jq '.sha')
+          gh api "repos/$REPO/git/refs" \
+            -f ref="refs/tags/$TAG" \
+            -f sha="$TAG_SHA" >/dev/null
+          echo "Created tag $TAG at $SHA"

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,46 @@
+name: Auto-tag release on main
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  auto-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main (full history + tags)
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TAG_PAT }}
+
+      - name: Read version from gradle.properties
+        id: ver
+        shell: bash
+        run: |
+          VERSION=$(grep -E '^version=' gradle.properties | head -1 | cut -d= -f2 | tr -d '[:space:]')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Version on main is $VERSION"
+
+      - name: Create and push tag if missing
+        shell: bash
+        run: |
+          VERSION="${{ steps.ver.outputs.version }}"
+          TAG="v$VERSION"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists; nothing to do."
+            exit 0
+          fi
+          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q "$TAG"; then
+            echo "Tag $TAG already exists on origin; nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+          echo "Created and pushed $TAG"

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -49,8 +49,9 @@ jobs:
 
       - name: Create tag if missing
         shell: bash
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
         run: |
-          VERSION="${{ steps.ver.outputs.version }}"
           TAG="v$VERSION"
           if gh api "repos/$REPO/git/ref/tags/$TAG" >/dev/null 2>&1; then
             echo "Tag $TAG already exists; nothing to do."

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,9 +1,13 @@
 name: Auto-tag release on main
 
+# Runs only after the build+test workflow ("Build Signum Node") finishes on main.
+# This makes the tag a *hard* guarantee that main's build and tests were green,
+# rather than relying on the promotion always being a clean merge of tested code.
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Build Signum Node"]
+    types:
+      - completed
 
 permissions:
   contents: write
@@ -11,11 +15,18 @@ permissions:
 jobs:
   auto-tag:
     runs-on: ubuntu-latest
+    # Only when the build succeeded, it was a push to main (not a PR build),
+    # so the tagged commit is exactly the one that passed CI.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
     steps:
-      - name: Checkout main (full history + tags)
+      - name: Checkout the built commit (full history + tags)
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
           token: ${{ secrets.RELEASE_TAG_PAT }}
 
       - name: Read version from gradle.properties
@@ -24,7 +35,7 @@ jobs:
         run: |
           VERSION=$(grep -E '^version=' gradle.properties | head -1 | cut -d= -f2 | tr -d '[:space:]')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Version on main is $VERSION"
+          echo "Version on main is $VERSION (commit ${{ github.event.workflow_run.head_sha }})"
 
       - name: Create and push tag if missing
         shell: bash

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -24,6 +24,10 @@ on:
         tags:
             - 'v*'
 
+# Images are pushed to Docker Hub via secrets; no write access to the repo is needed.
+permissions:
+    contents: read
+
 jobs:
   publish-image:
     name: Push Docker image to Docker Hub

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -20,6 +20,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write # required by claude-code-action to fetch an OIDC token
 
 jobs:
   review:

--- a/.github/workflows/pr-size-check.yml
+++ b/.github/workflows/pr-size-check.yml
@@ -78,12 +78,18 @@ jobs:
       - name: Enforce size limits
         id: limits
         uses: actions/github-script@v9
+        env:
+          FILE_COUNT: ${{ steps.stats.outputs.file_count }}
+          ADDITIONS: ${{ steps.stats.outputs.additions }}
+          PROTOCOL_COUNT: ${{ steps.stats.outputs.protocol_files_count }}
+          # Untrusted (contains attacker-controlled filenames) — never inline into the script.
+          PROTOCOL_FILES: ${{ steps.stats.outputs.protocol_files }}
         with:
           script: |
-            const fileCount = parseInt('${{ steps.stats.outputs.file_count }}');
-            const additions = parseInt('${{ steps.stats.outputs.additions }}');
-            const protocolCount = parseInt('${{ steps.stats.outputs.protocol_files_count }}');
-            const protocolFiles = JSON.parse('${{ steps.stats.outputs.protocol_files }}');
+            const fileCount = parseInt(process.env.FILE_COUNT);
+            const additions = parseInt(process.env.ADDITIONS);
+            const protocolCount = parseInt(process.env.PROTOCOL_COUNT);
+            const protocolFiles = JSON.parse(process.env.PROTOCOL_FILES);
 
             const MAX_FILES = 10;
             const MAX_ADDITIONS = 1000;
@@ -154,6 +160,21 @@ jobs:
 
       - name: Upload PR metadata
         if: success()
+        env:
+          # All values passed via env (not inlined) so attacker-controlled fields
+          # — titles, bodies, branch names, filenames — cannot inject code.
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          FILE_COUNT: ${{ steps.stats.outputs.file_count }}
+          ADDITIONS: ${{ steps.stats.outputs.additions }}
+          DELETIONS: ${{ steps.stats.outputs.deletions }}
+          PROTOCOL_FILES: ${{ steps.stats.outputs.protocol_files }}
         run: |
           mkdir -p pr-metadata
 
@@ -161,18 +182,18 @@ jobs:
           import json, os
 
           metadata = {
-              "pr_number": int("${{ github.event.pull_request.number }}"),
+              "pr_number": int(os.environ["PR_NUMBER"]),
               "pr_title": os.environ.get("PR_TITLE", ""),
               "pr_body": os.environ.get("PR_BODY", ""),
-              "pr_author": "${{ github.event.pull_request.user.login }}",
-              "base_ref": "${{ github.event.pull_request.base.ref }}",
-              "head_ref": "${{ github.event.pull_request.head.ref }}",
-              "head_sha": "${{ github.event.pull_request.head.sha }}",
-              "is_fork": "${{ github.event.pull_request.head.repo.fork }}" == "true",
-              "file_count": int("${{ steps.stats.outputs.file_count }}"),
-              "additions": int("${{ steps.stats.outputs.additions }}"),
-              "deletions": int("${{ steps.stats.outputs.deletions }}"),
-              "protocol_files": json.loads('${{ steps.stats.outputs.protocol_files }}'),
+              "pr_author": os.environ.get("PR_AUTHOR", ""),
+              "base_ref": os.environ.get("BASE_REF", ""),
+              "head_ref": os.environ.get("HEAD_REF", ""),
+              "head_sha": os.environ.get("HEAD_SHA", ""),
+              "is_fork": os.environ.get("IS_FORK", "") == "true",
+              "file_count": int(os.environ["FILE_COUNT"]),
+              "additions": int(os.environ["ADDITIONS"]),
+              "deletions": int(os.environ["DELETIONS"]),
+              "protocol_files": json.loads(os.environ.get("PROTOCOL_FILES", "[]")),
           }
 
           with open("pr-metadata/metadata.json", "w") as f:
@@ -180,9 +201,6 @@ jobs:
 
           print(f"Metadata saved for PR #{metadata['pr_number']}")
           PYEOF
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY: ${{ github.event.pull_request.body }}
 
       - name: Upload metadata artifact
         if: success()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,16 @@ on:
     tags:
       - 'v*'
 
+# create-release needs to write the draft release + upload assets.
+permissions:
+  contents: write
+
 jobs:
   build-node:
     name: Build and Package
     runs-on: windows-latest
+    env:
+      REF_NAME: ${{ github.ref_name }}
 
     steps:
       - name: Checkout code
@@ -20,8 +26,8 @@ jobs:
         id: get_version
         shell: bash
         run: |
-          echo VERSION=${{github.ref_name}}
-          echo VERSION=${{github.ref_name}} >> $GITHUB_ENV
+          echo "VERSION=$REF_NAME"
+          echo "VERSION=$REF_NAME" >> "$GITHUB_ENV"
 
       - name: Show version
         shell: bash
@@ -31,7 +37,7 @@ jobs:
         id: notes
         shell: bash
         run: |
-          TAG="${{ github.ref_name }}"   # e.g. v3.9.12
+          TAG="$REF_NAME"   # e.g. v3.9.12
           # Pull the section starting at "## <TAG>" up to the next "## " heading.
           SECTION=$(awk -v tag="## ${TAG} " '
             $0 ~ "^"tag {flag=1; next}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Get version from tag
         id: get_version
@@ -24,6 +26,31 @@ jobs:
       - name: Show version
         shell: bash
         run: echo "Version is $VERSION"
+
+      - name: Extract release notes
+        id: notes
+        shell: bash
+        run: |
+          TAG="${{ github.ref_name }}"   # e.g. v3.9.12
+          # Pull the section starting at "## <TAG>" up to the next "## " heading.
+          SECTION=$(awk -v tag="## ${TAG} " '
+            $0 ~ "^"tag {flag=1; next}
+            /^## / {flag=0}
+            flag {print}
+          ' CHANGELOG.md)
+          if [ -z "$SECTION" ]; then
+            SECTION="See CHANGELOG.md for details."
+          fi
+          if printf '%s' "$SECTION" | grep -q "Hard Fork"; then
+            echo "is_hf=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_hf=false" >> "$GITHUB_OUTPUT"
+          fi
+          {
+            echo "body<<RELEASE_NOTES_EOF"
+            printf '%s\n' "$SECTION"
+            echo "RELEASE_NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Update Wallets
         shell: bash
@@ -39,7 +66,7 @@ jobs:
           java-version: '21'
 
       - name: Build artifacts
-        run: ./gradlew unzipWindowsJDK shadowJar jpackageWin zipWinExe release
+        run: ./gradlew unzipWindowsJDK shadowJar jpackageWin zipWinExe release -PreleaseBuild
 
       - name: Create GitHub Release Draft
         id: create_release
@@ -48,7 +75,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Signum Node ${{ github.ref }}
+          release_name: ${{ steps.notes.outputs.is_hf == 'true' && format('⚠️ Hard Fork — Signum Node {0}', github.ref_name) || format('Signum Node {0}', github.ref_name) }}
+          body: ${{ steps.notes.outputs.body }}
           draft: true
           prerelease: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to Signum Node are documented here. This file is updated
+automatically by the `releaseTag` Gradle task; refine entries in the release PR.
+
+## v3.9.11 — 2026-06-25
+
+- Baseline entry created when introducing the automated release flow.

--- a/README.md
+++ b/README.md
@@ -306,13 +306,27 @@ Once WSL is set up, access the distribution and navigate to the folder containin
 
 # Releasing
 
-To cut a new (pre)-release just create a tag of the following format `vD.D.D[-suffix]`. Githubs actions automatically creates
-a pre-release with entirely build executable as zip.
+Releases are cut with a single command from an up-to-date, clean `develop`:
 
 ```bash
-git tag v3.0.1-beta
-git push --tags
+./gradlew releaseTag
 ```
+
+It asks for the version bump (`patch`/`minor`/`major`), whether the release is a
+hard fork (mandatory upgrade), and one line of release notes. It then runs the
+full build and tests, creates a `release/<version>` branch, bumps the version,
+updates `CHANGELOG.md`, and opens a pull request into `develop`.
+
+Once that PR is merged and `develop` is promoted to `main`, a GitHub Action tags
+`main` automatically, which triggers the build of the executables and Docker
+images and drafts the GitHub release.
+
+The version is defined in a single place — `gradle.properties` — and injected
+into the node, the API spec, and the installer at build time; you never edit
+version strings by hand.
+
+See [RELEASING.md](./RELEASING.md) for the full process, the non-interactive
+options, and required one-time setup.
 
 # Docker
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,54 +1,121 @@
 # Releasing Signum Node
 
 Releases are driven by a single command and a single source of truth
-(`gradle.properties` `version=`). You never hand-edit version strings.
+(`gradle.properties` `version=`). You never hand-edit version strings — the
+version is injected at build time into `Signum.VERSION`, the OpenAPI spec, and the
+Windows installer.
 
-## Cut a release
+## TL;DR — cut a release
 
 From an up-to-date, clean `develop`:
 
-    ./gradlew releaseTag
+```bash
+git switch develop
+git pull
+./gradlew releaseTag
+```
+
+Answer the three prompts (bump / hard fork? / notes). The task opens a release PR
+into `develop`. Merge it, promote `develop` → `main`, and the tag + GitHub release
+are produced automatically.
+
+## Prerequisites
+
+- You are on `develop`, the working tree is clean, and it is in sync with origin.
+  (The task refuses to run otherwise.)
+- The [`gh` CLI](https://cli.github.com/) is installed and authenticated, so the
+  release PR can be opened for you. (If it is missing, the task still pushes the
+  branch and prints a link to open the PR manually.)
+- One-time, by a repo admin: the `RELEASE_TAG_PAT` secret exists (see
+  [One-time setup](#one-time-setup)).
+
+## Step by step
+
+### 1. Run the release command
+
+```bash
+./gradlew releaseTag
+```
 
 You will be asked for:
 
-- **bump**: `patch` | `minor` | `major`
-- **hard fork?**: a mandatory-upgrade release. If yes, the bump must be at least
-  `minor` (a `patch` is rejected).
-- **release notes**: one line (refine later in the PR).
+- **bump** — `patch` | `minor` | `major`. Computed from the current
+  `gradle.properties` version (e.g. `3.9.11` + `minor` → `3.10.0`).
+- **hard fork?** — a mandatory-upgrade release. When `yes`, the bump must be at
+  least `minor` (a `patch` is rejected) and the changelog/release are marked with
+  a mandatory-upgrade warning.
+- **release notes** — a single line. You can refine the full notes later by
+  editing `CHANGELOG.md` on the release branch before the PR is merged.
 
-The task: runs pre-flight guards (on `develop`, clean tree, in sync) → runs the
-full build + tests (it stops here if anything fails) → creates
-`release/<version>` → bumps `gradle.properties` → adds a `CHANGELOG.md` section →
-commits, pushes, and opens a PR into `develop`.
+What the task does, in order:
 
-### Non-interactive (CI / scripted)
+1. Pre-flight guards (on `develop`, clean tree, in sync with origin).
+2. Full build **and tests** — it stops here if anything fails, before prompting.
+3. Creates `release/<version>`, bumps `gradle.properties`, prepends a
+   `CHANGELOG.md` section, commits (`release: vX.Y.Z`), pushes the branch, and
+   opens a PR into `develop`.
 
-    ./gradlew releaseTag -Prelease.bump=minor -Prelease.hardFork=true -Prelease.notes="..."
+### 2. Review and merge the PR
 
-Other properties: `-Prelease.notesFile=<path>`, `-Prelease.branch=<branch>`,
-`-Prelease.repo=<owner/name>`.
+Review the release PR (refine the CHANGELOG entry on the branch if needed) and
+merge it into `develop`.
 
-## After the PR merges
+### 3. Promote `develop` → `main`
 
-1. Merge the `release/<version>` PR into `develop` (normal review).
-2. Manually promote `develop` → `main` (as today).
-3. On push to `main`, **auto-tag.yml** reads the version from `gradle.properties`
-   and, if no `vX.Y.Z` tag exists, creates and pushes it.
-4. The tag push triggers **release.yml** (Windows artifacts + draft release whose
-   body is the matching `CHANGELOG.md` section) and **dockerhub.yml** (images).
-5. Review and publish the draft GitHub release.
+Merge `develop` into `main` as usual. This is the only manual git step after the
+PR; it is intentionally a human action.
+
+### 4. Automatic tag, build, and release
+
+On push to `main`, the **auto-tag** workflow reads the version from
+`gradle.properties` and, if no `vX.Y.Z` tag exists yet, creates and pushes it.
+That tag triggers:
+
+- **release.yml** — builds the Windows artifacts and drafts a GitHub release whose
+  body is the matching `CHANGELOG.md` section (titled with a hard-fork warning when
+  applicable).
+- **dockerhub.yml** — builds and pushes the multi-arch Docker images.
+
+### 5. Publish
+
+Review the drafted GitHub release and publish it.
+
+## Non-interactive (CI / scripted)
+
+Provide the answers as properties to skip the prompts:
+
+```bash
+./gradlew releaseTag \
+  -Prelease.bump=minor \
+  -Prelease.hardFork=true \
+  -Prelease.notes="What changed in this release"
+```
+
+Additional properties:
+
+- `-Prelease.notesFile=<path>` — read multi-line notes from a file.
+- `-Prelease.branch=<branch>` — release from a branch other than `develop`.
+- `-Prelease.repo=<owner/name>` — repo slug used for the manual-PR link fallback.
 
 ## One-time setup
 
-`auto-tag.yml` pushes the tag using the `RELEASE_TAG_PAT` repository secret
-(a PAT with `contents: write`). This is required so the tag push triggers the
-downstream release workflows — a tag pushed with the default `GITHUB_TOKEN`
-would not. Add the secret in repo Settings → Secrets and variables → Actions.
+The auto-tag job pushes the tag using the `RELEASE_TAG_PAT` repository secret — a
+PAT (fine-grained or classic) with `contents: write` on this repo. This is
+**required**: a tag pushed with the default `GITHUB_TOKEN` would not trigger the
+downstream `release.yml` / `dockerhub.yml` workflows. Add it under
+Settings → Secrets and variables → Actions.
 
 ## How the version flows
 
-`gradle.properties` → `nodeVersion` (build.gradle) → injected into
-`Signum.VERSION` (via `version.properties` resource read by `BuildInfo`), the
-OpenAPI JSON, and the Windows installer. CI builds pass `-PreleaseBuild` so
-released artifacts always carry a clean (non-`dev`) version; local/dev builds are
-suffixed `-dev` and flagged as prereleases.
+```
+gradle.properties (version=X.Y.Z)   ← single source of truth, bumped by releaseTag
+        │  build.gradle computes nodeVersion
+        ├── version.properties resource → BuildInfo → Signum.VERSION (runtime)
+        ├── OpenAPI info.version (bundled spec)
+        └── Windows installer app-version
+```
+
+CI builds pass `-PreleaseBuild` so released artifacts always carry a clean
+(non-prerelease) version. Local and CI builds that are not on a release tag are
+suffixed `-dev` and flagged as prereleases (a `-dev` node refuses to run on
+mainnet).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -67,9 +67,12 @@ PR; it is intentionally a human action.
 
 ### 4. Automatic tag, build, and release
 
-On push to `main`, the **auto-tag** workflow reads the version from
-`gradle.properties` and, if no `vX.Y.Z` tag exists yet, creates and pushes it.
-That tag triggers:
+After the push to `main`, the **Build Signum Node** workflow runs the build and
+tests. Only when it succeeds does the **auto-tag** workflow run (it is triggered
+by that workflow's successful completion, not by the raw push). It reads the
+version from `gradle.properties` at the built commit and, if no `vX.Y.Z` tag
+exists yet, creates and pushes it. This means a tag can only exist for a commit
+whose build and tests were green. That tag triggers:
 
 - **release.yml** — builds the Windows artifacts and drafts a GitHub release whose
   body is the matching `CHANGELOG.md` section (titled with a hard-fork warning when

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,54 @@
+# Releasing Signum Node
+
+Releases are driven by a single command and a single source of truth
+(`gradle.properties` `version=`). You never hand-edit version strings.
+
+## Cut a release
+
+From an up-to-date, clean `develop`:
+
+    ./gradlew releaseTag
+
+You will be asked for:
+
+- **bump**: `patch` | `minor` | `major`
+- **hard fork?**: a mandatory-upgrade release. If yes, the bump must be at least
+  `minor` (a `patch` is rejected).
+- **release notes**: one line (refine later in the PR).
+
+The task: runs pre-flight guards (on `develop`, clean tree, in sync) → runs the
+full build + tests (it stops here if anything fails) → creates
+`release/<version>` → bumps `gradle.properties` → adds a `CHANGELOG.md` section →
+commits, pushes, and opens a PR into `develop`.
+
+### Non-interactive (CI / scripted)
+
+    ./gradlew releaseTag -Prelease.bump=minor -Prelease.hardFork=true -Prelease.notes="..."
+
+Other properties: `-Prelease.notesFile=<path>`, `-Prelease.branch=<branch>`,
+`-Prelease.repo=<owner/name>`.
+
+## After the PR merges
+
+1. Merge the `release/<version>` PR into `develop` (normal review).
+2. Manually promote `develop` → `main` (as today).
+3. On push to `main`, **auto-tag.yml** reads the version from `gradle.properties`
+   and, if no `vX.Y.Z` tag exists, creates and pushes it.
+4. The tag push triggers **release.yml** (Windows artifacts + draft release whose
+   body is the matching `CHANGELOG.md` section) and **dockerhub.yml** (images).
+5. Review and publish the draft GitHub release.
+
+## One-time setup
+
+`auto-tag.yml` pushes the tag using the `RELEASE_TAG_PAT` repository secret
+(a PAT with `contents: write`). This is required so the tag push triggers the
+downstream release workflows — a tag pushed with the default `GITHUB_TOKEN`
+would not. Add the secret in repo Settings → Secrets and variables → Actions.
+
+## How the version flows
+
+`gradle.properties` → `nodeVersion` (build.gradle) → injected into
+`Signum.VERSION` (via `version.properties` resource read by `BuildInfo`), the
+OpenAPI JSON, and the Windows installer. CI builds pass `-PreleaseBuild` so
+released artifacts always carry a clean (non-`dev`) version; local/dev builds are
+suffixed `-dev` and flagged as prereleases.

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,16 @@ repositories {
 def baseNodeFileName = "signum-node"
 def details = versionDetails()
 
+// Single source of truth: gradle.properties `version`.
+// Official CI builds pass -PreleaseBuild to force a clean (non-prerelease) version.
+// Otherwise a clean tag (isCleanTag) also yields a clean version; all other builds
+// are flagged as `-dev` so Signum.VERSION.isPrelease() is true.
+def baseVersion = (project.version == null || project.version.toString() == 'unspecified')
+        ? '0.0.0' : project.version.toString()
+def isReleaseBuild = project.hasProperty('releaseBuild') || details.isCleanTag
+def nodeVersion = isReleaseBuild ? baseVersion : "${baseVersion}-dev"
+project.ext.nodeVersion = nodeVersion
+
 dependencies {
     implementation 'com.github.signum-network:signumj:v1.3.2'
     implementation 'io.reactivex.rxjava2:rxjava:2.2.21'
@@ -116,10 +126,25 @@ application {
     mainClass.set('signum.Launcher')
 }
 
+def generatedResourcesDir = layout.buildDirectory.dir("generated/resources")
+
+def generateVersionProperties = tasks.register('generateVersionProperties') {
+    outputs.dir(generatedResourcesDir)
+    inputs.property("version", nodeVersion)
+    doLast {
+        def outFile = generatedResourcesDir.get().file("version.properties").asFile
+        outFile.parentFile.mkdirs()
+        outFile.text = "version=${nodeVersion}\n"
+    }
+}
+
 sourceSets {
     main {
         java.srcDir "src"
         resources.srcDir "resources"
+        // Passing the TaskProvider wires the build dependency for every consumer
+        // (processResources, sourcesJar, ...) onto its output directory.
+        resources.srcDir generateVersionProperties
     }
     if (!project.hasProperty('skipTests')) {
         test {
@@ -142,6 +167,15 @@ shadowJar {
 tasks.register('buildOpenApi', NpmTask) {
     dependsOn npmInstall
     args = ['run', 'dist']
+    doLast {
+        ['openapi/dist/signum-api.json', 'html/api-doc/signum-api.json'].each { path ->
+            def f = file(path)
+            if (f.exists()) {
+                // Replace the first "version": "..." (info.version) with the build version.
+                f.text = f.text.replaceFirst(/("version"\s*:\s*)"[^"]*"/, "\$1\"${nodeVersion}\"")
+            }
+        }
+    }
 }
 
 node {
@@ -171,8 +205,7 @@ tasks.register('jpackageWin', Exec) {
     description = 'Builds a Windows EXE using jpackage'
     dependsOn shadowJar
 
-    def rawVersion = details.lastTag ?: "1.0.0"
-    def version = rawVersion.replaceAll("[^0-9.]", "")
+    def version = nodeVersion.replaceAll("[^0-9.]", "")
     if (!version.contains(".")) version = "${version}.0"
     def parts = version.tokenize('.').collect { it as int }
     while (parts.size() < 2) parts << 0
@@ -367,3 +400,5 @@ jooq {
 }
 
 generateJooq.dependsOn(flywayMigrate)
+
+apply from: 'gradle/release.gradle'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+# Single source of truth for the Signum Node version.
+# Bumped only by the `releaseTag` Gradle task. Injected into the build
+# (Signum.VERSION, OpenAPI, jpackage) — do not hardcode the version elsewhere.
+version=3.9.11

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -1,0 +1,180 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.internal.tasks.userinput.UserInputHandler
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+import java.io.ByteArrayOutputStream
+import java.text.SimpleDateFormat
+
+// ---- Pre-flight guards: must pass before the (slow) build+test runs ----
+tasks.register('releasePreflight') {
+    group = 'release'
+    description = 'Verifies the working copy is releasable (branch, clean, in sync).'
+    doLast {
+        def releaseBranch = (project.findProperty('release.branch') ?: 'develop').toString()
+        def git = { String... a ->
+            def out = new ByteArrayOutputStream()
+            def code = exec {
+                commandLine(['git'] + (a as List)); standardOutput = out; ignoreExitValue = true
+            }.exitValue
+            [code: code, out: out.toString().trim()]
+        }
+        def branch = git('rev-parse', '--abbrev-ref', 'HEAD').out
+        if (branch != releaseBranch) {
+            throw new GradleException("Must be on '${releaseBranch}' to release (currently '${branch}').")
+        }
+        if (!git('status', '--porcelain').out.isEmpty()) {
+            throw new GradleException("Working tree is not clean. Commit or stash changes first.")
+        }
+        git('fetch', 'origin', releaseBranch, '--tags')
+        if (git('rev-parse', 'HEAD').out != git('rev-parse', "origin/${releaseBranch}").out) {
+            throw new GradleException("Local '${releaseBranch}' is not in sync with origin. Pull/push first.")
+        }
+        logger.lifecycle("Pre-flight OK on '${releaseBranch}'.")
+    }
+}
+
+abstract class ReleaseTask extends DefaultTask {
+
+    @Inject abstract UserInputHandler getUserInput()
+    @Inject abstract ExecOperations getExecOps()
+    @Inject abstract ProjectLayout getLayout()
+
+    @Input abstract Property<String> getCurrentVersion()
+    @Input @Optional abstract Property<String> getBumpProp()
+    @Input @Optional abstract Property<String> getHardForkProp()
+    @Input @Optional abstract Property<String> getNotesProp()
+    @Input @Optional abstract Property<String> getNotesFileProp()
+    @Input abstract Property<String> getReleaseBranch()
+    @Input abstract Property<String> getRepoSlug()
+
+    private Map git(String... a) {
+        def out = new ByteArrayOutputStream()
+        def code = execOps.exec {
+            it.commandLine(['git'] + (a as List)); it.standardOutput = out; it.ignoreExitValue = true
+        }.exitValue
+        [code: code, out: out.toString().trim()]
+    }
+
+    @TaskAction
+    void run() {
+        def root = layout.projectDirectory
+
+        // ---- Resolve inputs: -P property wins, else prompt interactively ----
+        def bump = bumpProp.getOrNull()
+        if (bump == null) {
+            bump = userInput.selectOption("Select version bump", ["patch", "minor", "major"], "patch")
+        }
+        if (!(bump in ["patch", "minor", "major"])) {
+            throw new GradleException("Invalid bump '${bump}' (expected patch|minor|major).")
+        }
+
+        boolean hardFork
+        if (hardForkProp.isPresent()) {
+            hardFork = Boolean.parseBoolean(hardForkProp.get())
+        } else {
+            hardFork = userInput.askYesNoQuestion("Is this a hard fork (mandatory upgrade)?", false)
+        }
+
+        String notes
+        if (notesFileProp.isPresent()) {
+            notes = root.file(notesFileProp.get()).asFile.text.trim()
+        } else if (notesProp.isPresent()) {
+            notes = notesProp.get().trim()
+        } else {
+            notes = userInput.askQuestion("Release notes (one line; refine in the PR if needed)", "").trim()
+        }
+
+        // ---- HF enforces >= minor ----
+        if (hardFork && bump == "patch") {
+            throw new GradleException("Hard fork requires at least a 'minor' bump (got 'patch').")
+        }
+
+        // ---- Compute next version ----
+        def cur = currentVersion.get()
+        def m = (cur =~ /^(\d+)\.(\d+)\.(\d+)/)
+        if (!m) throw new GradleException("Cannot parse current version '${cur}'.")
+        int major = m[0][1] as int, minor = m[0][2] as int, patch = m[0][3] as int
+        if (bump == "major") { major++; minor = 0; patch = 0 }
+        else if (bump == "minor") { minor++; patch = 0 }
+        else { patch++ }
+        def next = "${major}.${minor}.${patch}"
+        def tag = "v${next}"
+        def branch = "release/${next}"
+        logger.lifecycle("Releasing ${cur} -> ${next} (bump=${bump}, hardFork=${hardFork})")
+
+        // ---- Guard: tag must not already exist ----
+        if (!git('tag', '-l', tag).out.isEmpty() || !git('ls-remote', '--tags', 'origin', tag).out.isEmpty()) {
+            throw new GradleException("Tag ${tag} already exists.")
+        }
+
+        // ---- Create release branch ----
+        if (git('checkout', '-b', branch).code != 0) {
+            throw new GradleException("Failed to create branch ${branch}.")
+        }
+
+        // ---- Bump gradle.properties ----
+        def gp = root.file("gradle.properties").asFile
+        gp.text = gp.text.replaceFirst(/(?m)^version=.*$/, "version=${next}")
+
+        // ---- Update CHANGELOG.md ----
+        def changelog = root.file("CHANGELOG.md").asFile
+        def today = new SimpleDateFormat("yyyy-MM-dd").format(new Date())
+        def hfBlock = hardFork ? "\n> ⚠️ **Hard Fork — mandatory upgrade.**\n" : ""
+        def bodyText = notes.isEmpty() ? "- _TODO: add release notes_" : notes
+        def entry = "## ${tag} — ${today}\n${hfBlock}\n${bodyText}\n\n"
+        def existing = changelog.exists() ? changelog.text : "# Changelog\n\n"
+        if (existing.startsWith("# Changelog")) {
+            def headerEnd = existing.indexOf('\n') + 1
+            changelog.text = existing.substring(0, headerEnd) + "\n" + entry +
+                    existing.substring(headerEnd).replaceFirst(/^\n+/, "")
+        } else {
+            changelog.text = "# Changelog\n\n" + entry + existing
+        }
+
+        // ---- Commit + push ----
+        git('add', 'gradle.properties', 'CHANGELOG.md')
+        if (git('commit', '-m', "release: ${tag}").code != 0) {
+            throw new GradleException("Commit failed.")
+        }
+        if (git('push', '-u', 'origin', branch).code != 0) {
+            throw new GradleException("Push failed.")
+        }
+
+        // ---- Open PR via gh (best effort) ----
+        def prTitle = (hardFork ? "⚠️ Hard Fork " : "") + "Release ${tag}"
+        def prBody = "Automated release PR for ${tag}.\n\n${bodyText}"
+        def ghCode = execOps.exec {
+            it.commandLine 'gh', 'pr', 'create', '--base', releaseBranch.get(),
+                    '--head', branch, '--title', prTitle, '--body', prBody
+            it.ignoreExitValue = true
+        }.exitValue
+        if (ghCode != 0) {
+            logger.warn("Could not open the PR automatically (gh missing or not authenticated).")
+            logger.lifecycle("Open it here: https://github.com/${repoSlug.get()}/compare/${releaseBranch.get()}...${branch}?expand=1")
+        }
+        logger.lifecycle("Done. Pushed ${branch}; PR targets ${releaseBranch.get()}.")
+    }
+}
+
+tasks.register('releaseTag', ReleaseTask) {
+    group = 'release'
+    description = 'Cut a release: verify, build+test, then branch/bump/changelog/push/PR.'
+    dependsOn 'releasePreflight', 'build'
+    currentVersion.set(project.version.toString())
+    bumpProp.set(project.findProperty('release.bump')?.toString())
+    hardForkProp.set(project.findProperty('release.hardFork')?.toString())
+    notesProp.set(project.findProperty('release.notes')?.toString())
+    notesFileProp.set(project.findProperty('release.notesFile')?.toString())
+    releaseBranch.set((project.findProperty('release.branch') ?: 'develop').toString())
+    repoSlug.set((project.findProperty('release.repo') ?: 'signum-network/signum-node').toString())
+}
+
+// Guards run first; the build (incl. tests) runs before the interactive action.
+tasks.named('build').configure { mustRunAfter('releasePreflight') }

--- a/openapi/signum-api.json
+++ b/openapi/signum-api.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Signum Node API",
-    "version": "3.9.11",
+    "version": "0.0.0-dev",
     "description": "This is the API documentation of the Signum Node"
   },
   "paths": {

--- a/src/brs/BuildInfo.java
+++ b/src/brs/BuildInfo.java
@@ -1,0 +1,44 @@
+package brs;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * Provides build-time information injected into the application.
+ *
+ * <p>The version is the single source of truth from {@code gradle.properties},
+ * written into the {@code /version.properties} classpath resource at build time
+ * by the {@code generateVersionProperties} Gradle task. When the resource is
+ * absent (e.g. running from an IDE without the generated resource), a
+ * development fallback is used so the node is flagged as a prerelease.
+ */
+public final class BuildInfo {
+
+    static final String RESOURCE = "/version.properties";
+    static final String DEV_FALLBACK = "0.0.0-dev";
+
+    private BuildInfo() {
+    }
+
+    /** Loads the version from the classpath resource, falling back to a dev version. */
+    public static Version loadVersion() {
+        try (InputStream in = BuildInfo.class.getResourceAsStream(RESOURCE)) {
+            if (in == null) {
+                return Version.parse(DEV_FALLBACK);
+            }
+            Properties props = new Properties();
+            props.load(in);
+            return fromProperties(props);
+        } catch (IOException e) {
+            return Version.parse(DEV_FALLBACK);
+        }
+    }
+
+    /** Pure helper: resolves a {@link Version} from the given properties. */
+    static Version fromProperties(Properties props) {
+        String raw = props.getProperty("version", "");
+        String value = raw == null ? "" : raw.trim();
+        return Version.parse(value.isEmpty() ? DEV_FALLBACK : value);
+    }
+}

--- a/src/brs/Signum.java
+++ b/src/brs/Signum.java
@@ -76,7 +76,7 @@ import signumj.util.SignumUtils;
  */
 public final class Signum {
 
-    public static final Version VERSION = Version.parse("v3.9.11");
+    public static final Version VERSION = BuildInfo.loadVersion();
     public static final String APPLICATION = "BRS";
 
     public static final String CONF_FOLDER = "./conf";

--- a/test/java/brs/BuildInfoTest.java
+++ b/test/java/brs/BuildInfoTest.java
@@ -1,0 +1,51 @@
+package brs;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BuildInfoTest {
+
+    @Test
+    void fromProperties_givenCleanVersion_returnsReleaseVersion() {
+        Properties p = new Properties();
+        p.setProperty("version", "3.9.12");
+
+        Version v = BuildInfo.fromProperties(p);
+
+        assertEquals(Version.parse("v3.9.12"), v);
+        assertFalse(v.isPrelease());
+    }
+
+    @Test
+    void fromProperties_givenDevVersion_returnsPrerelease() {
+        Properties p = new Properties();
+        p.setProperty("version", "3.9.12-dev");
+
+        Version v = BuildInfo.fromProperties(p);
+
+        assertTrue(v.isPrelease());
+    }
+
+    @Test
+    void fromProperties_givenMissingVersion_fallsBackToDev() {
+        Version v = BuildInfo.fromProperties(new Properties());
+
+        assertEquals(Version.parse("0.0.0-dev"), v);
+        assertTrue(v.isPrelease());
+    }
+
+    @Test
+    void fromProperties_givenBlankVersion_fallsBackToDev() {
+        Properties p = new Properties();
+        p.setProperty("version", "  ");
+
+        Version v = BuildInfo.fromProperties(p);
+
+        assertTrue(v.isPrelease());
+    }
+}


### PR DESCRIPTION
## Problem

Cutting a release was a manual, error-prone sequence. The version lived in three
places that drifted independently: a hardcoded literal in `src/brs/Signum.java`
(`Version.parse("v3.9.11")`), `info.version` in `openapi/signum-api.json`, and the
git tag. The artifact version came from the tag via `palantir-git-version`, but
`Signum.VERSION` was a separate constant — so the node could report a version that
disagreed with the released build if someone forgot one of the edits.

On top of that, the tag was created and pushed by hand (typo-prone, lightweight),
there was no changelog or release-notes capture, no way to flag a hard-fork
(mandatory-upgrade) release, and no single command to kick the whole thing off.

## Solution

`gradle.properties` `version=` is now the single source of truth. It is injected
at build time into `Signum.VERSION` (via a generated `version.properties` resource
read by a new `BuildInfo` class), the OpenAPI spec, and the Windows installer.
Off-tag builds are suffixed `-dev` so `isPrelease()` flags them; CI passes
`-PreleaseBuild` so released artifacts always carry a clean version and pass the
mainnet dev-build check.

A single interactive command drives a release:

```
./gradlew releaseTag        # asks: bump (patch/minor/major), hard fork?, release notes
```

It runs guards (on `develop`, clean, in sync) and the full build + tests *before*
prompting, then creates `release/<version>`, bumps the version, writes a
`CHANGELOG.md` section (with a mandatory-upgrade warning when hard-fork is set —
which also forces at least a minor bump), commits, pushes, and opens a PR into
`develop`. After the PR merges and `develop` is promoted to `main`, a new
`auto-tag` workflow tags `main` from the committed version, and the existing
`release.yml` publishes a draft whose body is pulled from the CHANGELOG section.

The result: one consistent command to start a release, a version that can no
longer drift, and reviewable, auditable release PRs. See `RELEASING.md` for the
full flow (including the one-time `RELEASE_TAG_PAT` secret the auto-tag job needs).